### PR TITLE
fix: allow explicitely configure no security in HTTP

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -46,7 +46,7 @@ export default class HttpServer implements ProtocolServer {
 
   private readonly port: number = 8080;
   private readonly address: string = undefined;
-  private readonly securityScheme: string = "NoSec";
+  private readonly httpSecurityScheme: string = "NoSec"; // HTTP header compatible string
   private readonly server: http.Server | https.Server = null;
   private readonly things: Map<string, ExposedThing> = new Map<string, ExposedThing>();
   private servient: Servient = null;
@@ -77,20 +77,19 @@ export default class HttpServer implements ProtocolServer {
 
     // Auth
     if (config.security) {
-      if (this.scheme !== "https") {
-        throw new Error(`HttpServer does not allow security without TLS (HTTPS)`);
-      }
-
       // storing HTTP header compatible string
       switch (config.security.scheme) {
+        case "nosec":
+          this.httpSecurityScheme = "NoSec";
+          break;
         case "basic":
-          this.securityScheme = "Basic";
+          this.httpSecurityScheme = "Basic";
           break;
         case "digest":
-          this.securityScheme = "Digest";
+          this.httpSecurityScheme = "Digest";
           break;
         case "bearer":
-          this.securityScheme = "Bearer";
+          this.httpSecurityScheme = "Bearer";
           break;
         default:
           throw new Error(`HttpServer does not support security scheme '${config.security.scheme}`);
@@ -147,6 +146,10 @@ export default class HttpServer implements ProtocolServer {
       // includes address() typeof "string" case, which is only for unix sockets
       return -1;
     }
+  }
+
+  public getHttpSecurityScheme(): string {
+    return this.httpSecurityScheme;
   }
 
 
@@ -292,7 +295,9 @@ export default class HttpServer implements ProtocolServer {
 
     let creds = this.servient.getCredentials(id);
 
-    switch (this.securityScheme) {
+    switch (this.httpSecurityScheme) {
+      case "NoSec":
+        return true;
       case "Basic":
         let basic = bauth(req);
         return (creds !== undefined) &&
@@ -455,8 +460,8 @@ export default class HttpServer implements ProtocolServer {
 
         } else {
           // Thing Interaction - Access Control
-          if (this.securityScheme!=="NoSec" && !this.checkCredentials(thing.id, req)) {
-            res.setHeader("WWW-Authenticate", `${this.securityScheme} realm="${thing.id}"`);
+          if (this.httpSecurityScheme!=="NoSec" && !this.checkCredentials(thing.id, req)) {
+            res.setHeader("WWW-Authenticate", `${this.httpSecurityScheme} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
  * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -112,5 +112,15 @@ class HttpServerTest {
       await httpServer1.stop();
       await httpServer2.stop();
     });
+  }
+
+  // https://github.com/eclipse/thingweb.node-wot/issues/181
+  @test async "should start and stop a server with no security"() {
+    let httpServer = new HttpServer({ port: 58080, security: {scheme: "nosec"}});
+
+    await httpServer.start(null);
+    expect(httpServer.getPort()).to.eq(58080); // port test
+    expect(httpServer.getHttpSecurityScheme()).to.eq("NoSec"); // HTTP security scheme test (nosec -> NoSec)
+    await httpServer.stop();
   }
 }


### PR DESCRIPTION
see https://github.com/eclipse/thingweb.node-wot/issues/181

besides the fix it also changes the internal variable name "securityScheme" to "httpSecurityScheme" to make clear the difference