### PR TITLE
Connect to mqtts

### DIFF
--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -44,6 +44,7 @@ export default class MqttBrokerServer implements ProtocolServer {
   private readonly things: Map<string, ExposedThing> = new Map<string, ExposedThing>();
 
   private broker: any;
+  private rejectUnauthorized: boolean;
 
   /*new MqttBrokerServer(this.config.mqtt.broker,
                         (typeof this.config.mqtt.username === "string") ? this.config.mqtt.username : undefined,
@@ -55,7 +56,7 @@ export default class MqttBrokerServer implements ProtocolServer {
         "port": BROKER-PORT,
         "version": MQTT_VERSION
   */
-  constructor(uri: string, user?: string, psw?: string, clientId?: string, protocolVersion?: number) {
+  constructor(uri: string, user?: string, psw?: string, clientId?: string, protocolVersion?: number, rejectUnauthorized?: boolean) {
     if (uri !== undefined) {
 
       //if there is a MQTT protocol identicator missing, add this
@@ -77,6 +78,8 @@ export default class MqttBrokerServer implements ProtocolServer {
     if (protocolVersion !== undefined) {
       this.protocolVersion = protocolVersion;
     }
+
+    this.rejectUnauthorized = rejectUnauthorized;
   }
 
   public expose(thing: ExposedThing): Promise<void> {
@@ -301,21 +304,15 @@ export default class MqttBrokerServer implements ProtocolServer {
         // try to connect to the broker without or with credentials
         if (this.psw === undefined) {
           console.debug("[binding-mqtt]",`MqttBrokerServer trying to connect to broker at ${this.brokerURI}`);
-          // TODO test if mqtt extracts port from passed URI (this.address)
-          this.broker = mqtt.connect(this.brokerURI);
         } else if (this.clientId === undefined) {
           console.debug("[binding-mqtt]",`MqttBrokerServer trying to connect to secured broker at ${this.brokerURI}`);
-          // TODO test if mqtt extracts port from passed URI (this.address)
-          this.broker = mqtt.connect(this.brokerURI, { username: this.user, password: this.psw });
         } else if (this.protocolVersion === undefined) {
           console.debug("[binding-mqtt]",`MqttBrokerServer trying to connect to secured broker at ${this.brokerURI} with client ID ${this.clientId}`);
-          // TODO test if mqtt extracts port from passed URI (this.address)
-          this.broker = mqtt.connect(this.brokerURI, { username: this.user, password: this.psw, clientId: this.clientId });
         } else {
           console.debug("[binding-mqtt]",`MqttBrokerServer trying to connect to secured broker at ${this.brokerURI} with client ID ${this.clientId}`);
-          // TODO test if mqtt extracts port from passed URI (this.address)
-          this.broker = mqtt.connect(this.brokerURI, { username: this.user, password: this.psw, clientId: this.clientId, protocolVersion: this.protocolVersion });
         }
+        // TODO test if mqtt extracts port from passed URI (this.address)
+        this.broker = mqtt.connect(this.brokerURI, { username: this.user, password: this.psw, clientId: this.clientId, protocolVersion: this.protocolVersion, rejectUnauthorized: this.rejectUnauthorized });
 
         this.broker.on("connect", () => {
           console.info("[binding-mqtt]",`MqttBrokerServer connected to broker at ${this.brokerURI}`);

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -20,7 +20,7 @@
 import { ProtocolClient, Content, ContentSerdes } from '@node-wot/core';
 import * as TD from '@node-wot/td-tools';
 import * as mqtt from 'mqtt';
-import { MqttForm, MqttQoS } from './mqtt';
+import { MqttClientConfig, MqttForm, MqttQoS } from './mqtt';
 import { IPublishPacket, QoS } from 'mqtt';
 import * as url from 'url';
 import { Subscription } from "rxjs/Subscription";
@@ -29,8 +29,12 @@ export default class MqttClient implements ProtocolClient {
     private user:string = undefined;
 
     private psw:string = undefined;
+    private scheme: string;
+    private rejectUnauthorized: boolean;
 
-    constructor(config: any = null, secure = false) {}
+    constructor(private readonly config: MqttClientConfig = null, secure = false) {
+        this.scheme = "mqtt" + (secure ? "s" : "");
+    }
 
     private client : any = undefined;
 
@@ -42,10 +46,10 @@ export default class MqttClient implements ProtocolClient {
         let qos = form["mqtt:qos"]; // TODO: is this needed here?
         let requestUri = url.parse(form['href']);
         let topic = requestUri.pathname.slice(1);
-        let brokerUri : String = "mqtt://"+requestUri.host;
+        let brokerUri: String = `${this.scheme}://${requestUri.host}`;
 
         if(this.client==undefined) {
-            this.client = mqtt.connect(brokerUri)
+            this.client = mqtt.connect(brokerUri, this.config)
         }
 
         this.client.on('connect', () => this.client.subscribe(topic))
@@ -88,10 +92,10 @@ export default class MqttClient implements ProtocolClient {
 
             let requestUri = url.parse(form['href']);
             let topic = requestUri.pathname.slice(1);
-            let brokerUri : String = "mqtt://"+requestUri.host;
+            let brokerUri: String = `${this.scheme}://${requestUri.host}`;
             
             if(this.client==undefined) {
-                this.client = mqtt.connect(brokerUri)
+                this.client = mqtt.connect(brokerUri, this.config)
             }
 
             // if not input was provided, set up an own body otherwise take input as body

--- a/packages/binding-mqtt/src/mqtt.ts
+++ b/packages/binding-mqtt/src/mqtt.ts
@@ -47,4 +47,8 @@ export class MqttForm extends Form {
 
 }
 
+export interface MqttClientConfig {
+    rejectUnauthorized?: boolean
+}
+
 

--- a/packages/binding-mqtt/src/mqtt.ts
+++ b/packages/binding-mqtt/src/mqtt.ts
@@ -21,10 +21,12 @@ import { Form } from "@node-wot/td-tools";
 
 export { default as MqttClient } from './mqtt-client';
 export { default as MqttClientFactory } from './mqtt-client-factory';
+export { default as MqttsClientFactory } from './mqtts-client-factory';
 export { default as MqttBrokerServer } from './mqtt-broker-server';
 
 export * from './mqtt-client';
 export * from './mqtt-client-factory'
+export * from './mqtts-client-factory'
 export * from './mqtt-broker-server'
 
 

--- a/packages/binding-mqtt/src/mqtts-client-factory.ts
+++ b/packages/binding-mqtt/src/mqtts-client-factory.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+/**
+ * Protocol test suite to test protocol implementations
+ */
+
+import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { MqttClientConfig } from "./mqtt";
+import MqttClient from "./mqtt-client";
+
+export default class MqttsClientFactory implements ProtocolClientFactory {
+
+    public readonly scheme: string = "mqtts";
+    private readonly clients: Array<ProtocolClient> = [];
+
+    constructor(private readonly config: MqttClientConfig) {
+    
+    }
+    getClient = (): ProtocolClient => {
+        let client = new MqttClient(this.config,true);
+        this.clients.push(client);
+        return client;
+    }
+
+    init(): boolean {
+        return true;
+    }
+
+    destroy(): boolean {
+        console.debug("[binding-mqtt]", `MqttClientFactory stopping all clients for '${this.scheme}'`);
+        this.clients.forEach((client) => client.stop())
+        return true;
+    }
+}

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
@@ -24,8 +24,9 @@ should();
 
 import { Servient, ExposedThing } from "@node-wot/core";
 
-import MqttBrokerServer from "../dist/mqtt-broker-server";
-import MqttClientFactory from "../dist/mqtt-client-factory";
+import MqttBrokerServer from "../src/mqtt-broker-server";
+import MqttClientFactory from "../src/mqtt-client-factory";
+import MqttsClientFactory from "../src/mqtts-client-factory";
 
 @suite("MQTT implementation")
 class MqttClientSubscribeTest {
@@ -75,6 +76,72 @@ class MqttClientSubscribeTest {
                                         }
                                     })
                                     .then(() => {})
+                                    .catch((e) => {
+                                        expect(true).to.equal(false);
+                                    });
+
+                                var job = setInterval(() => {
+                                    ++counter;
+                                    thing.emitEvent(eventName, counter);
+                                    if (counter === 3) {
+                                        clearInterval(job);
+                                    }
+                                }, 400);
+                            }
+                        );
+                    });
+                });
+            });
+        } catch (err) {
+            console.error("ERROR", err);
+        }
+    }
+
+    @test(timeout(5000)) "should subscribe using mqtts"(done: Function) {
+
+        try {
+            let servient = new Servient();
+            var brokerAddress = "test.mosquitto.org"
+            var brokerPort = 8883
+            var brokerUri = `mqtts://${brokerAddress}:${brokerPort}`
+
+            let brokerServer = new MqttBrokerServer(brokerUri, undefined,undefined,undefined,undefined, false);
+            servient.addServer(brokerServer);
+
+            servient.addClientFactory(new MqttsClientFactory({rejectUnauthorized: false}));
+
+            var counter = 0;
+
+            servient.start().then((WoT) => {
+                expect(brokerServer.getPort()).to.equal(brokerPort);
+                expect(brokerServer.getAddress()).to.equal(brokerAddress);
+
+                var eventNumber = Math.floor(Math.random() * 1000000);
+                var eventName: string = "event" + eventNumber;
+                var events: { [key: string]: any } = {};
+                events[eventName] = { type: "number" };
+
+                WoT.produce({
+                    title: "TestWoTMQTT",
+                    events: events,
+                }).then((thing) => {
+                    thing.expose().then(() => {
+                        console.info(
+                            "Exposed",
+                            thing.getThingDescription().title
+                        );
+
+                        WoT.consume(thing.getThingDescription()).then(
+                            (client) => {
+                                let check = 0;
+                                client
+                                    .subscribeEvent(eventName, (x) => {
+                                        expect(x).to.equal(++check);
+                                        if (check === 3) {
+                                            done();
+                                        }
+                                    })
+                                    .then(() => { })
                                     .catch((e) => {
                                         expect(true).to.equal(false);
                                     });


### PR DESCRIPTION
This PR should fix #455. I used a conservative style but the MQTT binding need multiple updates to put it in shape. Moreover, I did not test the change for custom self-signed certificate validation. People can use `rejectUnauthorized: false` meanwhile, but it is considered a temporary solution just for internal testing. 