### PR TITLE
fix(http-client): check invoke resource response status

### DIFF
--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -138,6 +138,8 @@ export default class HttpClient implements ProtocolClient {
     console.debug("[binding-http]",`HttpClient received ${result.status} from ${request.url}`);
     console.debug("[binding-http]",`HttpClient received Content-Type: ${result.headers.get("content-type")}`);
     
+    this.checkFetchResponse(result)
+    
     const buffer = await result.buffer()
 
     return { type: result.headers.get("content-type"), body: buffer };


### PR DESCRIPTION
As the title implies, while I was working on #258 example I noticed that the response code of invoke resource request was not validated. This PR adds the validation function before returning the result of the action. 