### PR TITLE
fix: examples/scripts/counter-client.js formIndex

### DIFF
--- a/examples/scripts/counter-client.js
+++ b/examples/scripts/counter-client.js
@@ -43,13 +43,12 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
 }).catch((err) => { console.error("Fetch error:", err); });
 
 function getFormIndexForDecrementWithCoAP(thing) {
-    // return formIndex: 0 if no CoAP target IRI found
-    let fi = 0;
     thing.getThingDescription()['actions']['decrement']['forms']
         .forEach((form, index) => {
         if (/^coaps?:\/\/.*/.test(form.href)) {
-            fi = index;
+            return index;
         }
     });
-    return fi;
+    // return formIndex: 0 if no CoAP target IRI found
+    return 0;
 }

--- a/examples/scripts/counter-client.js
+++ b/examples/scripts/counter-client.js
@@ -43,12 +43,12 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
 }).catch((err) => { console.error("Fetch error:", err); });
 
 function getFormIndexForDecrementWithCoAP(thing) {
-    thing.getThingDescription()['actions']['decrement']['forms']
-        .forEach((form, index) => {
-        if (/^coaps?:\/\/.*/.test(form.href)) {
-            return index;
+    let forms = thing.getThingDescription()['actions']['decrement']['forms'];
+    for (let i = 0; i < forms.length; i++) {
+        if (/^coaps?:\/\/.*/.test(forms[i].href)) {
+            return i;
         }
-    });
+    }
     // return formIndex: 0 if no CoAP target IRI found
     return 0;
 }

--- a/examples/scripts/counter-client.js
+++ b/examples/scripts/counter-client.js
@@ -12,7 +12,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
 WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
     // using await for serial execution (note 'async' in then() of fetch())
     try {
@@ -31,8 +30,16 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
         await thing.invokeAction("increment", undefined, { uriVariables: { 'step': 3 } });
         let inc2 = await thing.readProperty("count");
         console.info("count value after increment #2 (with step 3) is", inc2);
-        // decrement property with formIndex == 1 (via CoAP binding)
-        await thing.invokeAction("decrement", undefined, { formIndex: 1 });
+        // look for the first form for decrement with CoAP binding
+        // formIndex: 0 if not found
+        let fi = 0;
+        thing.getThingDescription()['actions']['decrement']['forms']
+            .forEach((form, index) => {
+            if (/^coaps?:\/\/.*/.test(form.href)) {
+                fi = index;
+            }
+        });
+        await thing.invokeAction("decrement", undefined, { formIndex: fi });
         let dec1 = await thing.readProperty("count");
         console.info("count value after decrement is", dec1);
     }

--- a/examples/scripts/counter-client.js
+++ b/examples/scripts/counter-client.js
@@ -31,8 +31,8 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
         await thing.invokeAction("increment", undefined, { uriVariables: { 'step': 3 } });
         let inc2 = await thing.readProperty("count");
         console.info("count value after increment #2 (with step 3) is", inc2);
-        // decrement property with formIndex == 2
-        await thing.invokeAction("decrement", undefined, { formIndex: 2 });
+        // decrement property with formIndex == 1 (via CoAP binding)
+        await thing.invokeAction("decrement", undefined, { formIndex: 1 });
         let dec1 = await thing.readProperty("count");
         console.info("count value after decrement is", dec1);
     }

--- a/examples/scripts/counter-client.js
+++ b/examples/scripts/counter-client.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -31,15 +31,9 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
         let inc2 = await thing.readProperty("count");
         console.info("count value after increment #2 (with step 3) is", inc2);
         // look for the first form for decrement with CoAP binding
-        // formIndex: 0 if not found
-        let fi = 0;
-        thing.getThingDescription()['actions']['decrement']['forms']
-            .forEach((form, index) => {
-            if (/^coaps?:\/\/.*/.test(form.href)) {
-                fi = index;
-            }
+        await thing.invokeAction("decrement", undefined, {
+            formIndex: getFormIndexForDecrementWithCoAP(thing)
         });
-        await thing.invokeAction("decrement", undefined, { formIndex: fi });
         let dec1 = await thing.readProperty("count");
         console.info("count value after decrement is", dec1);
     }
@@ -47,3 +41,15 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then(async (td) => {
         console.error("Script error:", err);
     }
 }).catch((err) => { console.error("Fetch error:", err); });
+
+function getFormIndexForDecrementWithCoAP(thing) {
+    // return formIndex: 0 if no CoAP target IRI found
+    let fi = 0;
+    thing.getThingDescription()['actions']['decrement']['forms']
+        .forEach((form, index) => {
+        if (/^coaps?:\/\/.*/.test(form.href)) {
+            fi = index;
+        }
+    });
+    return fi;
+}

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2021 Contributors to the Eclipse Foundation
  * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,15 +43,9 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
 		console.info("count value after increment #2 (with step 3) is", inc2);
 		
 		// look for the first form for decrement with CoAP binding
-		// formIndex: 0 if not found
-		let fi = 0
-		thing.getThingDescription()['actions']['decrement']['forms']
-			.forEach((form: TD.Form, index: number) => {
-				if (/^coaps?:\/\/.*/.test(form.href)) {
-					fi = index;
-				}
-			});
-		await thing.invokeAction("decrement", undefined, { formIndex: fi });
+		await thing.invokeAction("decrement", undefined, {
+			formIndex: getFormIndexForDecrementWithCoAP(thing)
+		});
 		let dec1 = await thing.readProperty("count");
 		console.info("count value after decrement is", dec1);
 	} catch(err) {
@@ -59,3 +53,15 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
     }
 
 }).catch( (err) => { console.error("Fetch error:", err); });
+
+function getFormIndexForDecrementWithCoAP(thing: WoT.ConsumedThing): number {
+	// return formIndex: 0 if no CoAP target IRI found
+	let fi = 0;
+	thing.getThingDescription()['actions']['decrement']['forms']
+		.forEach((form: TD.Form, index: number) => {
+			if (/^coaps?:\/\/.*/.test(form.href)) {
+				fi = index;
+			}
+		});
+	return fi;
+}

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -15,6 +15,7 @@
 
 import "wot-typescript-definitions"
 import { Helpers } from "@node-wot/core";
+import * as TD from "@node-wot/td-tools";
 
 let WoT:WoT.WoT;
 let WoTHelpers: Helpers;
@@ -40,9 +41,17 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
 		await thing.invokeAction("increment", undefined, {uriVariables: {'step' : 3}});
 		let inc2 = await thing.readProperty("count");
 		console.info("count value after increment #2 (with step 3) is", inc2);
-				
-		// decrement property with formIndex == 1 (via CoAP binding)
-		await thing.invokeAction("decrement", undefined, { formIndex: 1 });
+		
+		// look for the first form for decrement with CoAP binding
+		// formIndex: 0 if not found
+		let fi = 0
+		thing.getThingDescription()['actions']['decrement']['forms']
+			.forEach((form: TD.Form, index: number) => {
+				if (/^coaps?:\/\/.*/.test(form.href)) {
+					fi = index;
+				}
+			});
+		await thing.invokeAction("decrement", undefined, { formIndex: fi });
 		let dec1 = await thing.readProperty("count");
 		console.info("count value after decrement is", dec1);
 	} catch(err) {

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -55,13 +55,12 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
 }).catch( (err) => { console.error("Fetch error:", err); });
 
 function getFormIndexForDecrementWithCoAP(thing: WoT.ConsumedThing): number {
-	// return formIndex: 0 if no CoAP target IRI found
-	let fi = 0;
 	thing.getThingDescription()['actions']['decrement']['forms']
 		.forEach((form: TD.Form, index: number) => {
 			if (/^coaps?:\/\/.*/.test(form.href)) {
-				fi = index;
+				return index;
 			}
 		});
-	return fi;
+	// return formIndex: 0 if no CoAP target IRI found
+	return 0;
 }

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -55,12 +55,12 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
 }).catch( (err) => { console.error("Fetch error:", err); });
 
 function getFormIndexForDecrementWithCoAP(thing: WoT.ConsumedThing): number {
-	thing.getThingDescription()['actions']['decrement']['forms']
-		.forEach((form: TD.Form, index: number) => {
-			if (/^coaps?:\/\/.*/.test(form.href)) {
-				return index;
-			}
-		});
+	let forms = thing.getThingDescription()['actions']['decrement']['forms'];
+	for(let i = 0; i < forms.length; i++) {
+		if (/^coaps?:\/\/.*/.test(forms[i].href)) {
+			return i;
+		}
+	}
 	// return formIndex: 0 if no CoAP target IRI found
 	return 0;
 }

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -41,8 +41,8 @@ WoTHelpers.fetch("coap://localhost:5683/counter").then( async (td) => {
 		let inc2 = await thing.readProperty("count");
 		console.info("count value after increment #2 (with step 3) is", inc2);
 				
-		// decrement property with formIndex == 2
-		await thing.invokeAction("decrement", undefined, { formIndex: 2 });
+		// decrement property with formIndex == 1 (via CoAP binding)
+		await thing.invokeAction("decrement", undefined, { formIndex: 1 });
 		let dec1 = await thing.readProperty("count");
 		console.info("count value after decrement is", dec1);
 	} catch(err) {


### PR DESCRIPTION
When I run the example for the counter thing and its consumer `examples/scripts/counter-client.js` I get the error `ConsumedThing 'counter' missing formIndex '2'`:
```
vagrant@ubuntu-focal:/vagrant/thingweb.node-wot$ node packages/cli/dist/cli.js examples/scripts/counter-client.js -
-clientonly
[cli] WoT-Servient using defaults as 'wot-servient.conf.json' does not exist
{
  servient: { clientOnly: true, scriptAction: false },
  http: { port: 8080, selfSigned: false },
  coap: { port: 5683 },
  log: { level: 'info' }
}
[cli/default-servient] DefaultServient started
[core/servient] Servient generating ID for 'servient': 'urn:uuid:8b2cc2c6-2354-49b2-8b1c-fee5f9fd1351'
[core/servient] Servient has no servers to expose Things
[cli] WoT-Servient loading 1 command line script
[cli] WoT-Servient reading script examples/scripts/counter-client.js
[cli] WoT-Servient running script '/********************************************************************************'... (43 lines)
=== TD ===
{
...
}
==========
count value is 0
count value after increment #1 is 1
count value after increment #2 (with step 3) is 4
Script error: Error: ConsumedThing 'counter' missing formIndex '2'
    at Object.ConsumedThing.getClientFor (/vagrant/thingweb.node-wot/packages/core/dist/consumed-thing.js:139:23)
    at /vagrant/thingweb.node-wot/packages/core/dist/consumed-thing.js:288:32
    at new Promise (<anonymous>)
    at Object.ConsumedThing.invokeAction (/vagrant/thingweb.node-wot/packages/core/dist/consumed-thing.js:282:16)
    at Object.base.apply (/vagrant/thingweb.node-wot/packages/core/node_modules/vm2/lib/contextify.js:620:32)
    at /vagrant/thingweb.node-wot/examples/scripts/counter-client.js:35:21
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

It seems the client is invoking the "decrement" action with `formIndex` _InteractionOption_ as part of #228 but I suppose the corresponding form should be the one with CoAP (which is at the index 1), so the correct value should be 1 instead.

cf. in my environment the `forms` was:
```
[
  {
    href: 'http://10.0.2.15:8080/counter/actions/decrement{?step}',
    contentType: 'application/json',
    op: [ 'invokeaction' ],
    'htv:methodName': 'POST'
  },
  {
    href: 'coap://10.0.2.15:5683/counter/actions/decrement',
    contentType: 'application/json',
    op: 'invokeaction'
  }
]
```