### PR TITLE
Fix WoT scripts cannot require builtin modules

### DIFF
--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -69,7 +69,8 @@ export default class Servient {
         const vm = new NodeVM({
             sandbox:context,
             require: {
-                external: true
+                external: true,
+                builtin: ["*"]
             },
             argv: options.argv,
             compiler: options.compiler,

--- a/packages/core/test/RuntimeTest.ts
+++ b/packages/core/test/RuntimeTest.ts
@@ -90,6 +90,14 @@ class WoTRuntimeTest {
         assert.equal(test, undefined)
     }
 
+    @test "should require node builtin module"() {
+        const fs = require("fs")
+        let envScript = `module.exports = require("fs")`;
+
+        const test = WoTRuntimeTest.servient.runPrivilegedScript(envScript)
+        assert.equal(test, fs)
+    }
+
     @test "should catch synchronous errors"() {
 
         let failNowScript = `throw new Error("Synchronous error in Servient sandbox");`;


### PR DESCRIPTION
In #315 we updated node-wot to use [vm2](https://www.npmjs.com/package/vm2) module. Since [vm2](https://www.npmjs.com/package/vm2) is more restrictive, it needs to be manually set to support builtin modules require. 