### PR TITLE
BaseURI for links in TD

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -48,6 +48,7 @@ export default class HttpServer implements ProtocolServer {
 
   private readonly port: number = 8080;
   private readonly address: string = undefined;
+  private readonly baseUri: string = undefined;
   private readonly httpSecurityScheme: string = "NoSec"; // HTTP header compatible string
   private readonly validOAuthClients: RegExp = /.*/g; 
   private readonly server: http.Server | https.Server = null;
@@ -75,6 +76,9 @@ export default class HttpServer implements ProtocolServer {
 
     if (config.address !== undefined) {
       this.address = config.address;
+    }
+    if (config.baseUri !== undefined) {
+      this.baseUri = config.baseUri;
     }
 
     // TLS
@@ -205,113 +209,121 @@ export default class HttpServer implements ProtocolServer {
       console.debug("[binding-http]",`HttpServer on port ${this.getPort()} exposes '${thing.title}' as unique '/${urlPath}'`);
       this.things.set(urlPath, thing);
 
-      // fill in binding data
-      for (let address of Helpers.getAddresses()) {
-        for (let type of ContentSerdes.get().getOfferedMediaTypes()) {
+      if (this.baseUri !== undefined) {
+        let base: string = this.baseUri.concat("/", encodeURIComponent(urlPath))
+        console.info("[binding-http]", "HttpServer TD hrefs using baseUri " + this.baseUri)
+        this.addEndpoint(thing, tdTemplate, base )
+      } else {
+        // fill in binding data
+        for (let address of Helpers.getAddresses()) {
           let base: string = this.scheme + "://" + address + ":" + this.getPort() + "/" + encodeURIComponent(urlPath);
 
-          if (true) { // make reporting of all properties optional?
-            // check for readOnly/writeOnly for op field and whether there are any properties at all
-            let allReadOnly = true;
-            let allWriteOnly = true;
-            let anyProperties = false;
-            for (let propertyName in thing.properties) {
-              anyProperties = true;
-              if (!thing.properties[propertyName].readOnly) {
-                allReadOnly = false;
-              } else if (!thing.properties[propertyName].writeOnly) {
-                allWriteOnly = false;
-              }
-            }
-            if (anyProperties) {
-              let href = base + "/" + this.ALL_DIR + "/" + encodeURIComponent(this.ALL_PROPERTIES);
-              let form = new TD.Form(href, type);
-              if (allReadOnly) {
-                form.op = ["readallproperties", "readmultipleproperties"];
-              } else if (allWriteOnly) {
-                form.op = ["writeallproperties", "writemultipleproperties"];
-              } else {
-                form.op = ["readallproperties", "readmultipleproperties", "writeallproperties", "writemultipleproperties"];
-              }
-              if (!thing.forms) {
-                thing.forms = [];
-              }
-              thing.forms.push(form);
-            }
+          this.addEndpoint(thing, tdTemplate, base)
+          // media types
+        } // addresses
+
+        if (this.scheme === "https") {
+          this.fillSecurityScheme(thing)
+        }
+
+      return new Promise<void>((resolve, reject) => {
+        resolve();
+      });
+    }
+  }
+
+  public addEndpoint(thing: ExposedThing, tdTemplate: WoT.ThingDescription, base: string) {
+      for (let type of ContentSerdes.get().getOfferedMediaTypes()) {
+
+        let allReadOnly = true;
+        let allWriteOnly = true;
+        let anyProperties = false;
+        for (let propertyName in thing.properties) {
+          anyProperties = true;
+          if (!thing.properties[propertyName].readOnly) {
+            allReadOnly = false;
+          } else if (!thing.properties[propertyName].writeOnly) {
+            allWriteOnly = false;
           }
-
-          for (let propertyName in thing.properties) {
-            let propertyNamePattern = this.updateInteractionNameWithUriVariablePattern(propertyName, thing.properties[propertyName].uriVariables);
-            let href = base + "/" + this.PROPERTY_DIR + "/" + propertyNamePattern;
-            let form = new TD.Form(href, type);
-            ProtocolHelpers.updatePropertyFormWithTemplate(form, tdTemplate, propertyName);
-            if (thing.properties[propertyName].readOnly) {
-              form.op = ["readproperty"];
-              let hform : HttpForm = form;
-              if(hform["htv:methodName"] === undefined) {
-                hform["htv:methodName"] = "GET";
-              }    
-            } else if (thing.properties[propertyName].writeOnly) {
-              form.op = ["writeproperty"];
-              let hform : HttpForm = form;
-              if(hform["htv:methodName"] === undefined) {
-                hform["htv:methodName"] = "PUT";
-              }
-            } else {
-              form.op = ["readproperty", "writeproperty"];
-            }
-
-            thing.properties[propertyName].forms.push(form);
-            console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Property '${propertyName}'`);
-
-            // if property is observable add an additional form with a observable href
-            if (thing.properties[propertyName].observable) {
-              let href = base + "/" + this.PROPERTY_DIR + "/" + encodeURIComponent(propertyName) + "/" + this.OBSERVABLE_DIR;
-              let form = new TD.Form(href, type);
-              form.op = ["observeproperty", "unobserveproperty"];
-              form.subprotocol = "longpoll";
-              thing.properties[propertyName].forms.push(form);
-              console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to observable Property '${propertyName}'`);
-            }
+        }
+        if (anyProperties) {
+          let href = base + "/" + this.ALL_DIR + "/" + encodeURIComponent(this.ALL_PROPERTIES);
+          let form = new TD.Form(href, type);
+          if (allReadOnly) {
+            form.op = ["readallproperties", "readmultipleproperties"];
+          } else if (allWriteOnly) {
+            form.op = ["writeallproperties", "writemultipleproperties"];
+          } else {
+            form.op = ["readallproperties", "readmultipleproperties", "writeallproperties", "writemultipleproperties"];
           }
-          
-          for (let actionName in thing.actions) {
-            let actionNamePattern = this.updateInteractionNameWithUriVariablePattern(actionName, thing.actions[actionName].uriVariables);
-            let href = base + "/" + this.ACTION_DIR + "/" + actionNamePattern;
-            let form = new TD.Form(href, type);
-            ProtocolHelpers.updateActionFormWithTemplate(form, tdTemplate, actionName);
-            form.op = ["invokeaction"];
+          if (!thing.forms) {
+            thing.forms = [];
+          }
+          thing.forms.push(form);
+        }
+
+        for (let propertyName in thing.properties) {
+          let propertyNamePattern = this.updateInteractionNameWithUriVariablePattern(propertyName, thing.properties[propertyName].uriVariables);
+          let href = base + "/" + this.PROPERTY_DIR + "/" + propertyNamePattern;
+          let form = new TD.Form(href, type);
+          ProtocolHelpers.updatePropertyFormWithTemplate(form, tdTemplate, propertyName);
+          if (thing.properties[propertyName].readOnly) {
+            form.op = ["readproperty"];
             let hform : HttpForm = form;
             if(hform["htv:methodName"] === undefined) {
-              hform["htv:methodName"] = "POST";
+              hform["htv:methodName"] = "GET";
             }
-            thing.actions[actionName].forms.push(form);
-            console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Action '${actionName}'`);
+          } else if (thing.properties[propertyName].writeOnly) {
+            form.op = ["writeproperty"];
+            let hform : HttpForm = form;
+            if(hform["htv:methodName"] === undefined) {
+              hform["htv:methodName"] = "PUT";
+            }
+          } else {
+            form.op = ["readproperty", "writeproperty"];
           }
-          
-          for (let eventName in thing.events) {
-            let eventNamePattern = this.updateInteractionNameWithUriVariablePattern(eventName, thing.events[eventName].uriVariables);
-            let href = base + "/" + this.EVENT_DIR + "/" + eventNamePattern;
+
+          thing.properties[propertyName].forms.push(form);
+          console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Property '${propertyName}'`);
+
+          // if property is observable add an additional form with a observable href
+          if (thing.properties[propertyName].observable) {
+            let href = base + "/" + this.PROPERTY_DIR + "/" + encodeURIComponent(propertyName) + "/" + this.OBSERVABLE_DIR;
             let form = new TD.Form(href, type);
-            ProtocolHelpers.updateEventFormWithTemplate(form, tdTemplate, eventName);
+            form.op = ["observeproperty", "unobserveproperty"];
             form.subprotocol = "longpoll";
-            form.op = ["subscribeevent", "unsubscribeevent"];
-            thing.events[eventName].forms.push(form);
-            console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Event '${eventName}'`);
+            thing.properties[propertyName].forms.push(form);
+            console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to observable Property '${propertyName}'`);
           }
-        } // media types
-      } // addresses
+        }
 
-      if (this.scheme === "https") {
-        this.fillSecurityScheme(thing)
+        for (let actionName in thing.actions) {
+          let actionNamePattern = this.updateInteractionNameWithUriVariablePattern(actionName, thing.actions[actionName].uriVariables);
+          let href = base + "/" + this.ACTION_DIR + "/" + actionNamePattern;
+          let form = new TD.Form(href, type);
+          ProtocolHelpers.updateActionFormWithTemplate(form, tdTemplate, actionName);
+          form.op = ["invokeaction"];
+          let hform : HttpForm = form;
+          if(hform["htv:methodName"] === undefined) {
+            hform["htv:methodName"] = "POST";
+          }
+          thing.actions[actionName].forms.push(form);
+          console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Action '${actionName}'`);
+        }
+
+        for (let eventName in thing.events) {
+          let eventNamePattern = this.updateInteractionNameWithUriVariablePattern(eventName, thing.events[eventName].uriVariables);
+          let href = base + "/" + this.EVENT_DIR + "/" + eventNamePattern;
+          let form = new TD.Form(href, type);
+          ProtocolHelpers.updateEventFormWithTemplate(form, tdTemplate, eventName);
+          form.subprotocol = "longpoll";
+          form.op = ["subscribeevent", "unsubscribeevent"];
+          thing.events[eventName].forms.push(form);
+          console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Event '${eventName}'`);
+        }
       }
+    }
 
-    } // running
-
-    return new Promise<void>((resolve, reject) => {
-      resolve();
-    });
-  }
 
   private async checkCredentials(thing: ExposedThing, req: http.IncomingMessage): Promise<boolean> {
 

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -226,9 +226,10 @@ export default class HttpServer implements ProtocolServer {
           this.fillSecurityScheme(thing)
         }
 
-      return new Promise<void>((resolve, reject) => {
-        resolve();
-      });
+        return new Promise<void>((resolve, reject) => {
+          resolve();
+        });
+      }
     }
   }
 

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -28,6 +28,7 @@ export * from './https-client-factory'
 export interface HttpConfig {
     port?: number;
     address?: string;
+    baseUri?: string;
     proxy?: HttpProxyConfig;
     allowSelfSigned?: boolean;
     serverKey?: string;

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -203,6 +203,8 @@ class HttpServerTest {
     await httpServer.start(null);
     expect(httpServer.getPort()).to.eq(1337); // WOT PORT from test
     await httpServer.stop();
+    delete process.env.PORT
+    delete process.env.WOT_PORT
   }
 
   @test async "should allow HttpServer baseUri to specify url prefix for proxied/gateswayed/buildpack etc "() {
@@ -211,7 +213,8 @@ class HttpServerTest {
     let theBasePath= '/things'
     let theBaseUri = `http://${theHostname}${theBasePath}`;
     let httpServer = new HttpServer({
-      baseUri: theBaseUri
+      baseUri: theBaseUri,
+      port: 8080
     });
 
     await httpServer.start(null);


### PR DESCRIPTION
Related issues #214,  #878

TLDR:
> Implement 'base' property, and test, via
````
Assume thing.base = "http://all.your.base.are.belong.to.us:9999"

urlbase = thing.base || ( this.scheme + "://" + address + ":" + this.getPort() );
let href = base + "/" + this.ALL_DIR + "/" + encodeURIComponent(this.ALL_PROPERTIES);
console.log(href)
=> ":"http://all.your.base.are.belong.to.us:9999/WOT/all/properties" 
````

According to the language in the spec, the implied assumption is that the form, action, property URLs are relative, and relative to the base URI.

> base property: Define the base URI that is used for all relative URI references throughout a TD document. In TD instances, all relative URIs are resolved relative to the base URI using the algorithm defined in [RFC3986].
> base does not affect the URIs used in @context and the IRIs used within Linked Data [LINKED-DATA] graphs that are relevant when semantic processing is applied to TD instances.

However, node-wot has absolute URLs, and those are based on the network interfaces of the machine. See my comment https://github.com/eclipse/thingweb.node-wot/issues/214#issuecomment-621699899

This type of problem occurred in HAL as well.  In link relations, the implementations would use absolute URLs.  The challenge is that any implementations like this will probably barf if they start getting relative URLs.  They were never checking for the base, neither is node-wot. Right now, node-wot seems to be ignoring base.

This is a proposal for discussion.  In this PR, the http server expose function will check if there is a thing.base property.  If so, it will use that instead of the scheme, address and port in the HTTP config.
This keeps the links in forms, properties, actions as full URLs; it just does the "relative mapping" *squint* on the service side.  

It also behaves like a canonical URL prefix, that may be set on heroku, dokku, ec2, lambda or any front end server that is independent from node-wot.


 