### PR TITLE
[binding-http] fix multiple done called in sse tests

### DIFF
--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -33,7 +33,7 @@ import { Buffer } from "buffer";
 import OAuthManager from "./oauth-manager";
 import { parse } from "url";
 import { BasicCredential, Credential, BearerCredential, BasicKeyCredential, OAuthCredential } from "./credential";
-import * as EventSource from 'eventsource';
+import { LongPollingSubscription, SSESubscription, InternalSubscription } from "./subscription-protocols";
 
 export default class HttpClient implements ProtocolClient {
 
@@ -47,9 +47,7 @@ export default class HttpClient implements ProtocolClient {
 
   private credential: Credential = null;
 
-  private activeSubscriptions = new Set();
-
-  private activeEventSources = new Map <string, EventSource>();
+  private activeSubscriptions = new Map<string,InternalSubscription>();
 
   constructor(config: HttpConfig = null, secure = false, oauthManager: OAuthManager = new OAuthManager()) {
 
@@ -149,11 +147,12 @@ export default class HttpClient implements ProtocolClient {
 
   public async unlinkResource(form: HttpForm): Promise<any> {
     console.debug("[binding-http]",`HttpClient (unlinkResource) ${form.href}`);
-
-    this.activeSubscriptions.delete(form.href)
+    const internalSub = this.activeSubscriptions.get(form.href);
     
-    if(this.activeEventSources.has(form.href)){
-      this.activeEventSources.get(form.href).close()
+    if(internalSub){
+      this.activeSubscriptions.get(form.href).close()
+    }else{
+      console.warn("[binding-http]", `HttpClient cannot unlink ${form.href} no subscription found`)
     }
 
     return {};
@@ -161,58 +160,17 @@ export default class HttpClient implements ProtocolClient {
 
   public subscribeResource(form: HttpForm, next: ((value: any) => void), error?: (error: any) => void, complete?: () => void): any {
 
-    this.activeSubscriptions.add(form.href);
+    let internalSubscription;
     if (form.subprotocol == undefined || form.subprotocol == "longpoll") {
       //longpoll or subprotocol is not defined default is longpoll
-      let polling = async () => {
-        try {
-          // long timeout for long polling
-          const request = await this.generateFetchRequest(form, "GET", { timeout: 60 * 60 * 1000 })
-          console.debug("[binding-http]",`HttpClient (subscribeResource) sending ${request.method} to ${request.url}`);
-
-          const result = await this.fetch(request)
-
-          this.checkFetchResponse(result)
-
-          const buffer = await result.buffer()
-          console.debug("[binding-http]",`HttpClient received ${result.status} from ${request.url}`);
-
-          console.debug("[binding-http]",`HttpClient received headers: ${JSON.stringify(result.headers.raw())}`);
-          console.debug("[binding-http]",`HttpClient received Content-Type: ${result.headers.get("content-type")}`);
-
-          if (this.activeSubscriptions.has(form.href)) {
-            next({ type: result.headers.get("content-type"), body: buffer })
-            polling()
-          } {
-            complete && complete()
-          }
-        } catch (e) {
-          error && error(e)
-          complete && complete()
-          this.activeSubscriptions.delete(form.href)
-        }
-      }
-      polling();
+      internalSubscription = new LongPollingSubscription(form,this)
     } else if (form.subprotocol == "sse") {
       //server sent events
-      let _this = this;
-      const eventSource = new EventSource(form.href);
-      this.activeEventSources.set(form.href,eventSource);
-      
-      eventSource.onopen = function (event) {
-        console.info(`HttpClient (subscribeResource) Server-Sent Event connection is opened to ${form.href}`);
-      }
-      eventSource.onmessage = function (event) {
-        console.info(`HttpClient received ${JSON.stringify(event)} from ${form.href}`)
-        let output = { type: form.contentType, body: JSON.stringify(event) };
-        next(output);
-      }
-      eventSource.onerror = function (event) {
-        error(event.toString());
-        complete && complete()
-        _this.activeSubscriptions.delete(form.href)
-      }
+      internalSubscription = new SSESubscription(form)
     }
+
+    internalSubscription.open(next, error, complete);
+    this.activeSubscriptions.set(form.href,internalSubscription);
     return new Subscription(() => { });
   }
 

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -49,6 +49,8 @@ export default class HttpClient implements ProtocolClient {
 
   private activeSubscriptions = new Set();
 
+  private activeEventSources = new Map <string, EventSource>();
+
   constructor(config: HttpConfig = null, secure = false, oauthManager: OAuthManager = new OAuthManager()) {
 
     // config proxy by client side (not from TD)
@@ -149,6 +151,10 @@ export default class HttpClient implements ProtocolClient {
     console.debug("[binding-http]",`HttpClient (unlinkResource) ${form.href}`);
 
     this.activeSubscriptions.delete(form.href)
+    
+    if(this.activeEventSources.has(form.href)){
+      this.activeEventSources.get(form.href).close()
+    }
 
     return {};
   }
@@ -191,6 +197,8 @@ export default class HttpClient implements ProtocolClient {
       //server sent events
       let _this = this;
       const eventSource = new EventSource(form.href);
+      this.activeEventSources.set(form.href,eventSource);
+      
       eventSource.onopen = function (event) {
         console.info(`HttpClient (subscribeResource) Server-Sent Event connection is opened to ${form.href}`);
       }

--- a/packages/binding-http/src/subscription-protocols.ts
+++ b/packages/binding-http/src/subscription-protocols.ts
@@ -1,0 +1,103 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { HttpClient, HttpForm } from "./http";
+import * as EventSource from 'eventsource'
+export interface InternalSubscription {
+    open(next: ((value: any) => void), error?: (error: any) => void, complete?: () => void):void;
+    close():void;
+}
+export class LongPollingSubscription implements InternalSubscription{
+    private form: HttpForm;
+    private client: HttpClient;
+
+    private closed:Boolean;
+    /**
+     *
+     */
+    constructor(form:HttpForm,client:HttpClient) {
+        this.form = form;
+        this.client = client;
+        this.closed = false;
+    }
+
+    open(next: ((value: any) => void), error?: (error: any) => void, complete?: () => void){
+        let polling = async () => {
+            try {
+                // long timeout for long polling
+                const request = await this.client["generateFetchRequest"](this.form, "GET", { timeout: 60 * 60 * 1000 })
+                console.debug("[binding-http]", `HttpClient (subscribeResource) sending ${request.method} to ${request.url}`);
+
+                const result = await this.client["fetch"](request)
+
+                this.client["checkFetchResponse"](result)
+
+                const buffer = await result.buffer()
+                console.debug("[binding-http]", `HttpClient received ${result.status} from ${request.url}`);
+
+                console.debug("[binding-http]", `HttpClient received headers: ${JSON.stringify(result.headers.raw())}`);
+                console.debug("[binding-http]", `HttpClient received Content-Type: ${result.headers.get("content-type")}`);
+
+                if (!closed) {
+                    next({ type: result.headers.get("content-type"), body: buffer })
+                    polling()
+                } {
+                    complete && complete()
+                }
+            } catch (e) {
+                error && error(e)
+                complete && complete()
+            }
+        }
+        polling();
+    }
+
+    close(){
+        this.closed = true;
+    }
+}
+
+export class SSESubscription implements InternalSubscription{
+    private form: HttpForm;
+    private eventSource:EventSource;
+    private closed:Boolean;
+    /**
+     *
+     */
+    constructor(form:HttpForm) {
+        this.form = form;
+        this.closed = false;
+    }
+
+    open(next: ((value: any) => void), error?: (error: any) => void, complete?: () => void){
+        this.eventSource = new EventSource(this.form.href);
+
+        this.eventSource.onopen = (event) => {
+            console.debug("[binding-http]",`HttpClient (subscribeResource) Server-Sent Event connection is opened to ${this.form.href}`);
+        }
+        this.eventSource.onmessage =  (event) => {
+            console.debug("[binding-http]",`HttpClient received ${JSON.stringify(event)} from ${this.form.href}`)
+            let output = { type: this.form.contentType, body: JSON.stringify(event) };
+            next(output);
+        }
+        this.eventSource.onerror = function (event) {
+            error(event.toString());
+            complete && complete()
+        }
+    }
+
+    close(){
+        this.eventSource.close();
+    }
+}

--- a/packages/binding-http/test/http-client-test.ts
+++ b/packages/binding-http/test/http-client-test.ts
@@ -287,8 +287,8 @@ class HttpClientTest {
         };
 
         client.subscribeResource(form, (data) => {
-            done();
-            server.close()
+            client.unlinkResource(form);
+            server.close(done)
         });
     }
 


### PR DESCRIPTION
The problem was caused by the fact that the event connection was never closed. Now the EventSource is correctly closed when `unlinkResource` is called.

The PR is still WIP because I want to add a refactor to keep `http-client` code a little bit clean. But first I want to check that Travis do not fail.  