### PR TITLE
fix(core): fix unhandled property write rejection

### DIFF
--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -291,6 +291,10 @@ class ExposedThingProperty extends TD.ThingProperty implements WoT.ThingProperty
                             }
                             this.getState().value = customValue;
                             resolve();
+                        })
+                        .catch((customError) => {
+                            console.warn(`ExposedThing '${this.getThing().name}' write handler for Property '${this.getName()}' rejected the write with error '${customError}'`);
+                            reject(customError);
                         });
                     } else  {
                         console.warn(`ExposedThing '${this.getThing().name}' write handler for Property '${this.getName()}' does not return promise`);


### PR DESCRIPTION
fix(core): fix unhandled property write rejection

if the promise returned by a custom writeHandler for a property of ExposedThing is rejected, this rejection should be handled.

fixes #54