### PR TITLE
safeguard config.credentials to avoid null-ref 

### DIFF
--- a/packages/cli/src/default-servient.ts
+++ b/packages/cli/src/default-servient.ts
@@ -51,7 +51,7 @@ export default class DefaultServient extends Servient {
 
         Object.assign(this.config, config);
         // remove secrets from original for displaying config (still in copy on this)
-        delete config.credentials;
+        if(config && config.credentials) delete config.credentials;
         console.info("DefaultServient configured with", config);
 
         if (!this.config.servient.clientOnly) {


### PR DESCRIPTION
the servient crashed when running via cli resp. generally when running  default config, as this does not contain config.credentials (also config is null).
