### PR TITLE
fix: fix longpoll client

### DIFF
--- a/packages/binding-http/src/subscription-protocols.ts
+++ b/packages/binding-http/src/subscription-protocols.ts
@@ -49,7 +49,7 @@ export class LongPollingSubscription implements InternalSubscription{
                 console.debug("[binding-http]", `HttpClient received headers: ${JSON.stringify(result.headers.raw())}`);
                 console.debug("[binding-http]", `HttpClient received Content-Type: ${result.headers.get("content-type")}`);
 
-                if (!closed) {
+                if (!this.closed) {
                     next({ type: result.headers.get("content-type"), body: buffer })
                     polling()
                 } {


### PR DESCRIPTION
The longpoll client doesn't work giving an `UnhandledPromiseRejectionWarning: ReferenceError: closed is not defined` exception.
This PR fixes the error.

Signed-off-by: fatadel <fatadel@gmail.com>