### PR TITLE
Upgrade tasks file to v2.0.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,19 +1,30 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "npm",
     "args": ["run"],
     "echoCommand": true,
-    "isShellCommand": true,
-    "showOutput": "always",
     "problemMatcher": "$tsc",
     "tasks": [
         {
-            "taskName": "build"
+            "label": "build",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "build"
+            ],
+            "group": "build"
         },
         {
-            "taskName": "test"
+            "label": "test",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "test"
+            ]
         }
     ]
 }


### PR DESCRIPTION
VS code deprecated v1.0.0 version of the task file, considering that vscode is usually automatically updated I think we are safe to upgrade the task file to v2.0.0. Plus it doesn't really like the file and every time a user oper the repository it automatically replaces it with the new version. 