### PR TITLE
fix: sync counter.ts with counter.js

### DIFF
--- a/packages/examples/src/scripts/counter.ts
+++ b/packages/examples/src/scripts/counter.ts
@@ -187,7 +187,7 @@ WoT.produce({
 			lastChange = (new Date()).toISOString();
 			thing.emitEvent("change", count);
 		});
-		thing.setActionHandler("decrement", async (params, options) => {
+		thing.setActionHandler("reset", async (params, options) => {
 			console.log("Resetting count");
 			count = 0;
 			lastChange = (new Date()).toISOString();


### PR DESCRIPTION
According to #171 and `packages/examples/README.md`, PR #413 should also fix the typescript counterpart of counter.js

Signed-off-by: Iori Mizutani <iori.mizutani@gmail.com>