### PR TITLE
[CLI/core] custom compilers

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,9 @@
     "typescript": "3.7.5",
     "typescript-standard": "0.3.36"
   },
+  "optionalDependencies": {
+    "ts-node": "^8.6.2"
+  },
   "dependencies": {
     "@node-wot/core": "0.7.2",
     "@node-wot/binding-coap": "0.7.2",

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import {NodeVM} from "vm2";
+import {NodeVM, CompilerFunction} from "vm2";
 
 import * as WoT from "wot-typescript-definitions";
 
@@ -71,7 +71,8 @@ export default class Servient {
             require: {
                 external: true
             },
-            argv: options.argv
+            argv: options.argv,
+            compiler: options.compiler
         })
         
         let listener = (err: Error) => {
@@ -274,4 +275,5 @@ export default class Servient {
 
 export interface ScriptOptions {
     argv?:Array<string>;
+    compiler?: CompilerFunction;
 }

--- a/packages/core/test/RuntimeTest.ts
+++ b/packages/core/test/RuntimeTest.ts
@@ -62,6 +62,18 @@ class WoTRuntimeTest {
         assert.equal(test,'myArg')
     }
 
+    @test "should use the compiler function"() {
+
+        let envScript = `this is not js`;
+
+        const test = WoTRuntimeTest.servient.runPrivilegedScript(envScript, undefined, { 
+            compiler: ()=>{
+                return "module.exports = 'ok'"
+            }
+        })
+        assert.equal(test,'ok')
+    }
+
     @test "should catch synchronous errors"() {
 
         let failNowScript = `throw new Error("Synchronous error in Servient sandbox");`;


### PR DESCRIPTION
This PR add supports for custom compilers in the Servient runtime. Currently, I tested only `ts-node` but in principle also others might work. I managed to run this simple script inside `node-wot`:
```ts
/// <reference types="../types/wot" />

WoT.produce({}).then( (thing:WoT.ExposedThing) => {
    console.log(thing.getThingDescription().id)
})
```
to run it: `npm i ts-node && wot-servient --compiler ts-node main.ts` 

**Notice**: I used wam typescript project template (i.e. custom type definitions) and I needed to use `/// <reference types="../types/wot" />` (see point 2 below). 


.However, there still a couple of open points:
1. `cli.ts` is getting pretty messy. I think It wasn't originally designed to be a simple interface, now it is evolved in a quite complex command-line tool. Probably it needs a refactor. 
2. typescript examples still not work. The problem is how ts-node handles types (see [here](https://www.npmjs.com/package/ts-node#help-my-types-are-missing)) and how we defined our API type definitions. There still an open issue on the [scripting-api repo](https://github.com/w3c/wot-scripting-api/issues/215) so I did not go ahead and I'll wait until we make a final decision there.
3. if this PR will be merged, PR #240 is obsolete. 