### PR TITLE
Optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-alpine3.11
+FROM node:12.16.1-alpine3.11 as BUILD
 
 RUN apk add --no-cache \
 	gcc \
@@ -12,14 +12,30 @@ ARG BUILD_ENV=development
 
 WORKDIR /home/node/app
 
+COPY package*.json ./
+
+RUN npm install
+
 COPY . .
 
-RUN npm install \
-    && npm run build \
-    && if [ "${BUILD_ENV}" = "production" ]; then node_modules/.bin/lerna exec "npm prune --production"; fi \
-    && npm run link
+RUN npm run build  \
+    && if [ "${BUILD_ENV}" = "production" ]; then node_modules/.bin/lerna exec "npm prune --production"; fi 
+
+FROM node:12.16.1-alpine3.11
+
+COPY --from=BUILD  /home/node/app/packages/cli /usr/local/lib/node_modules/@node-wot/cli
+COPY --from=BUILD  /home/node/app/packages/td-tools /usr/local/lib/node_modules/@node-wot/td-tools
+COPY --from=BUILD  /home/node/app/packages/core /usr/local/lib/node_modules/@node-wot/core
+COPY --from=BUILD  /home/node/app/packages/binding-http /usr/local/lib/node_modules/@node-wot/binding-http
+COPY --from=BUILD  /home/node/app/packages/binding-file /usr/local/lib/node_modules/@node-wot/binding-file
+COPY --from=BUILD  /home/node/app/packages/binding-mqtt /usr/local/lib/node_modules/@node-wot/binding-mqtt
+COPY --from=BUILD  /home/node/app/packages/binding-coap /usr/local/lib/node_modules/@node-wot/binding-coap
+COPY --from=BUILD  /home/node/app/packages/binding-websockets /usr/local/lib/node_modules/@node-wot/binding-websockets
+
+
+WORKDIR /usr/local/lib/node_modules/@node-wot/cli
 
 EXPOSE 8080
 
-ENTRYPOINT [ "wot-servient" ]
+ENTRYPOINT [ "node", "dist/cli.js" ]
 CMD [ "-h" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM node:12.16.1-alpine3.11
 
 RUN apk add --no-cache \
 	gcc \
+    g++ \
 	make \
+    linux-headers \
+    udev \
     python2
 
 ARG BUILD_ENV=development


### PR DESCRIPTION
This PR provides two contributions:
1. fixes the docker build file. After #186 docker builds failed due to missing system dependencies. Now it correctly install also g++, linux-headers and udev (serial-port requires them for building).   
2. it reduces the size of the final image from about 650 Mb to 140 Mb. 