### PR TITLE
Fix 439

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,27 @@
                 "--timeout",
                 "999999",
                 "--colors",
+                "${file}"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "cwd": "${workspaceFolder}/packages/binding-modbus/",
+            "name": "Modbus Test current File",
+            "program": "${workspaceFolder}/packages/binding-http/node_modules/mocha/bin/_mocha",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "args": [
+                "-u",
+                "tdd",
+                "--compilers",
+                "ts:ts-node/register",
+                "--timeout",
+                "999999",
+                "--colors",
                 "${workspaceFolder}/packages/binding-coap/test"
             ],
             "internalConsoleOptions": "openOnSessionStart",

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -97,7 +97,7 @@ export default class ModbusClient implements ProtocolClient {
 
     if (!connection) {
       console.debug('[binding-modbus]', 'Creating new ModbusConnection for ', hostAndPort);
-      this._connections.set(hostAndPort, new ModbusConnection(host, port));
+      this._connections.set(hostAndPort, new ModbusConnection(host, port, {connectionTimeout: form['modbus:timeout'] || DEFAULT_TIMEOUT}));
       connection = this._connections.get(hostAndPort);
     }else {
       console.debug('[binding-modbus]', 'Reusing ModbusConnection for ', hostAndPort);
@@ -198,7 +198,7 @@ export default class ModbusClient implements ProtocolClient {
     }
 
 
-    if(form['modbus:offset'] !== 0) {
+    if(form['modbus:offset'] === undefined || form['modbus:offset'] === null) {
         throw new Error('Malformed form: offset must be defined');
     }
     

--- a/packages/binding-modbus/src/modbus-connection.ts
+++ b/packages/binding-modbus/src/modbus-connection.ts
@@ -262,7 +262,7 @@ export class ModbusConnection {
         this.connecting = false;
         this.connected = false;
       } else {
-        console.error('[binding-modbus]', 'cannot close session ' + err);
+        console.error('[binding-modbus]', 'cannot close session ' + err); 
       }
     });
     clearInterval(this.timer)

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -119,6 +119,18 @@ describe('Modbus client test', () => {
             result = await client.readResource(form)
             result.body.should.deep.equal(Buffer.from([1]), "Wrong data")
         });
+        it('should fail for timeout', async () => {
+            const form: ModbusForm = {
+                href: "modbus://127.0.0.1:8502",
+                "modbus:function": 1,
+                "modbus:offset": 4444,
+                "modbus:length": 1,
+                "modbus:unitID": 1,
+                "modbus:timeout": 1000
+            }
+
+            await client.readResource(form).should.eventually.be.rejected;
+        }).timeout(5000);
     });
     describe('read resource', () => {
         it('should read a resource using read coil function', async () => {

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -27,7 +27,7 @@ describe('Modbus connection', () => {
     it('should connect', async()=>{
         const connection = new ModbusConnection("127.0.0.1",8502)
         await connection.connect()
-        connection.connected.should.be.true
+        connection.client.isOpen.should.be.true
     })
 
     it('should throw for unknown host', () => {

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -31,12 +31,17 @@ describe('Modbus connection', () => {
     })
 
     it('should throw for unknown host', () => {
-        const connection = new ModbusConnection("127.0.0.2", 8503,{connectionTimeout:200,connectionRetryTime:10,maxRetries:1})
-        return connection.connect().should.eventually.be.rejected
+        const connection = new ModbusConnection("127.0.0.2", 8502,{connectionTimeout:200,connectionRetryTime:10,maxRetries:1})
+        return connection.connect().should.eventually.be.rejectedWith("Max connection retries");
+    }).timeout(5000);
+
+    it('should throw for timeout', () => {
+        const connection = new ModbusConnection("127.0.0.1", 8503, { connectionTimeout: 200, connectionRetryTime: 10, maxRetries: 1 })
+        return connection.connect().should.eventually.be.rejectedWith("Max connection retries");
     }).timeout(5000);
 
     describe('Operation', () => {
-        it('should fail for unknown host',()=>{
+        it('should fail for unknown host', async ()=>{
             const form: ModbusForm = {
                 href: "modbus://127.0.0.2:8502",
                 "modbus:function": 15,
@@ -48,7 +53,25 @@ describe('Modbus connection', () => {
             const op = new PropertyOperation(form, ModbusEndianness.BIG_ENDIAN)
             connection.enqueue(op);
 
-            return op.execute().should.eventually.be.rejected
+            await op.execute().should.eventually.be.rejected
+            connection.close();
+        }).timeout(5000);
+
+        it('should throw with timeout', async() => {
+            const form: ModbusForm = {
+                href: "modbus://127.0.0.1:8502",
+                "modbus:entity": "Coil",
+                "modbus:offset": 4444,
+                "modbus:length": 1,
+                "modbus:unitID": 1
+            }
+            const connection = new ModbusConnection("127.0.0.1", 8502, {connectionTimeout: 1000, connectionRetryTime: 10, maxRetries: 1 })
+            const op = new PropertyOperation(form, ModbusEndianness.BIG_ENDIAN)
+            connection.enqueue(op);
+
+            await op.execute().should.eventually.be.rejected
+
+            connection.close();
         }).timeout(5000);
     });
 });


### PR DESCRIPTION
A minor fix for issue #439. Now the Modbus client properly initializes the connection with the right timeout. Plus this PR also adds a convenient launch task to debug the Modbus test suite.