### PR TITLE
fix: Remove leading "/" from MQTT topics

### DIFF
--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -96,14 +96,14 @@ export default class MqttBrokerServer implements ProtocolServer {
       }
     }
 
-    console.debug("[binding-mqtt]",`MqttBrokerServer at ${this.brokerURI} exposes '${thing.title}' as unique '/${name}/*'`);
+    console.debug("[binding-mqtt]",`MqttBrokerServer at ${this.brokerURI} exposes '${thing.title}' as unique '${name}/*'`);
     return new Promise<void>((resolve, reject) => {
 
       // TODO clean-up on destroy and stop
       this.things.set(name, thing);
 
       for (let propertyName in thing.properties) {
-        let topic = "/" + encodeURIComponent(name) + "/properties/" + encodeURIComponent(propertyName);
+        let topic = encodeURIComponent(name) + "/properties/" + encodeURIComponent(propertyName);
         let property = thing.properties[propertyName];
 
         if(!property.writeOnly ){
@@ -124,7 +124,7 @@ export default class MqttBrokerServer implements ProtocolServer {
             }
           );
 
-          let href = this.brokerURI + topic;
+          let href = this.brokerURI + "/" + topic;
           let form = new TD.Form(href, ContentSerdes.DEFAULT);
           form.op = ["readproperty","observeproperty", "unobserveproperty"];
           thing.properties[propertyName].forms.push(form);
@@ -133,7 +133,7 @@ export default class MqttBrokerServer implements ProtocolServer {
         }
         if(!property.readOnly){
 
-          let href = this.brokerURI + topic +"/writeproperty";
+          let href = this.brokerURI + "/" + topic +"/writeproperty";
           this.broker.subscribe(topic + "/writeproperty");
           let form = new TD.Form(href, ContentSerdes.DEFAULT);
           form.op = ["writeproperty"];
@@ -144,10 +144,10 @@ export default class MqttBrokerServer implements ProtocolServer {
       }
 
       for (let actionName in thing.actions) {
-        let topic = "/" + encodeURIComponent(name) + "/actions/" + encodeURIComponent(actionName);
+        let topic = encodeURIComponent(name) + "/actions/" + encodeURIComponent(actionName);
         this.broker.subscribe(topic);
 
-        let href = this.brokerURI + topic;
+        let href = this.brokerURI + "/" + topic;
         let form = new TD.Form(href, ContentSerdes.DEFAULT);
         form.op = ["invokeaction"];
         thing.actions[actionName].forms.push(form);
@@ -238,7 +238,7 @@ export default class MqttBrokerServer implements ProtocolServer {
       });
 
       for (let eventName in thing.events) {
-        let topic = "/" + encodeURIComponent(name) + "/events/" + encodeURIComponent(eventName);
+        let topic = encodeURIComponent(name) + "/events/" + encodeURIComponent(eventName);
         let event = thing.events[eventName];
 
         thing.subscribeEvent(eventName,
@@ -261,13 +261,13 @@ export default class MqttBrokerServer implements ProtocolServer {
           }
         );
 
-        let href = this.brokerURI + topic;
+        let href = this.brokerURI + "/" + topic;
         let form = new TD.Form(href, ContentSerdes.DEFAULT);
         form.op = ["subscribeevent", "unsubscribeevent"];
         event.forms.push(form);
         console.debug("[binding-mqtt]",`MqttBrokerServer at ${this.brokerURI} assigns '${href}' to Event '${eventName}'`);
       }
-      this.broker.publish("/"+name, JSON.stringify(thing.getThingDescription()),{retain:true,contentType:"application/td+json"});
+      this.broker.publish(name, JSON.stringify(thing.getThingDescription()),{retain:true,contentType:"application/td+json"});
       resolve();
     });
   }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -41,7 +41,7 @@ export default class MqttClient implements ProtocolClient {
         let retain = form["mqtt:retain"]; // TODO: is this needed here?
         let qos = form["mqtt:qos"]; // TODO: is this needed here?
         let requestUri = url.parse(form['href']);
-        let topic = requestUri.pathname;
+        let topic = requestUri.pathname.slice(1);
         let brokerUri : String = "mqtt://"+requestUri.host;
 
         if(this.client==undefined) {
@@ -87,7 +87,7 @@ export default class MqttClient implements ProtocolClient {
 
 
             let requestUri = url.parse(form['href']);
-            let topic = requestUri.pathname;
+            let topic = requestUri.pathname.slice(1);
             let brokerUri : String = "mqtt://"+requestUri.host;
             
             if(this.client==undefined) {
@@ -109,7 +109,7 @@ export default class MqttClient implements ProtocolClient {
 
     unlinkResource = (form: TD.Form): Promise<void> => {
         let requestUri = url.parse(form['href']);
-        let topic = requestUri.pathname;
+        let topic = requestUri.pathname.slice(1);
 
         return new Promise<void>((resolve, reject) => {
             if(this.client && this.client.connected) {

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
@@ -17,7 +17,6 @@
  * Protocol test suite to test protocol implementations
  */
 
-
 import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
 import { expect, should, assert } from "chai";
 // should must be called to augment all variables
@@ -28,66 +27,70 @@ import { Servient, ExposedThing } from "@node-wot/core";
 import MqttBrokerServer from "../dist/mqtt-broker-server";
 import MqttClientFactory from "../dist/mqtt-client-factory";
 
-
-
-
-
 @suite("MQTT implementation")
 class MqttClientSubscribeTest {
 
-    @test.skip "should expose via broker"(done: Function) {
+    @test(timeout(5000)) "should expose via broker"(done: Function) {
 
         try {
-
             let servient = new Servient();
+            var brokerAddress = "test.mosquitto.org"
+            var brokerPort = 1883
+            var brokerUri = `mqtt://${brokerAddress}:${brokerPort}`
 
-            let brokerServer = new MqttBrokerServer("mqtt://test.mosquitto.org:1883");
+            let brokerServer = new MqttBrokerServer(brokerUri);
             servient.addServer(brokerServer);
-            
+
             servient.addClientFactory(new MqttClientFactory());
 
             var counter = 0;
 
-            servient.start().then( (WoT) => {
+            servient.start().then((WoT) => {
+                expect(brokerServer.getPort()).to.equal(brokerPort);
+                expect(brokerServer.getAddress()).to.equal(brokerAddress);
 
-                expect(brokerServer.getPort()).to.equal(1883);
-                expect(brokerServer.getAddress()).to.equal("test.mosquitto.org");
+                var eventNumber = Math.floor(Math.random() * 1000000); 
+                var eventName : string = "event" + eventNumber;
+                var events : {[key: string] : any} = {};
+                events[eventName] = { type: "number" };
 
-                WoT.produce({ title: "TestWoTMQTT" })
-                    .then((thing) => {
-                        if(thing instanceof ExposedThing) {
-                            let exposedThing : ExposedThing = thing;
-                            thing.addEvent("event1", { type: "number" });
+                WoT.produce({
+                    title: "TestWoTMQTT",
+                    events: events,
+                }).then((thing) => {
+                    thing.expose().then(() => {
+                        console.info(
+                            "Exposed",
+                            thing.getThingDescription().title
+                        );
 
-                            thing.expose();
-    
-                            console.info("Exposed", thing.title);
-    
-                            WoT.consume(thing.getTD())
-                                .then((client) => {
-                                    let check = 0;
-                                    client.subscribeEvent("event1",
-                                        (x) => {
-                                            expect(x).to.equal(++check);
-                                            if (check === 3) done();
+                        WoT.consume(thing.getThingDescription()).then(
+                            (client) => {
+                                let check = 0;
+                                client
+                                    .subscribeEvent(eventName, (x) => {
+                                        expect(x).to.equal(++check);
+                                        if (check === 3) {
+                                            done();
                                         }
-                                    )
-                                    .then(() => { })
-                                    .catch((e) => { expect(true).to.equal(false); });
-            
-                                    var job = setInterval(() => {
-                                        ++counter;
-                                        thing.events.event1.emit(counter); // sends data to the topic /TestWoTMQTT/events/event1
-            
-                                        if (counter === 3) clearInterval(job);
-                                    }, 100);
-                                });
-                        } else {
-                            throw("no ExposedThing");
-                        }
-                    });
-            });
+                                    })
+                                    .then(() => {})
+                                    .catch((e) => {
+                                        expect(true).to.equal(false);
+                                    });
 
+                                var job = setInterval(() => {
+                                    ++counter;
+                                    thing.emitEvent(eventName, counter);
+                                    if (counter === 3) {
+                                        clearInterval(job);
+                                    }
+                                }, 400);
+                            }
+                        );
+                    });
+                });
+            });
         } catch (err) {
             console.error("ERROR", err);
         }


### PR DESCRIPTION
This PR is a very simple fix/workaround for #255: The leading `/` that is currently derived from the URI path is being removed. As most MQTT topics should not feature a leading `/` (among other things, because it is not best practice to so, see #255) this fix should not cause much harm while making it possible to actually use `node-wot` with the majority of MQTT devices.