### PR TITLE
docs: Docker example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ COPY --from=BUILD  /home/node/app/packages/binding-websockets /usr/local/lib/nod
 
 WORKDIR /usr/local/lib/node_modules/@node-wot/cli
 
-EXPOSE 8080
+EXPOSE 8080/tcp
+EXPOSE 5683/udp
+
+STOPSIGNAL SIGINT
 
 ENTRYPOINT [ "node", "dist/cli.js" ]
 CMD [ "-h" ]

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Useful labels:
 - [How to get the library](#how-to-get-the-library)
   * [As a Node.js dependency](#as-a-nodejs-dependency)
   * [As a standalone application](#as-a-standalone-application)
+  * [As a Docker image](#as-a-docker-image)
   * [As a browser library](#as-a-browser-library)
 - [No time for explanations - show me a running example!](#no-time-for-explanations---show-me-a-running-example)
   * [Using Node.js](#using-nodejs)
+  * [Using Docker](#using-docker)
   * [Using a browser](#using-a-browser)
 - [How to use the library](#how-to-use-the-library)
   * [The API](#the-api)
@@ -295,6 +297,27 @@ To reduce the size of the installation from about 800 MByte down to about 200 MB
 * Build error around `prebuild: npm run bootstrap`
    * This has been seen failing on WSL.  Try using Node 12.13.0
 
+### As a Docker image
+
+Alternatively, Node-wot can be built as a Docker image with the `Dockerfile`.
+
+Clone the repository:
+```
+git clone https://github.com/eclipse/thingweb.node-wot
+```
+Go into the repository:
+```
+cd thingweb.node-wot
+```
+Build the Docker image named `wot-servient` from the `Dockerfile`:
+```
+docker build --rm -t wot-servient .
+```
+Run the wot-servient as a container:
+```
+docker run --rm wot-servient -h
+```
+
 ### As a browser library
 
 Node-wot can also be imported as browser-side library. To do so, include the following `script` tag in your html:
@@ -331,6 +354,19 @@ node packages\cli\dist\cli.js --clientonly examples\scripts\counter-client.js
 * Query the count by http://localhost:8080/counter/properties/count
 * Modify the count via POST on http://localhost:8080/counter/actions/increment and http://localhost:8080/counter/actions/decrement
 * Application logic is in `examples/scripts/counter.js`
+
+### Using Docker
+First [build the docker image](#as-a-docker-image) and then run the counter example:
+```
+# expose
+docker run -it --init -p 8080:8080/tcp -p 5683:5683/udp -v "$(pwd)"/examples:/srv/examples --rm wot-servient /srv/examples/scripts/counter.js
+# consume
+docker run -it --init -v "$(pwd)"/examples:/srv/examples --rm --net=host wot-servient /srv/examples/scripts/counter-client.js --clientonly
+```
+
+* The counter exposes the HTTP endpoint at 8080/tcp and the CoAP endpoint at 5683/udp and they are bound to the host machine (with `-p 8080:8080/tcp -p 5683:5683/udp`).
+* The counter-client binds the network of the host machine (`--net=host`) so that it can access the counter thing's endpoints.
+* `--init` allows the containers to be killed with SIGINT (e.g., Ctrl+c)
 
 ### Using a browser
 An example of how to use node-wot as a browser-side library can be found under `examples/browser/index.html`.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ To reduce the size of the installation from about 800 MByte down to about 200 MB
 
 ### As a Docker image
 
-Alternatively, Node-wot can be built as a Docker image with the `Dockerfile`.
+Alternatively, node-wot can be built as a Docker image with the `Dockerfile`.
 
 Clone the repository:
 ```
@@ -320,7 +320,7 @@ docker run --rm wot-servient -h
 
 ### As a browser library
 
-Node-wot can also be imported as browser-side library. To do so, include the following `script` tag in your html:
+node-wot can also be imported as browser-side library. To do so, include the following `script` tag in your html:
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@node-wot/browser-bundle@latest/dist/wot-bundle.min.js"></script>
 ```

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ docker run -it --init -v "$(pwd)"/examples:/srv/examples --rm --net=host wot-ser
 * The counter exposes the HTTP endpoint at 8080/tcp and the CoAP endpoint at 5683/udp and they are bound to the host machine (with `-p 8080:8080/tcp -p 5683:5683/udp`).
 * The counter-client binds the network of the host machine (`--net=host`) so that it can access the counter thing's endpoints.
 * `--init` allows the containers to be killed with SIGINT (e.g., Ctrl+c)
+* `-v "$(pwd)"/examples:/srv/examples` mounts the `examples` directory to `/srv/examples` on the container so that the node inside the container can read the example scripts.
 
 ### Using a browser
 An example of how to use node-wot as a browser-side library can be found under `examples/browser/index.html`.


### PR DESCRIPTION
I've added the following:
- `docker build` instruction for wot-servient
- "No time for explanations" example using Docker

To make the built Docker image a bit more useful, I also added `STOPSIGNAL SIGINT` to `Dockerfile`.