### PR TITLE
add htv:methodName in addition to http:methodName

### DIFF
--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -348,6 +348,18 @@ export default class HttpClient implements ProtocolClient {
       }
     }
 
+    if (typeof form["htv:methodName"] === "string") {
+      console.log("HttpClient got Form 'methodName'", form["htv:methodName"]);
+      switch (form["htv:methodName"]) {
+        case "GET": options.method = "GET"; break;
+        case "POST": options.method = "POST"; break;
+        case "PUT": options.method = "PUT"; break;
+        case "DELETE": options.method = "DELETE"; break;
+        case "PATCH": options.method = "PATCH"; break;
+        default: console.warn("HttpClient got invalid 'methodName', using default", options.method);
+      }
+    }
+
     let req = this.provider.request(options);
 
     console.debug(`HttpClient applying form`);

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -45,9 +45,13 @@ export interface HttpProxyConfig {
 export class HttpForm extends Form {
     public "http:methodName"?: string; // "GET", "PUT", "POST", "DELETE"
     public "http:headers"?: Array<HttpHeader> | HttpHeader;
+    public "htv:methodName"?: string; // "GET", "PUT", "POST", "DELETE"
+    public "htv:headers"?: Array<HttpHeader> | HttpHeader;
 }
 
 export class HttpHeader {
     public "http:fieldName": number;
     public "http:fieldValue": any;
+    public "htv:fieldName": number;
+    public "htv:fieldValue": any;
 }


### PR DESCRIPTION
fix(http-client.ts): add htv:methodName in addition of http:methodName
In documentation (https://w3c.github.io/wot-thing-description/#) usage of htv:Methodname is suggested in forms but by default node-wot only accepts http:methodName within forms. With this change both htv and http can be used in forms.
Closes #80
Signed-off-by: Yagiz Yalcintas <yagizy@sabanciuniv.edu>