### PR TITLE
Observe property

### DIFF
--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -145,8 +145,11 @@ export default class MqttBrokerServer implements ProtocolServer {
         let subscription = thing.properties[propertyName].subscribe(
           (value) => {
             // send event data
-            console.log(`MqttBrokerServer at ${this.brokerURI} publishing to Property topic '${propertyName}' `);
-            this.broker.publish(topic, value.body, {retain:true});
+            if(value.body!==undefined) {
+
+              console.log(`MqttBrokerServer at ${this.brokerURI} publishing to Property topic '${propertyName} with value ${value.body} `);
+              this.broker.publish(topic, value.body, {retain:true});
+            }
           }
         );
 

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -285,6 +285,7 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
                                 this.getState().subject.next(customValue);
                             }
                             this.getState().value = customValue;
+ 
                             resolve();
                         });
                     } else  {
@@ -292,7 +293,9 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
                         if (this.getState().value!==promiseOrValueOrNil) {
                             this.getState().subject.next(<any>promiseOrValueOrNil);
                         }
+                       
                         this.getState().value = <any>promiseOrValueOrNil;
+ 
                         resolve();
                     }
                 } else {
@@ -302,6 +305,7 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
                         this.getState().subject.next(value);
                     }
                     this.getState().value = value;
+
                     resolve();
                 }
             } else {
@@ -311,6 +315,14 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
                     this.getState().subject.next(value);
                 }
                 this.getState().value = value;
+
+                // notify subscriber clients
+                let content;
+                if (value!==undefined) {
+                    content = ContentSerdes.get().valueToContent(value, <any>this);
+                }
+                this.getState().subject.next(content);
+
                 resolve();
             }
         });
@@ -320,13 +332,7 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
         return this.getState().subject.asObservable().subscribe(next, error, complete);
     }
 
-    public emit(data?: any): void {
-        let content;
-        if (data!==undefined) {
-            content = ContentSerdes.get().valueToContent(data, <any>this);
-        }
-        this.getState().subject.next(content);
-    }
+
 }
 
 class ExposedThingAction extends TD.ActionFragment implements WoT.ThingAction {

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -319,6 +319,14 @@ class ExposedThingProperty extends TD.PropertyFragment implements WoT.ThingPrope
     public subscribe(next?: (value: any) => void, error?: (error: any) => void, complete?: () => void): Subscription {
         return this.getState().subject.asObservable().subscribe(next, error, complete);
     }
+
+    public emit(data?: any): void {
+        let content;
+        if (data!==undefined) {
+            content = ContentSerdes.get().valueToContent(data, <any>this);
+        }
+        this.getState().subject.next(content);
+    }
 }
 
 class ExposedThingAction extends TD.ActionFragment implements WoT.ThingAction {


### PR DESCRIPTION
- enables 'observe-able' Properties in node-wot for consumer and exposer wot servient
- tested with MQTT
- open: rel assignment for wot exposer (tbd: Form class has to be extended)