### PR TITLE
fix: issue 244, avoid logging serialized TD every time

### DIFF
--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -224,7 +224,5 @@ export function serializeTD(thing: Thing): string {
 
   let td: string = JSON.stringify(copy);
 
-  console.debug("[td-tools/td-parser]",`serializeTD() produced\n\`\`\`\n${td}\n\`\`\``);
-
   return td;
 }


### PR DESCRIPTION
Note: causes lots of noise in HTTP observe

caller may still to do logging if required/wanted