### PR TITLE
feat: add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12.16.1-alpine3.11
+
+RUN apk add --no-cache \
+	gcc \
+	make \
+    python2
+
+ARG BUILD_ENV=development
+
+WORKDIR /home/node/app
+
+COPY . .
+
+RUN npm install \
+    && npm run build \
+    && if [ "${BUILD_ENV}" = "production" ]; then node_modules/.bin/lerna exec "npm prune --production"; fi \
+    && npm run link
+
+EXPOSE 8080
+
+ENTRYPOINT [ "wot-servient" ]
+CMD [ "-h" ]


### PR DESCRIPTION
#197

The docker image can be built in development (default) or production mode, the only difference is that the second will automatically execute the prune command.

After the build, you can easily test it by passing one of the sample scripts inside as an argument:
`docker run -p 8080:8080 IMAGE_ID /home/node/app/examples/scripts/counter.js`