### PR TITLE
improve http PORT env var situation

### DIFF
--- a/packages/binding-http/README.md
+++ b/packages/binding-http/README.md
@@ -160,6 +160,17 @@ The protocol binding can be configured using his constructor or trough servient 
 ```
 When both `serverKey` and `serverCert` are defined the server is started in `https` mode. Examples of `serverKey` and `serverCert` can be found [here](../../examples/security). Moreover, when a security schema is provided the servient must be also configured with valid credentials both client and server side. See [Security](#Security) for further details.
 
+### Environment Variable Overrides
+HttpServer will check the environment variables `WOT_PORT`, then `PORT`.  If either are set, they will override the port the HttpServer will bind to.  
+
+You'll see log entries indicating this:
+
+`[binding-http] HttpServer Port Overridden to 1337 by Environment Variable WOT_PORT`
+
+These are useful on Heroku, Dokku, buildpack deployment, or Docker, etc.
+
+> `WOT_PORT` takes higher precedence than `PORT`
+
 ### HttpProxyConfig
 ```ts
 {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -63,6 +63,16 @@ export default class HttpServer implements ProtocolServer {
     if (config.port !== undefined) {
       this.port = config.port;
     }
+
+    const environmentObj = ['WOT_PORT', 'PORT' ]
+        .map(envVar => { return { key: envVar, value: process.env[envVar] } })
+        .find( envObj => envObj.value != null )
+
+    if ( environmentObj ) {
+      console.info("[binding-http]", `HttpServer Port Overridden to ${environmentObj.value} by Environment Variable ${environmentObj.key}`)
+      this.port = +environmentObj.value
+    }
+
     if (config.address !== undefined) {
       this.address = config.address;
     }
@@ -128,7 +138,7 @@ export default class HttpServer implements ProtocolServer {
         });
         resolve();
       });
-      this.server.listen(+process.env.PORT || this.port, this.address);
+      this.server.listen(this.port, this.address);
     });
   }
 

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -172,4 +172,36 @@ class HttpServerTest {
     await httpServer.stop();
 
   }
+
+  @test async "config.port is overriden by WOT_PORT or PORT"() {
+
+    // Works when none set
+    let httpServer = new HttpServer({ port: 58080 });
+    await httpServer.start(null);
+    expect(httpServer.getPort()).to.eq(58080); // WOT PORT from test
+    await httpServer.stop();
+
+    // Check PORT
+    process.env.PORT='2222'
+    httpServer = new HttpServer({ port: 58080 });
+    await httpServer.start(null);
+    expect(httpServer.getPort()).to.eq(2222); // from PORT
+    await httpServer.stop();
+
+    // CHECK WOT_PORT
+    process.env.PORT=undefined
+    process.env.WOT_PORT='3333'
+    httpServer = new HttpServer({ port: 58080 });
+    await httpServer.start(null);
+    expect(httpServer.getPort()).to.eq(3333); // WOT PORT from test
+    await httpServer.stop();
+
+    // Check WOT_PORT has higher priority than PORT
+    process.env.PORT='2600'
+    process.env.WOT_PORT='1337'
+    httpServer = new HttpServer({ port: 58080 });
+    await httpServer.start(null);
+    expect(httpServer.getPort()).to.eq(1337); // WOT PORT from test
+    await httpServer.stop();
+  }
 }


### PR DESCRIPTION
and when we override with an environment variable, let's actually tell the user!

This is the  PORT side of the issue I raised in  #214   The BaseURI is in #220 
The current implementation silently overrides the port.  This change shows a clear message that it has been overridden.

it also adds an additional environment variable WOT_PORT which will take precedence over PORT if present. This is to allow node-wot implementations that coexist with another web server in the same container, such as nodejs, ruby on rails, nginx/apache for static assets etc.  

Test and documentation included

In #214 I also mentioned running into this, where both servers were trying to bind to the PORT value specified by the heroku build pack.

@danielpeintner I saw your recent env-var PR #319 was merged, so I figured the PORT issue was important to fix.




Signed-off-by: Josh Cohen <joshco@gmail.com>