### PR TITLE
[Core] small refactoring with runScript  tests

### DIFF
--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -52,7 +52,7 @@ export default class Servient {
         this.uncaughtListeners.push(listener)
 
         try {
-            vm.run(code, filename)
+            return vm.run(code, filename)
         } catch (err) {
             this.logScriptError(`Servient found error in privileged script '${filename}'`, err)
         }
@@ -83,7 +83,7 @@ export default class Servient {
         this.uncaughtListeners.push(listener)
 
         try {
-            vm.run(code,filename)
+            return vm.run(code,filename)
         } catch (err) {
             this.logScriptError(`Servient found error in privileged script '${filename}'`,err)
         }

--- a/packages/core/test/RuntimeTest.ts
+++ b/packages/core/test/RuntimeTest.ts
@@ -54,6 +54,14 @@ class WoTRuntimeTest {
         this.servient.shutdown();
     }
 
+    @test "should provide cli args"() {
+
+        let envScript = `module.exports = process.argv[0]`;
+
+        const test = WoTRuntimeTest.servient.runPrivilegedScript(envScript, undefined, { argv: ['myArg']})
+        assert.equal(test,'myArg')
+    }
+
     @test "should catch synchronous errors"() {
 
         let failNowScript = `throw new Error("Synchronous error in Servient sandbox");`;


### PR DESCRIPTION
This PR adds missing tests for the new "passing args" feature. I required a small refactor but I think it was necessary and it might be useful in the future to enable a servient/script communication. 