### PR TITLE
Fix netconf tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 os:
   - linux
   - osx
+  - windows
 node_js:
   - "node"
   - "10"

--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -37,8 +37,12 @@ import * as xpath2json from '../src/xpath2json';
 
 describe('outer describe', function () {
 
+    this.timeout(10000);
+    let client: NetconfClient;
 
-    let client: NetconfClient = new NetconfClient();
+    before(() => {
+        client = new NetconfClient();
+    });
 
     it("should apply security", async function () {
         let metadata = [{ scheme: 'nosec' }];


### PR DESCRIPTION
This PR fixes `netconf` tests that failed on my windows machine. It was basically just a time issue. The tests are verifying the correct behavior when the `netconf` server is not online. In my windows version, the operating systems give up just after 2000 ms which is the default mocha time out. Increasing the timeout solved the issue.  

As you can see from the commit logs the PR also adds windows as a testing platform in travis. I thought it might worth it since now it seems that all the tests are green. 