### PR TITLE
MQTT features

### DIFF
--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -120,13 +120,13 @@ export default class MqttBrokerServer implements ProtocolServer {
                 return;
               }
               console.log(`MqttBrokerServer at ${this.brokerURI} publishing to Property topic '${propertyName}' `);
-              this.broker.publish(topic, content.body);
+              this.broker.publish(topic, content.body,{retain:true});
             }
           );
 
           let href = this.brokerURI + topic;
           let form = new TD.Form(href, ContentSerdes.DEFAULT);
-          form.op = ["observeproperty", "unobserveproperty"];
+          form.op = ["readproperty","observeproperty", "unobserveproperty"];
           thing.properties[propertyName].forms.push(form);
           console.log(`MqttBrokerServer at ${this.brokerURI} assigns '${href}' to property '${propertyName}'`);
 

--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -206,7 +206,7 @@ export default class MqttBrokerServer implements ProtocolServer {
         event.forms.push(form);
         console.log(`MqttBrokerServer at ${this.brokerURI} assigns '${href}' to Event '${eventName}'`);
       }
-
+      this.broker.publish(name, JSON.stringify(thing.getThingDescription()),{retain:true,contentType:"application/td+json"});
       resolve();
     });
   }


### PR DESCRIPTION
Added features:
- Before the `expose()` returns, the TD is published to the broker, addresses issue #144. This is also published with retain set to true
- readOnly and writeOnly properties are handled. Before even writeOnly properties were readable and there was no way to write to properties via MQTT. Now, only readable properties are published to and there is handling of subscribed topics to handle writing, like with actions. Addresses issue #152 

I am not able to write tests for this due to 2 reasons:
1. See #161 
2. A test for this would require to fetch the TD from the broker. This is not possible with the `fetch()` function since it always maps to `readResource()` which is not implemented in the mqtt binding. Then I have tried the following but was blocked by the same reason as in the point 1:
```
                            let broker = mqtt.connect("test.mosquitto.org");
                            broker.on("connect", () => {
                                broker.subscribe("TestWoTMQTT");
                                broker.on("message", (receivedTopic: string, payload: string) => {
                                    if (receivedTopic == "TestWoTMQTT"){
                                        expect(payload).contain("TestWoTMQTT")
                                        console.log(payload)
                                    }
                                });
```
However, I have tested using mosquitto_sub and mosquitto_pub and gotten the TD, even multiple times or published before subscription. Only writeable properties are written to and their form show up in the TD. Same for readable properties.
Signed-off-by: Ege Korkan <egekorkan@gmail.com>