### PR TITLE
Octet stream encoding process and support for float16

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -67,6 +67,15 @@
 				}
 			}
 		},
+		"@petamoriken/float16": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.1.1.tgz",
+			"integrity": "sha512-gxydAv75Opn+qWaii5kCyw3iMsC7rvah6ZA5nv+Ajyp6ZeQ90sMRPllol/dIljzNNe9VXWQLh2rgk55EJI8JRA==",
+			"requires": {
+				"lodash": ">=4.17.5 <5.0.0",
+				"lodash-es": ">=4.17.5 <5.0.0"
+			}
+		},
 		"@types/chai": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.8.tgz",
@@ -493,6 +502,16 @@
 				"pinkie-promise": "^2.0.0",
 				"strip-bom": "^2.0.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,13 +24,14 @@
     "typescript-standard": "0.3.36"
   },
   "dependencies": {
-    "wot-typescript-definitions": "0.7.3",
     "@node-wot/td-tools": "0.7.7",
-    "uuid": "3.4.0",
+    "@petamoriken/float16": "^3.1.1",
+    "@types/uritemplate": "0.3.4",
     "rxjs": "5.5.11",
     "uritemplate": "0.3.4",
-    "@types/uritemplate": "0.3.4",
-    "vm2": "^3.9.2"
+    "uuid": "3.4.0",
+    "vm2": "^3.9.2",
+    "wot-typescript-definitions": "0.7.3"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -17,6 +17,7 @@
  import * as TD from "@node-wot/td-tools";
 import { ArraySchema } from "@node-wot/td-tools";
 import { sign } from "crypto";
+import { getFloat16, setFloat16 } from "@petamoriken/float16";
 
 /**
  * Codec to produce and consume simple data items and deserialize and serialize
@@ -65,7 +66,7 @@ export default class OctetstreamCodec implements ContentCodec {
         // Check type specification 
         // according paragraph 3.3.3 of https://datatracker.ietf.org/doc/rfc8927/
         // Parse type property only if this test passes
-        if(/(short|(u)?int(8|16|32)?$|float(32|64)?|byte)/.test(dataType.toLowerCase())) {
+        if(/(short|(u)?int(8|16|32)?$|float(16|32|64)?|byte)/.test(dataType.toLowerCase())) {
             let typeSem = /(u)?(short|int|float|byte)(8|16|32|64)?/.exec(dataType.toLowerCase());
             if(typeSem) {
                 signed = typeSem[1] === undefined;
@@ -124,6 +125,8 @@ export default class OctetstreamCodec implements ContentCodec {
             case "double":
             case "number":
                 switch (dataLength) {
+                    case 2: 
+                        return getFloat16( new DataView(bytes.buffer), bytes.byteOffset, !bigendian );
                     case 4:
                         return bigendian ? bytes.readFloatBE(0) : bytes.readFloatLE(0);
 
@@ -131,7 +134,7 @@ export default class OctetstreamCodec implements ContentCodec {
                         return bigendian ? bytes.readDoubleBE(0) : bytes.readDoubleLE(0);
 
                     default:
-                        throw new Error("Wrong buffer length for type 'number', must be 4 or 8, is " + dataLength);
+                        throw new Error("Wrong buffer length for type 'number', must be 2, 4, 8, or is " + dataLength);
                 }
 
             case "string":
@@ -150,44 +153,41 @@ export default class OctetstreamCodec implements ContentCodec {
     valueToBytes(value: any, schema: TD.DataSchema, parameters?: { [key: string]: string; }): Buffer {
         //console.debug(`OctetstreamCodec serializing '${value}'`);
 
-         if (parameters.length === null) {
-            throw new Error("Missing 'length' parameter necessary for write");
+         if (!parameters.length) {
+            console.warn("[core/octetstream-codec]","Missing 'length' parameter necessary for write. I'll do my best");
          }
 
         let bigendian = parameters.byteorder ? parameters.byteorder === "bigendian" : true;
-        let signed = parameters.signed ? parameters.signed === "true" : false;
-        let length = parseInt(parameters.length);
+        let signed = parameters.signed ? parameters.signed === "true" : true; // default is signed
+        let length = parameters.length ? parseInt(parameters.length) : undefined;
         let buf: Buffer;
 
         if (value === undefined) {
             throw new Error("Undefined value");
         }
 
-        let dataType = schema.type;
+        let dataType: string = schema.type;
 
-        // check @type property for further information
-        if(schema['@type'] !== undefined) {
-            let semTypes: Array<string> = schema["@type"];
-            // check for endianness semantic type
-            // see http://www.meta-share.org/ontologies/meta-share/meta-share-ontology.owl/documentation/index-en.html
-            let endianSem = semTypes.find(v => v.endsWith(":bigEndian") || v.endsWith(':littleEndian'));
-            bigendian = endianSem === undefined ? bigendian : endianSem.endsWith(":bigEndian");
-            // check for numeric datatype semantic
-            // see https://www.w3.org/TR/xmlschema-2/
-            let typeSem = semTypes.find(v => /:(unsigned)?(short|int|long|float|double|byte)/.test(v.toLowerCase()));
-            if(typeSem) {
-                // check for sign semantic type
-                signed = typeSem.toLowerCase().indexOf('unsigned') === -1;
-                let numberSem = /(short|int|long|float|double|byte)/.exec(typeSem.toLowerCase())[1];
-                dataType = numberSem === "int" || numberSem === "short" || numberSem === "byte" ? "integer" : "number";
+        // Check type specification 
+        // according paragraph 3.3.3 of https://datatracker.ietf.org/doc/rfc8927/
+        // Parse type property only if this test passes
+        if (/(short|(u)?int(8|16|32)?$|float(16|32|64)?|byte)/.test(dataType.toLowerCase())) {
+            let typeSem = /(u)?(short|int|float|byte)(8|16|32|64)?/.exec(dataType.toLowerCase());
+            if (typeSem) {
+                signed = typeSem[1] === undefined;
+                dataType = typeSem[2];
+                length = +typeSem[3] / 8 ?? length;
             }
         }
 
         switch (dataType) {
             case "boolean":
                 return Buffer.alloc(length, value ? 255 : 0);
-
+            case "byte":
+            case "short":
+            case "int":
             case "integer":
+                length = length ?? 4;
                 if (typeof value !== "number") {
                     throw new Error("Value is not a number");
                 }
@@ -196,14 +196,14 @@ export default class OctetstreamCodec implements ContentCodec {
                 if (!Number.isSafeInteger(value)) {
                     console.warn("[core/octetstream-codec]","Value is not a safe integer");
                 }
-
+                let limit = Math.pow(2, 8 * length) - 1;
                 // throw error on overflow
                 if (signed) {
-                    if (value < -(1 << 8 * length - 1) || value >= (1 << 8 * length - 1)) {
+                    if (value < -limit || value >= limit) {
                         throw new Error("Integer overflow when representing signed " + value + " in " + length + " byte(s)");
                     }
                 } else {
-                    if (value < 0 || value >= (1 << 8 * length)) {
+                    if (value < 0 || value >= limit) {
                         throw new Error("Integer overflow when representing unsigned " + value + " in " + length + " byte(s)");
                     }
                 }
@@ -240,15 +240,19 @@ export default class OctetstreamCodec implements ContentCodec {
                 }
 
                 return buf;
-
+            case "float":
             case "number":
                 if (typeof value !== "number") {
                     throw new Error("Value is not a number");
                 }
 
+                length = length ?? 8;
                 buf = Buffer.alloc(length);
 
                 switch (length) {
+                    case 2:
+                        setFloat16(new DataView(buf.buffer),0,value, !bigendian);
+                        break;
                     case 4:
                         bigendian ? buf.writeFloatBE(value, 0) : buf.writeFloatLE(value, 0);
                         break;

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -64,8 +64,38 @@ class SerdesOctetTests {
         checkStreamToValue([ 0x49, 0x25 ], 18725, "integer")
         checkStreamToValue([ 0xA4, 0x78 ], -23432, "int16")
         checkStreamToValue([ 0xEB, 0xE6, 0x90, 0x49 ], -5.5746861179443064e+26, "number")
+        checkStreamToValue([0x44, 0x80], 4.5, "float16")
         checkStreamToValue([ 0xEB, 0xE6, 0x90, 0x49 ], -5.5746861179443064e+26, "float32")
         checkStreamToValue([ 0xD3, 0xCD, 0xCC, 0xCC, 0xC1, 0xB4, 0x82, 0x70 ], -4.9728447076484896e+95, "float64")
+    }
+    @test "value to OctetStream"() {
+        let content = ContentSerdes.valueToContent(2345, { type: "integer" }, "application/octet-stream")
+        expect(content.body).to.deep.equal(Buffer.from([0x00, 0x00, 0x09, 0x29 ]));
+        // should default to signed
+        content = ContentSerdes.valueToContent(-2345, { type: "integer" }, "application/octet-stream")
+        expect(content.body).to.deep.equal(Buffer.from([0xFF, 0xFF, 0xF6, 0xD7]));
+
+        //@ts-ignore new dataschema types are not yet supported in the td type definitions 
+        content = ContentSerdes.valueToContent(2345, { type: "int16" }, "application/octet-stream")
+        expect(content.body).to.deep.equal(Buffer.from([0x09, 0x29]));
+
+        //@ts-ignore new dataschema types are not yet supported in the td type definitions 
+        content = ContentSerdes.valueToContent(10, { type: "int8" }, "application/octet-stream")
+        expect(content.body).to.deep.equal(Buffer.from([0x0a]));
+
+        //should serialize a number as a float16
+        //@ts-ignore new dataschema types are not yet supported in the td type definitions 
+        content = ContentSerdes.valueToContent(4.5, { type: "float16" }, "application/octet-stream")
+        expect(content.body).to.deep.equal(Buffer.from([0x44, 0x80]));
+    }
+
+    @test "value to OctetStream should throw for overflow"() {
+        //@ts-ignore new dataschema types are not yet supported in the td type definitions 
+        expect(() => ContentSerdes.valueToContent(2345, { type: "int8" }, "application/octet-stream") )
+            .to.throw(Error, "Integer overflow when representing signed 2345 in 1 byte(s)");
+        //@ts-ignore new dataschema types are not yet supported in the td type definitions 
+        expect(() => ContentSerdes.valueToContent(23450000, { type: "int16" }, "application/octet-stream"))
+            .to.throw(Error, "Integer overflow when representing signed 23450000 in 2 byte(s)");
     }
 }
 


### PR DESCRIPTION
This PR fixes issues #448 and #447.  Notice that `@type` is not used as the source of information for the encoding format. The library now uses `type` and a set of well know identifiers for complex types like `uint8`. 