### PR TITLE
feat: add log levels

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ The `-h` option explains the functionality and also how node-wot can be configur
 * `wot-servient -h` *or*
 * `node packages\cli\dist\cli.js`
 
-The `-h` help options shows the the following output:
+The `-h` help options shows the following output:
 
 ```
 Usage: wot-servient [options] [SCRIPT]...
@@ -50,6 +50,9 @@ wot-servient.conf.json syntax:
         "clientId": BROKER-UNIQUEID,
         "protocolVersion": MQTT_VERSION
     },
+    "log": {
+        "level": LEVEL
+    },
     "credentials": {
         THING_ID1: {
             "token": TOKEN
@@ -77,6 +80,7 @@ wot-servient.conf.json fields:
   BROKER-URL      : URL to an MQTT broker that publisher and subscribers will use
   BROKER-UNIQUEID : unique id set by mqtt client while connecting to broker
   MQTT_VERSION    : number indicating the MQTT protocol version to be used (3, 4, or 5)
+  LEVEL           : string or number setting the log level: { error: 0, warn: 1, info: 2, debug: 3 } (default info)
   THING_IDx       : string with TD "id" for which credentials should be configured
   TOKEN           : string for providing a Bearer token
   USERNAME        : string for providing a Basic Auth username

--- a/packages/cli/wot-servient.conf.json.md
+++ b/packages/cli/wot-servient.conf.json.md
@@ -58,7 +58,7 @@ BROKER-UNIQUEID is a string indicating an optional MQTT broker unique ID
 
 MQTT_VERSION is a number indicating the MQTT protocol version to be used (3, 4, or 5)
 
-LEVEL is a string or number to set the logging level: `{ error: 0, warn: 1, info: 2, log: 3, debug: 4 }`
+LEVEL is a string or number to set the logging level: `{ error: 0, warn: 1, info: 2, debug: 3 }` (default `info`)
 
 THING_IDx is a TD @id for which credentials should be configured
 


### PR DESCRIPTION
This PR closes #193.
Among adding support for the log levels, I have also slightly changed the levels themselves.
Originally, in `packages/cli/wot-servient.conf.json.md` it states "LEVEL is a string or number to set the logging level: `{ error: 0, warn: 1, info: 2, log: 3, debug: 4 }`". But I have changed it to `{ error: 0, warn: 1, info: 2, debug: 3 }` removing the level `log` since I find it quite silly to suppress `console.log` level messages. I've made the level `info` as default which is pretty logical and it also was the default level in the `examples/scripts/wot-servient.conf.json` config file.