### PR TITLE
fix: node-wot issue#32 about NS contexts

### DIFF
--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -27,13 +27,17 @@ export function parseTD(td: string, normalize?: boolean): Thing {
   // apply defaults as per WoT Thing Description spec
 
   if (thing["@context"] === undefined) {
-    thing["@context"] = TD.DEFAULT_HTTPS_CONTEXT;
+    thing["@context"] = TD.DEFAULT_HTTP_CONTEXT;
   } else if (Array.isArray(thing["@context"])) {
     let semContext: Array<string> = thing["@context"];
-    if ( (semContext.indexOf(TD.DEFAULT_HTTPS_CONTEXT) === -1) &&
-         (semContext.indexOf(TD.DEFAULT_HTTP_CONTEXT) === -1) ) {
+    if ((semContext.indexOf(TD.DEFAULT_HTTPS_CONTEXT) === -1) &&
+      (semContext.indexOf(TD.DEFAULT_HTTP_CONTEXT) === -1) &&
+      // keep compatibility for "old" context URI for now
+      (semContext.indexOf("http://w3c.github.io/wot/w3c-wot-td-context.jsonld") === -1) &&
+      (semContext.indexOf("https://w3c.github.io/wot/w3c-wot-td-context.jsonld") === -1)
+    ) {
       // insert last
-      semContext.push(TD.DEFAULT_HTTPS_CONTEXT);
+      semContext.push(TD.DEFAULT_HTTP_CONTEXT);
     }
   }
 
@@ -86,7 +90,7 @@ export function parseTD(td: string, normalize?: boolean): Thing {
       // ensure forms mandatory forms field
       if (!thing[pattern][interaction].hasOwnProperty("forms")) throw new Error(`${interactionPatterns[pattern]} '${interaction}' has no forms field`);
       // ensure array structure internally
-      if (!Array.isArray(thing[pattern][interaction].forms)) thing[pattern][interaction].forms = [ thing[pattern][interaction].forms ];
+      if (!Array.isArray(thing[pattern][interaction].forms)) thing[pattern][interaction].forms = [thing[pattern][interaction].forms];
       for (let form of thing[pattern][interaction].forms) {
         // ensure mandatory href field
         if (!form.hasOwnProperty("href")) throw new Error(`Form of ${interactionPatterns[pattern]} '${interaction}' has no href field`);
@@ -99,7 +103,7 @@ export function parseTD(td: string, normalize?: boolean): Thing {
   }
 
   if (thing.hasOwnProperty("base")) {
-    if (normalize===undefined || normalize===true) {
+    if (normalize === undefined || normalize === true) {
       console.log(`parseTD() normalizing 'base' into 'forms'`);
 
       const url = require('url');

--- a/packages/td-tools/src/thing-description.ts
+++ b/packages/td-tools/src/thing-description.ts
@@ -16,8 +16,8 @@
 // global W3C WoT Scripting API definitions
 import * as WoT from "wot-typescript-definitions";
 
-export const DEFAULT_HTTP_CONTEXT: string = "http://w3c.github.io/wot/w3c-wot-td-context.jsonld";
-export const DEFAULT_HTTPS_CONTEXT: string = "https://w3c.github.io/wot/w3c-wot-td-context.jsonld";
+export const DEFAULT_HTTP_CONTEXT: string = "http://www.w3.org/ns/td";
+export const DEFAULT_HTTPS_CONTEXT: string = "http://www.w3.org/ns/td";
 export const DEFAULT_THING_TYPE: string = "Thing";
 
 /* TODOs / Questions

--- a/packages/td-tools/test/TDParseTest.ts
+++ b/packages/td-tools/test/TDParseTest.ts
@@ -328,7 +328,7 @@ class TDParserTest {
   @test "should parse the example from Current Practices"() {
     let thing: Thing = TDParser.parseTD(tdSample1);
 
-    expect(thing).to.have.property("@context").that.equals("https://w3c.github.io/wot/w3c-wot-td-context.jsonld");
+    expect(thing).to.have.property("@context").that.equals("http://www.w3.org/ns/td");
     expect(thing).to.have.property("@type").that.equals("Thing");
     expect(thing).to.have.property("name").that.equals("MyTemperatureThing");
     expect(thing).to.not.have.property("base");


### PR DESCRIPTION
See https://github.com/eclipse/thingweb.node-wot/issues/32
AND auto-format td-parser.ts

Note1: by default use http and not https context uri
Note2: for compatibility reasons still allow "old" namespaces