### PR TITLE
fix(binding-netconf, binding-opcua): package.json update for netconf cli and ocpua cli.

### DIFF
--- a/examples/servients/netconf-cli/package.json
+++ b/examples/servients/netconf-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-wot/netconf-cli",
-  "version": "0.7.0-SNAPSHOT.5",
+  "version": "0.7.0-SNAPSHOT.6",
   "description": "servient command line interface",
   "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
   "license": "EPL-2.0 OR W3C-20150513",
@@ -25,11 +25,13 @@
   },
   "dependencies": {
     "fs": "0.0.1-security",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "@node-wot/core": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-http": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-netconf": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-file": "0.7.0-SNAPSHOT.6"
   },
   "scripts": {
-    "install": "npm link @node-wot/core; npm link @node-wot/binding-netconf; npm link @node-wot/binding-http; npm link @node-wot/binding-file",
-    "installModules": "npm install",
     "build": "tsc",
     "start": "ts-node src/netconf-cli.ts",
     "codestyle": "standard --pretty"

--- a/examples/servients/opcua-cli/package.json
+++ b/examples/servients/opcua-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-wot/opcua-cli",
-  "version": "0.7.0-SNAPSHOT.5",
+  "version": "0.7.0-SNAPSHOT.6",
   "description": "servient command line interface",
   "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
   "license": "EPL-2.0 OR W3C-20150513",
@@ -24,13 +24,14 @@
     "wot-typescript-definitions": "0.7.1-SNAPSHOT.1"
   },
   "dependencies": {
+    "@node-wot/core": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-http": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-file": "0.7.0-SNAPSHOT.6",
+    "@node-wot/binding-opcua": "0.7.0-SNAPSHOT.6",
     "fs": "0.0.1-security",
-    "path": "^0.12.7",
-    "xml-writer": "^1.7.0"
+    "path": "^0.12.7"
   },
   "scripts": {
-    "install": "npm link @node-wot/core; npm link @node-wot/binding-opcua; npm link @node-wot/binding-http; npm link @node-wot/binding-file",
-    "installModules": "npm install",
     "build": "tsc",
     "start": "ts-node src/opcua-cli.ts",
     "codestyle": "standard --pretty"

--- a/packages/binding-opcua/README.md
+++ b/packages/binding-opcua/README.md
@@ -63,7 +63,7 @@ To enable support for a proper Datatype translation, the DataSchema information 
  
 ### opc:DataType
 
-Among all the possible OPC UA Datatypes, at the moment all the ones supported by (node-wot)[https://github.com/node-opcua/node-opcua/blob/master/packages/node-opcua-variant/source/DataType_enum.ts] can be used. 
+Among all the possible OPC UA Datatypes, at the moment all the ones supported by [node-wot](https://github.com/node-opcua/node-opcua/blob/master/packages/node-opcua-variant/source/DataType_enum.ts) can be used. 
 The binding uses a new custom ContentSerdes in order to handle the proper OPC UA Datatype and adjust the OPC UA request accordingly. Please note that this binding does not directly handle OPC UA raw bytes but instead an intermediate format to be passed to another NodeJS library ([node-opcua](https://github.com/node-opcua)) that is in charge of making the raw conversion. In this sense, the new ContentSerdes strongly depends on the Nodejs library used behind.
 
 ## Additional tools


### PR DESCRIPTION
PR for fixing #182.
package.json for netconf cli and opcua cli updated for installing the latest snapshot of netconf and opcua bindings.

Signed-off-by: lukesmolo <lukesmolo@gmail.com>