### PR TITLE
Introduce WoT scripts command line args

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,8 @@ const baseDir = ".";
 var clientOnly: boolean = false;
 
 var flagArgConfigfile = false;
+var flagScriptArgs = false;
+var scriptArgs:Array<string> = [];
 var confFile: string;
 
 interface DebugParams {
@@ -69,7 +71,7 @@ const runScripts =async function(servient: DefaultServient, scripts: Array<strin
                     // limit printout to first line
                     console.info("[cli]",`WoT-Servient running script '${data.substr(0, data.indexOf("\n")).replace("\r", "")}'... (${data.split(/\r\n|\r|\n/).length} lines)`);
                     fname = path.resolve(fname)
-                    servient.runPrivilegedScript(data, fname);
+                    servient.runPrivilegedScript(data, fname,{argv:scriptArgs});
                 }
             });
         });
@@ -135,6 +137,15 @@ for( let i = 0; i < argv.length; i++){
         argv.splice(i, 1);
         i--;
 
+    } else if (flagScriptArgs){ 
+        scriptArgs.push(argv[i])
+        argv.splice(i, 1);
+        i--;
+    }else if (argv[i] === "--") {
+        // next args are script args
+        flagScriptArgs = true;
+        argv.splice(i, 1);
+        i--;
     } else if (argv[i].match(/^(-c|--clientonly|\/c)$/i)) {
         clientOnly = true;
         argv.splice(i, 1);
@@ -161,11 +172,12 @@ for( let i = 0; i < argv.length; i++){
         process.exit(0);
 
     } else if (argv[i].match(/^(-h|--help|\/?|\/h)$/i)) {
-        console.log(`Usage: wot-servient [options] [SCRIPT]...
+        console.log(`Usage: wot-servient [options] [SCRIPT]... -- [ARGS]...
        wot-servient
        wot-servient examples/scripts/counter.js examples/scripts/example-event.js
        wot-servient -c counter-client.js
        wot-servient -f ~/mywot.conf.json examples/testthing/testthing.js
+       wot-servient examples/testthing/testthing.js -- script_arg1 script_arg2
 
 Run a WoT Servient in the current directory.
 If no SCRIPT is given, all .js files in the current directory are loaded.

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -59,7 +59,7 @@ export default class Servient {
     }
 
     /** runs the script in privileged context (dangerous) - means here: scripts can require */
-    public runPrivilegedScript(code: string, filename = 'script') {
+    public runPrivilegedScript(code: string, filename = 'script',options:ScriptOptions={}) {
     
         let context = {
             "WoT": new WoTImpl(this),
@@ -70,7 +70,8 @@ export default class Servient {
             sandbox:context,
             require: {
                 external: true
-            }
+            },
+            argv: options.argv
         })
         
         let listener = (err: Error) => {
@@ -269,4 +270,8 @@ export default class Servient {
             process.removeListener("uncaughtException",listener);
         })
     }
+}
+
+export interface ScriptOptions {
+    argv?:Array<string>;
 }


### PR DESCRIPTION
This PR is based on #315 so I put this as a draft until #315 is merged. It closes #275 introducing the ability to pass command-line arguments to WoT Scripts. I choose the same syntax used by npm and other CLIs. Basically, to recognize which arguments should be passed and which argument should be used by the CLIs I used `--` as a separator. For example in the following command line:
```bash
wot-servient -c config.js script1.js script2.js -- -option arg1 arg2
```
`-c`, `config.js`, `script1.js`, and script2.js are interpreted by our CLI package whereas `-option`, `arg1`,and arg2 can be read by **both** script1.js and script2.js.

This means that scripts can have the same argument without conflicts: 
```bash
wot-servient script1.js script2.js -- -c config.js
```
Node-wot cli does not read the config.js file. 