### PR TITLE
Fix 437

### DIFF
--- a/examples/security/oauth/package.json
+++ b/examples/security/oauth/package.json
@@ -12,6 +12,7 @@
   "license": "EPL-2.0 OR W3C-20150513",
   "devDependencies": {
     "@types/express-oauth-server": "^2.0.2",
+    "cors": "^2.8.5",
     "express-oauth-server": "^2.0.0"
   }
 }

--- a/examples/security/oauth/server.js
+++ b/examples/security/oauth/server.js
@@ -17,12 +17,18 @@
  */
 const OAuthServer = require('express-oauth-server')
 const bodyParser = require('body-parser');
+const cors = require('cors');
 const https = require('https');
 const fs = require('fs')
 const express = require('express')
 const Memory = require('./memory-model');
 
+
+
+
 var app = express();
+app.use(cors());
+app.options('*', cors());
 
 const model = new Memory()
 

--- a/packages/binding-http/src/credential.ts
+++ b/packages/binding-http/src/credential.ts
@@ -116,9 +116,8 @@ export class OAuthCredential extends Credential {
         tempRequest = this.token.sign(tempRequest)
         
         const mergeHeaders = new Request(request,tempRequest)
-        const useNewURL = new Request(tempRequest.url,mergeHeaders)
         
-        return useNewURL
+        return mergeHeaders;
     }
 
     async refreshToken() {

--- a/packages/examples/src/security/oauth/package.json
+++ b/packages/examples/src/security/oauth/package.json
@@ -16,6 +16,7 @@
     "@types/express-oauth-server": "^2.0.2",
     "express-oauth-server": "^2.0.0",
     "@types/node": "13.7.0",
+    "cors": "^2.8.5",
     "wot-typescript-definitions": "0.7.1-SNAPSHOT.1",
     "ts-node": "8.6.2",
     "typescript": "3.7.5",

--- a/packages/examples/src/security/oauth/server.js
+++ b/packages/examples/src/security/oauth/server.js
@@ -17,12 +17,18 @@
  */
 const OAuthServer = require('express-oauth-server')
 const bodyParser = require('body-parser');
+const cors = require('cors');
 const https = require('https');
 const fs = require('fs')
 const express = require('express')
 const Memory = require('./memory-model');
 
+
+
+
 var app = express();
+app.use(cors());
+app.options('*', cors());
 
 const model = new Memory()
 
@@ -32,7 +38,7 @@ app.oauth = new OAuthServer({
 
 app.use(bodyParser.json());
 app.use("/introspect", bodyParser.urlencoded({ extended: false }));
-app.use("/introspect", (req,res,next)=>{
+app.use("/introspect", (req, res, next) => {
     if (req.method !== "POST" || !req.is("application/x-www-form-urlencoded")) {
         return res.status(400).end()
     }
@@ -45,16 +51,16 @@ app.use("/introspect", (req,res,next)=>{
     next()
 })
 
-app.use("/introspect", async(req, res, next) => { 
-    return app.oauth.authenticate()(req,res,next)
-    
-    
+app.use("/introspect", async (req, res, next) => {
+    return app.oauth.authenticate()(req, res, next)
+
+
 });
-app.use("/introspect",(req,res)=>{
+app.use("/introspect", (req, res) => {
     const token = res.locals.oauth.token
-    console.log("Token was",token? "Ok": "not Ok")
+    console.log("Token was", token ? "Ok" : "not Ok")
     res.json({
-        active : !!token,
+        active: !!token,
         scope: token.client.grants.join(" "),
         client_id: token.client.clientId
     }).end()


### PR DESCRIPTION
This PR fix #437 plus a minor addition for testing OAuth 2.0 with browsers. Basically, I found that in the previous implementation we cloned the request many times. This process worked well on nodes but on browsers, it fails to copy the body in the last `const useNewURL = new Request(tempRequest.url,mergeHeaders)` assigned. Sadly, I didn't have time to dig more about the reasons why this is happing (maybe browsers don't like to copy too many times a ReadableStream?) but  `const useNewURL = new Request(tempRequest.url,mergeHeaders)` was just a precaution to ensure that the URL was not rewritten by `token.sign`. Indeed `const mergeHeaders = new Request(request,tempRequest)` should be already sufficient