### PR TITLE
fix(http-binding): stop polling in case of error

### DIFF
--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -33,6 +33,7 @@
     "wot-typescript-definitions": "0.6.2",
     "@node-wot/td-tools": "0.6.3-SNAPSHOT.1",
     "@node-wot/core": "0.6.3-SNAPSHOT.1",
+    "@types/chai-spies": "1.0.0",
     "basic-auth": "2.0.1",
     "rxjs": "5.4.3",
     "accept-language-parser": "1.5.0"

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -20,6 +20,7 @@
     "@types/node": "10.9.4",
     "@types/request-promise": "4.1.41",
     "chai": "4.1.2",
+    "chai-spies": "1.0.0",
     "mocha": "3.5.3",
     "mocha-typescript": "1.1.8",
     "request": "2.88.0",

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -215,8 +215,20 @@ export default class HttpClient implements ProtocolClient {
         res.on("data", (data) => { body.push(data) });
         res.on("end", () => {
           if (active) {
-            this.checkResponse(res.statusCode, contentType, Buffer.concat(body), next, error);
-            polling();
+            this.checkResponse(
+              res.statusCode,
+              contentType,
+              Buffer.concat(body),
+              (data: any) => { 
+                next(data);
+                polling();
+              },
+              (err: any) => {
+                if (error) error(err);
+                if (complete) complete();
+                active = false;
+              }
+            );
           }
         });
       });


### PR DESCRIPTION
When a subscription returns a response with an error code, don't keep polling forever.

Right now, when a subscription return a 404 for example (not a request error), polling() is directly called again, and return another 404, which results in an endless loop.

Signed-off-by: Hassib Belhaj <hassib.blh@gmail.com>