### PR TITLE
#363 Fix: Use udp6 for IPv6 and udp4 for legacy IP

### DIFF
--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -28,8 +28,8 @@
     "wot-typescript-definitions": "0.7.3",
     "@node-wot/core": "0.7.5",
     "rxjs": "5.5.11",
-    "coap": "0.23.1",
-    "node-coap-client": "1.0.2",
+    "coap": "0.24.0",
+    "node-coap-client": "1.0.8",
     "slugify": "^1.4.5"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #363.
Bump versions for packages `node-coap-client` and `coap`. 
`node-coap-client` had an [similar issue with IPv6](https://github.com/AlCalzone/node-coap-client/issues/253). This bump should avoid it in the coaps implementation. 

Not a very nice implementation btw, but it doesn't change the API too much. It keeps everything quite stable. 

**Please test with IPv4. Only tested it with coap on IPv6.**