### PR TITLE
feat: add missing op fields

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -124,6 +124,14 @@ export default class CoapServer implements ProtocolServer {
             } else {
               form.op = ["readproperty", "writeproperty"];
             }
+            if (thing.properties[propertyName].observable) {
+              if(!form.op) {
+                form.op = [];
+              }
+              form.op.push("observeproperty");
+              form.op.push("unobserveproperty");
+            }
+
             thing.properties[propertyName].forms.push(form);
             console.debug("[binding-coap]",`CoapServer on port ${this.getPort()} assigns '${href}' to Property '${propertyName}'`);
           }
@@ -141,7 +149,7 @@ export default class CoapServer implements ProtocolServer {
             let href = base + "/" + this.EVENT_DIR + "/" + encodeURIComponent(eventName);
             let form = new TD.Form(href, type);
             ProtocolHelpers.updateEventFormWithTemplate(form, tdTemplate, eventName);
-            form.op = "subscribeevent";
+            form.op = ["subscribeevent", "unsubscribeevent"];
             thing.events[eventName].forms.push(form);
             console.debug("[binding-coap]",`CoapServer on port ${this.getPort()} assigns '${href}' to Event '${eventName}'`);
           }

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -257,7 +257,7 @@ export default class HttpServer implements ProtocolServer {
             if (thing.properties[propertyName].observable) {
               let href = base + "/" + this.PROPERTY_DIR + "/" + encodeURIComponent(propertyName) + "/" + this.OBSERVABLE_DIR;
               let form = new TD.Form(href, type);
-              form.op = ["observeproperty"];
+              form.op = ["observeproperty", "unobserveproperty"];
               form.subprotocol = "longpoll";
               thing.properties[propertyName].forms.push(form);
               console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to observable Property '${propertyName}'`);
@@ -284,7 +284,7 @@ export default class HttpServer implements ProtocolServer {
             let form = new TD.Form(href, type);
             ProtocolHelpers.updateEventFormWithTemplate(form, tdTemplate, eventName);
             form.subprotocol = "longpoll";
-            form.op = ["subscribeevent"];
+            form.op = ["subscribeevent", "unsubscribeevent"];
             thing.events[eventName].forms.push(form);
             console.debug("[binding-http]",`HttpServer on port ${this.getPort()} assigns '${href}' to Event '${eventName}'`);
           }


### PR DESCRIPTION
add "unsubscribeevent" and "unobserveproperty" for HTTP
add "observeproperty", "unobserveproperty", and "unsubscribeevent" for CoAP