### PR TITLE
Feature/add sse support to binding http

### DIFF
--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -35,13 +35,15 @@
     "typescript-standard": "0.3.36"
   },
   "dependencies": {
-    "@node-wot/td-tools": "0.7.1",
     "@node-wot/core": "0.7.1",
+    "@node-wot/td-tools": "0.7.1",
+    "@types/eventsource": "^1.1.2",
+    "accept-language-parser": "1.5.0",
     "basic-auth": "2.0.1",
     "client-oauth2": "^4.2.5",
+    "eventsource": "^1.0.7",
     "node-fetch": "^2.6.0",
-    "rxjs": "5.5.11",
-    "accept-language-parser": "1.5.0"
+    "rxjs": "5.5.11"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -30,6 +30,7 @@
     "mocha-typescript": "1.1.8",
     "request": "2.88.0",
     "request-promise": "4.2.5",
+    "ssestream": "1.0.0",
     "ts-node": "8.6.2",
     "typescript": "3.7.5",
     "typescript-standard": "0.3.36"

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -28,11 +28,12 @@ import * as WoT from "wot-typescript-definitions";
 
 import { ProtocolClient, Content } from "@node-wot/core";
 import { HttpForm, HttpHeader, HttpConfig, HTTPMethodName } from "./http";
-import fetch, { Request,RequestInit,Response } from 'node-fetch';
+import fetch, { Request, RequestInit, Response } from 'node-fetch';
 import { Buffer } from "buffer";
 import OAuthManager from "./oauth-manager";
 import { parse } from "url";
 import { BasicCredential, Credential, BearerCredential, BasicKeyCredential, OAuthCredential } from "./credential";
+import * as EventSource from 'eventsource';
 
 export default class HttpClient implements ProtocolClient {
 
@@ -44,16 +45,16 @@ export default class HttpClient implements ProtocolClient {
   private allowSelfSigned: boolean = false;
   private oauth: OAuthManager;
 
-  private credential:Credential = null;
+  private credential: Credential = null;
 
   private activeSubscriptions = new Set();
 
   constructor(config: HttpConfig = null, secure = false, oauthManager: OAuthManager = new OAuthManager()) {
 
     // config proxy by client side (not from TD)
-    if (config!==null && config.proxy && config.proxy.href) {
+    if (config !== null && config.proxy && config.proxy.href) {
       this.proxyRequest = new Request(HttpClient.fixLocalhostName(config.proxy.href))
-      
+
       if (config.proxy.scheme === "basic") {
         if (!config.proxy.hasOwnProperty("username") || !config.proxy.hasOwnProperty("password")) console.warn("[binding-http]",`HttpClient client configured for basic proxy auth, but no username/password given`);
         this.proxyRequest.headers.set('proxy-authorization', "Basic " + Buffer.from(config.proxy.username + ":" + config.proxy.password).toString('base64'));
@@ -70,14 +71,14 @@ export default class HttpClient implements ProtocolClient {
     }
 
     // config certificate checks
-    if (config!==null && config.allowSelfSigned!==undefined) {
+    if (config !== null && config.allowSelfSigned !== undefined) {
       this.allowSelfSigned = config.allowSelfSigned;
       console.warn("[binding-http]",`HttpClient allowing self-signed/untrusted certificates -- USE FOR TESTING ONLY`);
     }
 
     // using one client impl for both HTTP and HTTPS
     this.agent = secure ? new https.Agent({
-      rejectUnauthorized : !this.allowSelfSigned
+      rejectUnauthorized: !this.allowSelfSigned
     }) : new http.Agent();
 
     this.provider = secure ? https : http;
@@ -105,8 +106,8 @@ export default class HttpClient implements ProtocolClient {
   }
 
   public async writeResource(form: HttpForm, content: Content): Promise<any> {
-    const request = await this.generateFetchRequest(form, "PUT",{
-      headers : [["content-type",content.type]],
+    const request = await this.generateFetchRequest(form, "PUT", {
+      headers: [["content-type", content.type]],
       body: content.body
     })
 
@@ -125,9 +126,9 @@ export default class HttpClient implements ProtocolClient {
   public async invokeResource(form: HttpForm, content?: Content): Promise<Content> {
     const headers = content ? [["content-type", content.type]] : []
 
-    const request = await this.generateFetchRequest(form, "POST",{
-      headers : headers,
-      body : content?.body
+    const request = await this.generateFetchRequest(form, "POST", {
+      headers: headers,
+      body: content?.body
     })
 
     console.debug("[binding-http]",`HttpClient (invokeResource) sending ${request.method} ${content ? "with '" + request.headers.get("Content-Type") + "' " : " "}to ${request.url}`);
@@ -153,38 +154,55 @@ export default class HttpClient implements ProtocolClient {
   public subscribeResource(form: HttpForm, next: ((value: any) => void), error?: (error: any) => void, complete?: () => void): any {
 
     this.activeSubscriptions.add(form.href);
-    let polling = async () => {
-      try {
-        // long timeout for long polling
-        const request = await this.generateFetchRequest(form, "GET", { timeout: 60 * 60 * 1000 })
-        console.debug("[binding-http]",`HttpClient (subscribeResource) sending ${request.method} to ${request.url}`);
+    if (form.subprotocol == undefined || form.subprotocol == "longpoll") {
+      //longpoll or subprotocol is not defined default is longpoll
+      let polling = async () => {
+        try {
+          // long timeout for long polling
+          const request = await this.generateFetchRequest(form, "GET", { timeout: 60 * 60 * 1000 })
+          console.debug("[binding-http]",`HttpClient (subscribeResource) sending ${request.method} to ${request.url}`);
 
-        const result = await this.fetch(request)
+          const result = await this.fetch(request)
 
-        this.checkFetchResponse(result)
+          this.checkFetchResponse(result)
 
-        const buffer = await result.buffer()
-        console.debug("[binding-http]",`HttpClient received ${result.status} from ${request.url}`);
+          const buffer = await result.buffer()
+          console.debug("[binding-http]",`HttpClient received ${result.status} from ${request.url}`);
 
-        console.debug("[binding-http]",`HttpClient received headers: ${JSON.stringify(result.headers.raw())}`);
-        console.debug("[binding-http]",`HttpClient received Content-Type: ${result.headers.get("content-type")}`);
+          console.debug("[binding-http]",`HttpClient received headers: ${JSON.stringify(result.headers.raw())}`);
+          console.debug("[binding-http]",`HttpClient received Content-Type: ${result.headers.get("content-type")}`);
 
-        if (this.activeSubscriptions.has(form.href)) {
-          next({ type: result.headers.get("content-type"), body: buffer })
-          polling()
-        } {
+          if (this.activeSubscriptions.has(form.href)) {
+            next({ type: result.headers.get("content-type"), body: buffer })
+            polling()
+          } {
+            complete && complete()
+          }
+        } catch (e) {
+          error && error(e)
           complete && complete()
+          this.activeSubscriptions.delete(form.href)
         }
-      } catch (e) {
-        error && error(e)
+      }
+      polling();
+    } else if (form.subprotocol == "sse") {
+      //server sent events
+      let _this = this;
+      const eventSource = new EventSource(form.href);
+      eventSource.onopen = function (event) {
+        console.info(`HttpClient (subscribeResource) Server-Sent Event connection is opened to ${form.href}`);
+      }
+      eventSource.onmessage = function (event) {
+        let output = { type: form.contentType, body: JSON.stringify(event) };
+        next(output);
+      }
+      eventSource.onerror = function (event) {
+        error(event.toString());
         complete && complete()
-        this.activeSubscriptions.delete(form.href)
+        _this.activeSubscriptions.delete(form.href)
       }
     }
-
-    polling();
-
-    return new Subscription( () => { } );
+    return new Subscription(() => { });
   }
 
   public start(): boolean {
@@ -261,16 +279,16 @@ export default class HttpClient implements ProtocolClient {
     return true;
   }
 
-  private async generateFetchRequest(form: HttpForm, defaultMethod: HTTPMethodName, additionalOptions: RequestInit={}){
-    let requestInit : RequestInit = additionalOptions
-   
+  private async generateFetchRequest(form: HttpForm, defaultMethod: HTTPMethodName, additionalOptions: RequestInit = {}) {
+    let requestInit: RequestInit = additionalOptions
+
     let url = HttpClient.fixLocalhostName(form.href)
 
     requestInit.method = form["htv:methodName"] ? form["htv:methodName"] : defaultMethod;
-    
+
     requestInit.headers = requestInit.headers ?? []
     requestInit.headers = requestInit.headers as string[][]
-    
+
     if (Array.isArray(form["htv:headers"])) {
       console.debug("[binding-http]","HttpClient got Form 'headers'", form["htv:headers"]);
       
@@ -285,18 +303,18 @@ export default class HttpClient implements ProtocolClient {
       requestInit.headers.push([option["htv:fieldName"], option["htv:fieldValue"]]);
     }
 
-    
-    
+
+
     requestInit.agent = this.agent
 
     let request = this.proxyRequest ? new Request(this.proxyRequest, requestInit) : new Request(url, requestInit);
-    
+
     // Sign the request using client credentials
     if (this.credential) {
       request = await this.credential.sign(request)
     }
 
-    if(this.proxyRequest){
+    if (this.proxyRequest) {
       const parsedBaseURL = parse(url)
       request.url = request.url + parsedBaseURL.path
       
@@ -305,27 +323,27 @@ export default class HttpClient implements ProtocolClient {
       request.headers.set("host", parsedBaseURL.hostname)
     }
 
-    return  request;
+    return request;
   }
 
-  private async fetch(request:Request,content?:Content){
+  private async fetch(request: Request, content?: Content) {
     let result = await fetch(request, { body: content?.body })
-    
-    if (HttpClient.isOAuthTokenExpired(result,this.credential)) {
+
+    if (HttpClient.isOAuthTokenExpired(result, this.credential)) {
       this.credential = await (this.credential as OAuthCredential).refreshToken()
-      return await fetch( await this.credential.sign(request))
+      return await fetch(await this.credential.sign(request))
     }
 
     return result;
   }
 
-  private checkFetchResponse(response:Response){
+  private checkFetchResponse(response: Response) {
     const statusCode = response.status
 
     if (statusCode < 200) {
       throw new Error(`HttpClient received ${statusCode} and cannot continue (not implemented, open GitHub Issue)`);
-    }else if (statusCode < 300) {
-        return // No error
+    } else if (statusCode < 300) {
+      return // No error
     } else if (statusCode < 400) {
       throw new Error(`HttpClient received ${statusCode} and cannot continue (not implemented, open GitHub Issue)`);
     } else if (statusCode < 500) {
@@ -335,13 +353,13 @@ export default class HttpClient implements ProtocolClient {
     }
   }
 
-  private static isOAuthTokenExpired(result:Response,credential:Credential){
+  private static isOAuthTokenExpired(result: Response, credential: Credential) {
     return result.status === 401 && credential instanceof OAuthCredential
   }
 
-  private static fixLocalhostName(url:string) {
+  private static fixLocalhostName(url: string) {
     const localhostPresent = /^(https?:)?(\/\/)?(?:[^@\n]+@)?(www\.)?(localhost)/gm
-    
+
     if (localhostPresent.test(url)) {
       console.warn("[binding-http]","LOCALHOST FIX");
       return url.replace(localhostPresent, "$1$2127.0.0.1")

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -193,6 +193,7 @@ export default class HttpClient implements ProtocolClient {
         console.info(`HttpClient (subscribeResource) Server-Sent Event connection is opened to ${form.href}`);
       }
       eventSource.onmessage = function (event) {
+        console.info(`HttpClient received ${JSON.stringify(event)} from ${form.href}`)
         let output = { type: form.contentType, body: JSON.stringify(event) };
         next(output);
       }


### PR DESCRIPTION
With this PR Server-sent events support is added in binding HTTP.
One package called: eventsource (https://www.npmjs.com/package/eventsource) is added.
A simple connection test is written, by using its own example code for server side.
It is also tested with a real world use.