### PR TITLE
[http-binding] OAuth server side token validation 

### DIFF
--- a/examples/security/oauth/README.md
+++ b/examples/security/oauth/README.md
@@ -1,13 +1,11 @@
-# oAuth example
-The example is composed by two actors: one Thing that expose an action with oAuth2.0 client credential security constraint and a client who want to use that function. In the example, we are using an utility server to generate tokens and validate client credentials. Therefore, the **wot-consumer** force the action `href` to be the same as the utility server with the goal to validate the obtained oAuth2.0 token. In the feature the exposing servient could also play this role. 
+# oAuth JavaScript example
+This is example is composed by two actors: one Thing that expose an action with oAuth2.0 client credential security constraint and a client who want to use that function. In the example, we are using an utility server to generate tokens and validate client credentials. Therefore, the **wot-consumer** force the action `href` to be the same as the utility server with the goal to validate the obtained oAuth2.0 token. In the feature the exposing servient could also play this role. 
 
 ## run the example
 Set the current working directory to this folder. Then execute:
 ```bash
 npm install
-npm run build
 ```
-After this follow the procedure described in [here](../../README.md) and remove the unwanted line of codes inside the scripts `./dist/consumer.js` and `./dist/exposer.js`.
 
 Now you are ready to run the example.
 
@@ -33,5 +31,5 @@ oAuth token was Ok!
 This confirm that the oAuth flow was completed successfully. Now you can have fun revoking the access to the consumer script. Go
 to `./memory-model.js` and try to remove the string `"limited"` from the grants. Run again the example and you will see that the action is not executed and an error is returned by the client. 
 
-## Where is a JS version?
-See [here](../../../examples/security/oauth)
+## Where is a TS version?
+See [here](../../../packages/examples/src/security/oauth)

--- a/examples/security/oauth/consumer.js
+++ b/examples/security/oauth/consumer.js
@@ -1,3 +1,4 @@
+
 /********************************************************************************
  * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
  *
@@ -12,13 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
-WoTHelpers.fetch("http://localhost:8080/OAuth").then(td => {
-    td.actions.sayOk.forms[0].href = "https://localhost:3000/resource";
-    td.actions.sayOk.forms[0]["htv:methodName"] = "GET";
+WoTHelpers.fetch("https://localhost:8080/OAuth").then(td => {
     WoT.consume(td).then(async (thing) => {
-        const result = await thing.invokeAction("sayOk");
-        console.log("oAuth token was", result);
+        try {
+            const result = await thing.invokeAction("sayOk");
+            console.log("oAuth token was", result);
+        }
+        catch (error) {
+            console.log("It seems that I couldn't access the resource");
+        }
     });
 });
-

--- a/examples/security/oauth/exposer.js
+++ b/examples/security/oauth/exposer.js
@@ -33,17 +33,14 @@ let td = {
     ],
     "actions": {
         "sayOk": {
-            "forms": [
-                {
-                    "href": "https://localhost:3000/resource",
-                    "htv:methodName": "GET"
-                }
-            ]
+            "description": "A simple action protected with oauth",
+            "idempotent": true
         }
     }
 };
 try {
     WoT.produce(td).then((thing) => {
+        thing.setActionHandler("sayOk", async () => "Ok!");
         thing.expose();
     });
 }

--- a/examples/security/oauth/memory-model.js
+++ b/examples/security/oauth/memory-model.js
@@ -21,7 +21,7 @@ module.exports =  class InMemoryModel{
      *
      */
     constructor() {
-        this.clients = [{ clientId: 'node-wot', clientSecret: 'isgreat!', redirectUris: [''], grants:["client_credentials","password"] }];
+        this.clients = [{ clientId: 'node-wot', clientSecret: 'isgreat!', redirectUris: [''], grants:["client_credentials","limited"] }];
         this.tokens = [];
         this.users = [{ id: '123', username: 'thomseddon', password: 'nightworld' }];
         

--- a/examples/security/oauth/package.json
+++ b/examples/security/oauth/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "server": "node server.js",
-    "start:exposer": "node ../../../packages/cli/dist/cli.js exposer.js",
+    "start:exposer": "node ../../../packages/cli/dist/cli.js -f ./wot-server-servient-conf.json exposer.js",
     "start:consumer": "node ../../../packages/cli/dist/cli.js -f ./wot-client-servient-conf.json consumer.js"
   },
   "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",

--- a/examples/security/oauth/wot-server-servient-conf.json
+++ b/examples/security/oauth/wot-server-servient-conf.json
@@ -1,0 +1,24 @@
+{
+    "servient": {
+    },
+    "http":{
+        "allowSelfSigned": true,
+        "serverKey": "../privatekey.pem",
+        "serverCert": "../certificate.pem",
+        "security": {
+            "scheme": "oauth2",
+            "method": {
+                "name":"introspection_endpoint",
+                "endpoint": "https://localhost:3000/introspect",
+                "allowSelfSigned": true
+            }
+
+        }
+    },
+    "credentials": {
+        "urn:dev:wot:oauth:test": {
+            "clientId" : "node-wot",
+            "clientSecret": "isgreat!"
+        }
+    }
+}

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -19,10 +19,10 @@
     "@types/chai": "4.2.8",
     "@types/express": "^4.17.3",
     "@types/express-oauth-server": "^2.0.2",
+    "@types/mocha": "^7.0.2",
     "@types/node": "13.7.0",
     "@types/node-fetch": "^2.5.6",
     "@types/request-promise": "4.1.45",
-    "wot-typescript-definitions": "0.7.3",
     "chai": "4.2.0",
     "chai-spies": "1.0.0",
     "express-oauth-server": "^2.0.0",
@@ -32,7 +32,8 @@
     "request-promise": "4.2.5",
     "ts-node": "8.6.2",
     "typescript": "3.7.5",
-    "typescript-standard": "0.3.36"
+    "typescript-standard": "0.3.36",
+    "wot-typescript-definitions": "0.7.3"
   },
   "dependencies": {
     "@node-wot/td-tools": "0.7.1",

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -319,7 +319,18 @@ export default class HttpServer implements ProtocolServer {
         
         //TODO: Support security schemes defined at affordance level
         const scopes = oAuthScheme.scopes ?? []
-        return this.oAuthValidator.validate(req, scopes, this.validOAuthClients);
+        let valid = false
+        
+        try {
+          valid = await this.oAuthValidator.validate(req, scopes, this.validOAuthClients);
+        } catch (error) {
+          // TODO: should we answer differently to the client if something went wrong?
+          console.error("OAuth authorization error; sending unauthorized response error")
+          console.error("this was possibly caused by a misconfiguration of the server")
+          console.error(error)
+        }
+
+        return valid
       case "Bearer":
         if (req.headers["authorization"]===undefined) return false;
         // TODO proper token evaluation

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -298,11 +298,11 @@ export default class HttpServer implements ProtocolServer {
     });
   }
 
-  private async checkCredentials(id: string, req: http.IncomingMessage): Promise<boolean> {
+  private async checkCredentials(thing: ExposedThing, req: http.IncomingMessage): Promise<boolean> {
 
-    console.log(`HttpServer on port ${this.getPort()} checking credentials for '${id}'`);
+    console.log(`HttpServer on port ${this.getPort()} checking credentials for '${thing.id}'`);
 
-    let creds = this.servient.getCredentials(id);
+    let creds = this.servient.getCredentials(thing.id);
 
     switch (this.httpSecurityScheme) {
       case "NoSec":
@@ -315,7 +315,6 @@ export default class HttpServer implements ProtocolServer {
       case "Digest":
         return false;
       case "OAuth":
-        const thing = this.things.get(id)
         const oAuthScheme = thing.securityDefinitions[thing.security[0] as string] as OAuth2SecurityScheme
         
         //TODO: Support security schemes defined at affordance level
@@ -502,7 +501,7 @@ export default class HttpServer implements ProtocolServer {
 
         } else {
           // Thing Interaction - Access Control
-          if (this.httpSecurityScheme!=="NoSec" && ! await this.checkCredentials(thing.id, req)) {
+          if (this.httpSecurityScheme!=="NoSec" && ! await this.checkCredentials(thing, req)) {
             res.setHeader("WWW-Authenticate", `${this.httpSecurityScheme} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -95,7 +95,7 @@ export default class HttpServer implements ProtocolServer {
         case "bearer":
           this.httpSecurityScheme = "Bearer";
           break;
-        case "oauth":
+        case "oauth2":
           this.httpSecurityScheme = "OAuth";
           const oAuthConfig = config.security as OAuth2ServerConfig
           this.validOAuthClients = new RegExp(oAuthConfig.allowedClients ?? ".*");
@@ -347,7 +347,12 @@ export default class HttpServer implements ProtocolServer {
   private fillSecurityScheme(thing: ExposedThing){
     if (thing.securityDefinitions) {
       const secCandidate = Object.keys(thing.securityDefinitions).find(key => {
-        return thing.securityDefinitions[key].scheme === this.httpSecurityScheme.toLowerCase()
+        let scheme = thing.securityDefinitions[key].scheme
+        // HTTP Authentication Scheme for OAuth does not contain the version number
+        // see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+        // remove version number for oauth2 schemes
+        scheme = scheme === "oauth2" ? scheme.split("2")[0] : scheme
+        return scheme === this.httpSecurityScheme.toLowerCase()
       })
 
       if (!secCandidate) {

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -14,6 +14,7 @@
  ********************************************************************************/
 
 import * as TD from "@node-wot/td-tools";
+import { Method } from "./oauth-token-validation";
 
 export { default as HttpServer } from './http-server'
 export { default as HttpClient } from './http-client'
@@ -32,6 +33,14 @@ export interface HttpConfig {
     serverKey?: string;
     serverCert?: string;
     security?: TD.SecurityScheme;
+}
+
+export interface OAuth2ServerConfig extends TD.SecurityScheme{
+    method: Method;
+    /**
+     * Regex to select the valid clients ids. Default: .*
+     */
+    allowedClients?:string; 
 }
 
 export interface HttpProxyConfig {

--- a/packages/binding-http/src/oauth-token-validation.ts
+++ b/packages/binding-http/src/oauth-token-validation.ts
@@ -1,0 +1,136 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import fetch, { Request } from "node-fetch";
+import { BasicCredential } from "./credential";
+import * as http from "http";
+
+export interface Method {
+    name: string
+}
+
+export interface IntrospectionEndpoint extends Method {
+    endpoint:string;
+    credentials?: {username:string, password:string}
+}
+/**
+ * Identify an introspection result. It contains some of the 
+ * properties defined in 
+ * https://tools.ietf.org/html/rfc7662#section-2.2
+ */
+interface TokenInformation {
+    /**
+     * Boolean indicator of whether or not the presented token
+     * is currently active.
+     */
+    active: boolean
+    /**
+     * A JSON string containing a space-separated list of
+     * scopes associated with this token
+     */
+    scope?: string
+    /**
+     * Client identifier for the OAuth 2.0 client that 
+     * requested this token
+     */
+    client_id?:string
+    
+}
+
+export default function (method?:Method) {
+    if(!method || method?.name){
+        throw new Error("Undefined oauth token validation method")
+    } 
+
+    switch (method.name) {
+        case "introspection_endpoint":
+            return new EndpointValidator(method as IntrospectionEndpoint)
+        default:
+            throw new Error("Unsupported oauth token validation method " + method.name)
+    }
+
+}
+
+export abstract class Validator{
+    abstract validate(tokenRequest: http.IncomingMessage, scopes: Array<string>, clients: RegExp):Promise<boolean>
+}
+
+export class EndpointValidator extends Validator{
+    private config: IntrospectionEndpoint;
+    
+    constructor(config:IntrospectionEndpoint) {
+        super();
+        this.config = config
+    }
+    async validate(tokenRequest: http.IncomingMessage,scopes:Array<string>,clients:RegExp): Promise<boolean> {
+        const token = extractTokenFromRequest(tokenRequest)
+        const request = new Request(this.config.endpoint,{
+            body:`token=${token}`
+        });
+        
+        if(this.config.credentials){
+            await new BasicCredential(this.config.credentials).sign(request)
+        }
+        
+        const response = await fetch(request);
+        const validationResult = await response.json() as TokenInformation
+
+        // Endpoint validation
+        if(!validationResult.active){
+            return false
+        }
+
+        // Check if the token's scopes are allowed by the Thing Descriptor
+        if(validationResult.scope){
+            const tokenScopes = validationResult.scope.split(" ")
+            const validScope = tokenScopes.some(tokenScope => {
+                return scopes.some(thingScope => tokenScope === thingScope)
+            })
+
+            if(!validScope) return false;
+        }
+
+        // Check if the client was allowed in the servient configuration file
+        if(validationResult.client_id && !validationResult.client_id.match(clients)){
+            return false
+        }
+
+        return true;
+
+    }
+
+}
+
+function extractTokenFromRequest(request: http.IncomingMessage) {
+    const headerToken = request.headers.authorization;
+    const url = new URL(request.url)
+    const queryToken = url.searchParams.get("access_token")
+
+    if(!!headerToken && !!queryToken ){
+        throw new Error("Invalid request: only one authentication method is allowed");
+    }
+
+    if(queryToken){
+        return queryToken
+    }
+   
+    var matches = headerToken.match(/Bearer\s(\S+)/);
+
+    if (!matches) {
+        throw new Error('Invalid request: malformed authorization header');
+    }
+
+    return matches[1];
+
+}

--- a/packages/binding-http/src/oauth-token-validation.ts
+++ b/packages/binding-http/src/oauth-token-validation.ts
@@ -134,7 +134,7 @@ export class EndpointValidator extends Validator{
 
 function extractTokenFromRequest(request: http.IncomingMessage) {
     const headerToken = request.headers.authorization;
-    const url = new URL(request.url)
+    const url = new URL(request.url, `http://${request.headers.host}`)
     const queryToken = url.searchParams.get("access_token")
 
     if(!headerToken && !queryToken ){

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { suite, test, slow, timeout, skip, only, describe } from "mocha-typescript";
+import { expect, should, assert } from "chai";
+import * as express from 'express';
+import { HttpServer, OAuth2ServerConfig } from "../src/http";
+import { IntrospectionEndpoint, EndpointValidator } from "../src/oauth-token-validation";
+
+
+should()
+@suite("OAuth server token validation tests")
+class OAuthServerTests{
+
+    static before(){
+        var app: express.Express = express();
+        app.use((req)=>{
+
+            return 
+        })
+    }
+
+    @test async "should configure oauth"(){
+        const method: IntrospectionEndpoint = {
+            name: "introspection_endpoint",
+            endpoint: "http://localhost:4242"
+        }
+        const authConfig: OAuth2ServerConfig = {
+            scheme:"oauth",
+            method: method,
+        }
+        const server = new HttpServer({
+            security : authConfig
+        })
+
+        server["httpSecurityScheme"].should.be.equal("OAuth")
+        server["oAuthValidator"].should.be.instanceOf(EndpointValidator)
+    }
+}

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -35,7 +35,7 @@ class OAuthServerTests{
             endpoint: "http://localhost:4242"
         }
         const authConfig: OAuth2ServerConfig = {
-            scheme: "oauth",
+            scheme: "oauth2",
             method: method,
         }
         this.server = new HttpServer({
@@ -119,7 +119,7 @@ class OAuthServerTests{
         
         this.server["oAuthValidator"].validate = async (token,scopes,clients) => {
             called = true
-            throw new Error("errore");
+            return false
         }
 
         const response = await fetch("http://localhost:8080/TestOAuth/TestOAuth")

--- a/packages/binding-http/test/oauth-token-validation-tests.ts
+++ b/packages/binding-http/test/oauth-token-validation-tests.ts
@@ -35,7 +35,7 @@ describe('OAuth2.0 Validator tests', () => {
             const tokens = ["active","notActive"];
 
             var introspectEndpoint: express.Express = express();
-            introspectEndpoint.use(express.urlencoded())
+            introspectEndpoint.use(express.urlencoded({extended: true}))
             
             introspectEndpoint.use("/invalid",(req,res)=>{
                 return res.status(400).end()
@@ -284,7 +284,7 @@ describe('OAuth2.0 Validator tests', () => {
             //Initialize test
 
             var introspectEndpoint: express.Express = express();
-            introspectEndpoint.use(express.urlencoded())
+            introspectEndpoint.use(express.urlencoded({extended:true}))
             
             introspectEndpoint.use((req, res) =>{
                 // No validation just testing https connection

--- a/packages/binding-http/test/oauth-token-validation-tests.ts
+++ b/packages/binding-http/test/oauth-token-validation-tests.ts
@@ -1,0 +1,283 @@
+import { suite, test, slow, timeout } from 'mocha-typescript';
+import * as express from 'express';
+import { should } from "chai";
+import create, { IntrospectionEndpoint, Validator, EndpointValidator } from '../src/oauth-token-validation'
+import * as http from "http";
+import { assert } from 'console';
+
+
+should()
+
+describe('OAuth2.0 Validator tests', () => {
+    it('should create an introspection validator', () => {
+        const config: IntrospectionEndpoint = {
+            name: "introspection_endpoint",
+            endpoint: "http://localhost:7777"
+        }
+        create(config).should.be.instanceOf(EndpointValidator)
+    });
+
+    it('should throw for invalid method', () => {
+        
+        const test = () => create({name : "unknown" })
+
+        test.should.throw()
+    });
+    @suite class IntrospectProtocolTests {
+        private validator: Validator;
+        static before() {
+            console.debug = () => { }
+            console.warn = () => { }
+            console.info = () => { }
+
+            const tokens = ["active","notActive"];
+
+            var introspectEndpoint: express.Express = express();
+            introspectEndpoint.use(express.urlencoded())
+            
+            introspectEndpoint.use("/invalid",(req,res)=>{
+                return res.status(400).end()
+            })
+
+            introspectEndpoint.use("/invalidResponse",(req,res)=>{
+                return res.status(200).json({
+                    scope: "1 2",
+                    client_id: "coolClient"
+                }).end()
+            })
+
+            introspectEndpoint.use("/invalidContent",(req,res)=>{
+                return res.status(200).end()
+            })
+
+            introspectEndpoint.use((req,res) => {
+                if (req.method !== "POST" || !req.is("application/x-www-form-urlencoded")){
+                    return res.status(400).end()
+                }
+                
+                const token = req.body.token
+
+                if(!token){
+                    return res.status(400).end()
+                }
+
+                if(token === tokens[0]){
+                    return res.status(200).json({
+                        active: true,
+                        scope: "1 2",
+                        client_id: "coolClient"
+                    }).end()
+                }else{
+                    return res.status(200).json({
+                        active: false
+                    }).end()
+                }
+            })
+
+            introspectEndpoint.listen(7777)
+
+        }
+
+        before(){
+            const config: IntrospectionEndpoint = {
+                name: "introspection_endpoint",
+                endpoint: "http://localhost:7777"
+            }
+            this.validator = create(config)
+        }
+        
+        @test async "should validate token from headers"() {
+
+            var req ={
+                headers: {
+                    'authorization': 'Bearer active'
+                },
+                url : "http://test"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","2"],/.*/g)
+            valid.should.be.true
+        }
+        @test async "should validate token from query string"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","2"],/.*/g)
+            valid.should.be.true
+        }
+
+        @test async "should validate a single scope"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1"],/.*/g)
+            valid.should.be.true
+        }
+
+        @test async "should validate a single scope mixed with invalid scopes"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","3","4"],/.*/g)
+            valid.should.be.true
+        }
+
+        @test async "should validate cliedId"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","3","4"],/coolClient/g)
+            valid.should.be.true
+        }
+
+        @test async "should validate cliedId using regex"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","3","4"],/cool.*/g)
+            valid.should.be.true
+        }
+
+        @test async "should reject invalid cliedId"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["1","3","4"],/otherClient/g)
+            valid.should.be.false
+        }
+        @test async "should reject invalid scopes"() {
+
+            var req ={
+                headers:{},
+                url : "http://test?access_token=active"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,["3"],/.*/g)
+            valid.should.be.false
+        }
+        @test async "should reject invalid token from headers"() {
+
+            var req ={
+                headers: {
+                    'authorization': 'Bearer notActive'
+                },
+                url : "http://test"
+            };
+            
+            const valid = await this.validator.validate(req as http.IncomingMessage,[],/.*/g)
+            valid.should.be.false
+        }
+
+        @test async "should reject invalid token from query string"() {
+
+            var req = {
+                headers: {},
+                url: "http://test?access_token=notActive"
+            };
+
+            const valid = await this.validator.validate(req as http.IncomingMessage, [], /.*/g)
+            valid.should.be.false
+        }
+
+        @test async "should throw invalid incoming message"() {
+
+            var req = {
+                headers: {},
+                url: "http://test"
+            };
+
+            try {
+                const valid = await this.validator.validate(req as http.IncomingMessage, [], /.*/g)
+                assert(false,"method did not throw")
+            } catch (error) {
+                assert(true)
+            }
+        }
+        @test async "should throw invalid introspection http response"() {
+            const config: IntrospectionEndpoint = {
+                name: "introspection_endpoint",
+                endpoint: "http://localhost:7777/invalid"
+            }
+            this.validator = create(config)
+
+            var req = {
+                headers: {
+                    'authorization': 'Bearer active'
+                },
+                url: "http://test"
+            };
+
+            try {
+                const valid = await this.validator.validate(req as http.IncomingMessage, [], /.*/g)
+                assert(false,"method did not throw")
+            } catch (error) {
+                assert(true)
+            }
+        }
+
+        @test async "should throw invalid introspection token response"() {
+            const config: IntrospectionEndpoint = {
+                name: "introspection_endpoint",
+                endpoint: "http://localhost:7777/invalidResponse"
+            }
+            this.validator = create(config)
+
+            var req = {
+                headers: {
+                    'authorization': 'Bearer active'
+                },
+                url: "http://test"
+            };
+
+            try {
+                const valid = await this.validator.validate(req as http.IncomingMessage, [], /.*/g)
+                assert(false,"method did not throw")
+            } catch (error) {
+                assert(true)
+            }
+        }
+
+        @test async "should throw invalid introspection content type response"() {
+            const config: IntrospectionEndpoint = {
+                name: "introspection_endpoint",
+                endpoint: "http://localhost:7777/invalidContent"
+            }
+            this.validator = create(config)
+
+            var req = {
+                headers: {
+                    'authorization': 'Bearer active'
+                },
+                url: "http://test"
+            };
+
+            try {
+                const valid = await this.validator.validate(req as http.IncomingMessage, [], /.*/g)
+                assert(false,"method did not throw")
+            } catch (error) {
+                assert(true)
+            }
+        }
+
+
+    }
+});
+

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -321,7 +321,10 @@ export default class ConsumedThing extends TD.Thing implements WoT.ConsumedThing
                         reject(new Error(`Received invalid content from Thing`));
                     }
                 })
-                    .catch(err => { reject(err); });
+                    .catch(err => { 
+                        console.log();
+                        
+                        reject(err); });
             }
         });
     }

--- a/packages/examples/src/security/oauth/consumer.ts
+++ b/packages/examples/src/security/oauth/consumer.ts
@@ -18,14 +18,15 @@ import { Helpers } from "@node-wot/core";
 let WoT: WoT.WoT;
 let WoTHelpers: Helpers;
 
-WoTHelpers.fetch("http://localhost:8080/OAuth").then(td => {
-    //Call oAuth server instead of the servient.
-    td.actions.sayOk.forms[0].href ="https://localhost:3000/resource"
-    td.actions.sayOk.forms[0]["htv:methodName"] ="GET"
+WoTHelpers.fetch("https://localhost:8080/OAuth").then(td => {
 
     WoT.consume(td).then(async thing => {
-        const result = await thing.invokeAction("sayOk")
-        console.log("oAuth token was",result)
+        try {
+            const result = await thing.invokeAction("sayOk")
+            console.log("oAuth token was", result)   
+        } catch (error) {
+            console.log("It seems that I couldn't access the resource")
+        }
     })
 })
 

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -39,17 +39,14 @@ let td = {
     ],
     "actions": {
         "sayOk": {
-            "forms": [
-                {
-                    "href": "https://localhost:3000/resource",
-                    "htv:methodName": "GET"
-                }
-            ]
+            "description": "A simple action protected with oauth",
+            "idempotent": true
         }
     }
 }
 try {
     WoT.produce(td).then((thing) => {
+        thing.setActionHandler("sayOk",async ()=> "Ok!" )
         thing.expose()
     });
 }

--- a/packages/examples/src/security/oauth/memory-model.js
+++ b/packages/examples/src/security/oauth/memory-model.js
@@ -21,7 +21,7 @@ module.exports =  class InMemoryModel{
      *
      */
     constructor() {
-        this.clients = [{ clientId: 'node-wot', clientSecret: 'isgreat!', redirectUris: [''], grants:["client_credentials","password"] }];
+        this.clients = [{ clientId: 'node-wot', clientSecret: 'isgreat!', redirectUris: [''], grants:["client_credentials","limited"] }];
         this.tokens = [];
         this.users = [{ id: '123', username: 'thomseddon', password: 'nightworld' }];
         

--- a/packages/examples/src/security/oauth/package.json
+++ b/packages/examples/src/security/oauth/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "build": "tsc",
     "server": "node server.js",
-    "start:exposer": "node ../../../../cli/dist/cli.js ../../../dist/security/oauth/exposer.js",
-    "start:consumer": "node ../../../../cli/dist/cli.js -f ./wot-client-servient-conf.json ../../../dist/security/oauth/consumer.js"
+    "start:exposer": "node ../../../../cli/dist/cli.js -f ./wot-server-servient-conf.json ../../../dist/security/oauth/exposer.js",
+    "start:consumer": "node ../../../../cli/dist/cli.js -f ./wot-client-servient-conf.json ../../../dist/security/oauth/consumer.js",
+    "debug:consumer": "node --inspect-brk ../../../../cli/dist/cli.js -f ./wot-client-servient-conf.json ../../../dist/security/oauth/consumer.js"
   },
   "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
   "license": "EPL-2.0 OR W3C-20150513",

--- a/packages/examples/src/security/oauth/server.js
+++ b/packages/examples/src/security/oauth/server.js
@@ -27,16 +27,44 @@ var app = express();
 const model = new Memory()
 
 app.oauth = new OAuthServer({
-    model: model,
-    accessTokenLifetime: 1 
+    model: model
 });
 
 app.use(bodyParser.json());
-app.use("/resource", app.oauth.authenticate());
+app.use("/introspect", bodyParser.urlencoded({ extended: false }));
+app.use("/introspect", (req,res,next)=>{
+    if (req.method !== "POST" || !req.is("application/x-www-form-urlencoded")) {
+        return res.status(400).end()
+    }
+
+    // rewrite body authenticate method is not compliant to https://tools.ietf.org/html/rfc7662
+    const token = req.body.token
+    delete req.body.token
+    req.body.access_token = token
+    console.log("Body changed,")
+    next()
+})
+
+app.use("/introspect", async(req, res, next) => { 
+    return app.oauth.authenticate()(req,res,next)
+    
+    
+});
+app.use("/introspect",(req,res)=>{
+    const token = res.locals.oauth.token
+    console.log("Token was",token? "Ok": "not Ok")
+    res.json({
+        active : !!token,
+        scope: token.client.grants.join(" "),
+        client_id: token.client.clientId
+    }).end()
+})
+
 app.use("/token", bodyParser.urlencoded({ extended: false }));
 app.use("/token", app.oauth.token());
 
 app.use("/resource", (req, res) => {
+    console.log("qui?")
     res.send('Ok!')
 })
 

--- a/packages/examples/src/security/oauth/wot-server-servient-conf.json
+++ b/packages/examples/src/security/oauth/wot-server-servient-conf.json
@@ -1,0 +1,24 @@
+{
+    "servient": {
+    },
+    "http":{
+        "allowSelfSigned": true,
+        "serverKey": "../privatekey.pem",
+        "serverCert": "../certificate.pem",
+        "security": {
+            "scheme": "oauth2",
+            "method": {
+                "name":"introspection_endpoint",
+                "endpoint": "https://localhost:3000/introspect",
+                "allowSelfSigned": true
+            }
+
+        }
+    },
+    "credentials": {
+        "urn:dev:wot:oauth:test": {
+            "clientId" : "node-wot",
+            "clientSecret": "isgreat!"
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces token validation for OAuth tokens in HTTP server implementation. OAuth token validation can be carried out using different methods. This PR uses a standard protocol to request token validation to a `introspection-endpoint`. Specifically, the protocol is defined in [RFC7662](https://tools.ietf.org/html/rfc7662) and it defines how a resource server interacts with the authorization server to validate a token. The protocol is quite flexible but it has some security implications and therefore it is advised to be used with caution. For example, the `introspection-endpoint` must be not visible to other clients or it must be protected using an authentication method (basic or even OAuth again).

This PR is still a draft because I want to complete the OAuth example with also the server-side validation. 