### PR TITLE
Fix typescript defintions in 0.8.x branch

### DIFF
--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -118,9 +118,9 @@ export default class DefaultServient extends Servient {
     /**
      * start
      */
-    public start(): Promise<WoT.WoT> {
+    public start(): Promise<typeof WoT> {
 
-        return new Promise<WoT.WoT>((resolve, reject) => {
+        return new Promise<typeof WoT>((resolve, reject) => {
             super.start().then((myWoT) => {
                 console.info("[cli/default-servient]","DefaultServient started");
 

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -306,12 +306,12 @@ export default class Servient {
     }
 
     // will return WoT object
-    public start(): Promise<WoT.WoT> {
+    public start(): Promise<typeof WoT> {
         let serverStatus: Array<Promise<void>> = [];
         this.servers.forEach((server) => serverStatus.push(server.start(this)));
         this.clientFactories.forEach((clientFactory) => clientFactory.init());
 
-        return new Promise<WoT.WoT>((resolve, reject) => {
+        return new Promise<typeof WoT>((resolve, reject) => {
             Promise.all(serverStatus)
                 .then(() => {
                     resolve(new WoTImpl(this));

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -24,9 +24,9 @@ import ConsumedThing from "./consumed-thing";
 import Helpers from "./helpers";
 import { ContentSerdes } from "./content-serdes";
 
-export default class WoTImpl implements WoT.WoT {
+export default class WoTImpl {
     private srv: Servient;
-
+    DiscoveryMethod:typeof WoT.DiscoveryMethod;
     constructor(srv: Servient) {
         this.srv = srv;
     }

--- a/packages/examples/src/demo-servients/bridge-cli-servient.ts
+++ b/packages/examples/src/demo-servients/bridge-cli-servient.ts
@@ -81,9 +81,9 @@ export default class BridgeServient extends Servient {
     /**
      * start
      */
-    public start(): Promise<WoT.WoT> {
+    public start(): Promise<typeof WoT> {
 
-        return new Promise<WoT.WoT>((resolve, reject) => {
+        return new Promise<typeof WoT>((resolve, reject) => {
             super.start().then((myWoT) => {
                 console.info("BridgeServient started");
 

--- a/packages/examples/src/proxy-scripts/festo-fake.ts
+++ b/packages/examples/src/proxy-scripts/festo-fake.ts
@@ -1,6 +1,4 @@
-import "wot-typescript-definitions"
 
-let WoT:WoT.WoT;
 
 WoT.produce({
   title: "FestoFake",

--- a/packages/examples/src/proxy-scripts/festo-live.ts
+++ b/packages/examples/src/proxy-scripts/festo-live.ts
@@ -1,7 +1,5 @@
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
 
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 console.debug = () =>  {};

--- a/packages/examples/src/scripts/cf-sandbox-client.ts
+++ b/packages/examples/src/scripts/cf-sandbox-client.ts
@@ -13,10 +13,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
 
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
  /**

--- a/packages/examples/src/scripts/cf-secure-client.ts
+++ b/packages/examples/src/scripts/cf-secure-client.ts
@@ -13,10 +13,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
 
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
  /**

--- a/packages/examples/src/scripts/coffee-machine-client.ts
+++ b/packages/examples/src/scripts/coffee-machine-client.ts
@@ -19,8 +19,6 @@
 
 import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core"
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 WoTHelpers.fetch("http://127.0.0.1:8080/Smart-Coffee-Machine").then(async (td) => {

--- a/packages/examples/src/scripts/coffee-machine-oauth.ts
+++ b/packages/examples/src/scripts/coffee-machine-oauth.ts
@@ -16,11 +16,7 @@
 // This is an example of Web of Things producer ("server" mode) Thing script.
 // It considers a fictional smart coffee machine in order to demonstrate the capabilities of Web of Things.
 // An accompanying tutorial is available at http://www.thingweb.io/smart-coffee-machine.html.
-
-import 'wot-typescript-definitions'
 import { Helpers } from '@node-wot/core';
-
-let WoT:WoT.WoT;
 
 WoT.produce({
     title: 'Smart-Coffee-Machine',

--- a/packages/examples/src/scripts/coffee-machine.ts
+++ b/packages/examples/src/scripts/coffee-machine.ts
@@ -17,10 +17,7 @@
 // It considers a fictional smart coffee machine in order to demonstrate the capabilities of Web of Things.
 // An accompanying tutorial is available at http://www.thingweb.io/smart-coffee-machine.html.
 
-import 'wot-typescript-definitions'
 import { Helpers } from "@node-wot/core"
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 WoT.produce({

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -13,10 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {

--- a/packages/examples/src/scripts/counter.ts
+++ b/packages/examples/src/scripts/counter.ts
@@ -13,10 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 // This is an example Thing script. 

--- a/packages/examples/src/scripts/example-event-client.ts
+++ b/packages/examples/src/scripts/example-event-client.ts
@@ -13,10 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 WoTHelpers.fetch("http://localhost:8080/EventSource").then( async (td) => {

--- a/packages/examples/src/scripts/example-event.ts
+++ b/packages/examples/src/scripts/example-event.ts
@@ -13,10 +13,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
-
-let WoT:WoT.WoT;
-
 try {
   // internal state, not exposed as Property
   let counter = 0;

--- a/packages/examples/src/scripts/lwm2m-client.ts
+++ b/packages/examples/src/scripts/lwm2m-client.ts
@@ -13,10 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 console.info("Ensure https://leshan.eclipse.org/#/security has the Client Endpoint 'node-wot-test' with Identity 'node-wot' and Key '68656c6c6f'");

--- a/packages/examples/src/scripts/mqtt-publish.ts
+++ b/packages/examples/src/scripts/mqtt-publish.ts
@@ -13,9 +13,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
-
-let WoT:WoT.WoT;
 
 var counter  = 0;
 

--- a/packages/examples/src/scripts/mqtt-subscribe.ts
+++ b/packages/examples/src/scripts/mqtt-subscribe.ts
@@ -12,11 +12,7 @@
  * 
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 let td = 

--- a/packages/examples/src/security/oauth/consumer.ts
+++ b/packages/examples/src/security/oauth/consumer.ts
@@ -12,10 +12,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
 
-let WoT: WoT.WoT;
 let WoTHelpers: Helpers;
 
 WoTHelpers.fetch("https://localhost:8080/OAuth").then(td => {

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -12,11 +12,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import "wot-typescript-definitions"
-import { Helpers } from "@node-wot/core";
-
-let WoT: WoT.WoT;
-let WoTHelpers: Helpers;
 
 let td = {
     "@context": "https://www.w3.org/2019/wot/td/v1",

--- a/packages/examples/src/testthing/testclient.ts
+++ b/packages/examples/src/testthing/testclient.ts
@@ -13,10 +13,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import "wot-typescript-definitions"
-import { Helpers } from "@node-wot/core";
 
-let WoT:WoT.WoT;
+import { Helpers } from "@node-wot/core";
 let WoTHelpers: Helpers;
 
 console.log = () => {};

--- a/packages/examples/src/testthing/testthing.ts
+++ b/packages/examples/src/testthing/testthing.ts
@@ -12,11 +12,7 @@
  * 
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
-import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
-
-let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
 
 function checkPropertyWrite(expected: any, actual: any) {


### PR DESCRIPTION
This PR fixes the errors provided by the new typescript definition file of the Scripting API. Notice that now classes cannot implement directly `WoT` type since it is a namespace.  This PR works around the issue using `typeof WoT` when returning an object that should implement the functions defined inside the `WoT` namespace. 