### PR TITLE
change package name and versions for binding-wotfirestore

### DIFF
--- a/packages/binding-wotfirestore-browser-bundle/README.md
+++ b/packages/binding-wotfirestore-browser-bundle/README.md
@@ -2,27 +2,28 @@
 
 Bundle to run Firestore Binding as browser-side library.
 
-## Supported bindings 
+## Supported bindings
+
 HTTP / HTTPS / WebSockets
 
-## Embedding Firestore Binding library in HTML 
+## Embedding Firestore Binding library in HTML
 
 Include the following script tag in your html
 
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@hidetak/binding-wotfirestore-browser-bundle@latest/dist/binding-wotfirestore-bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@node-wot/binding-wotfirestore-browser-bundle@latest/dist/binding-wotfirestore-bundle.js"></script>
 ```
 
 You can access all binding-wotfirestore functionality through the "BindingWoTFirestore" global object:
 
 ```js
-var WoTFirestoreClientFactory = BindingWoTFirestore.WoTFirestoreClientFactory;
-var WoTFirestoreCodec = BindingWoTFirestore.WoTFirestoreCodec;
-var WoTFirestoreServer = BindingWoTFirestore.WoTFirestoreServer;
+var WoTFirestoreClientFactory = BindingWoTFirestore.WoTFirestoreClientFactory
+var WoTFirestoreCodec = BindingWoTFirestore.WoTFirestoreCodec
+var WoTFirestoreServer = BindingWoTFirestore.WoTFirestoreServer
 ```
 
 ## Using binding-wotfirestore browser bundle library in web frameworks
 
 Install browser-bundle in your project by running
 
-* `npm install @hidetak/binding-wotfirestore-browser-bundle`
+- `npm install @node-wot/binding-wotfirestore-browser-bundle`

--- a/packages/binding-wotfirestore-browser-bundle/index.js
+++ b/packages/binding-wotfirestore-browser-bundle/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BindingWoTFirestore = require("@hidetak/binding-wotfirestore");
+const BindingWoTFirestore = require("@node-wot/binding-wotfirestore");
 
 if (typeof window !== "undefined") {
     window.BindingWoTFirestore = BindingWoTFirestore;

--- a/packages/binding-wotfirestore-browser-bundle/package-lock.json
+++ b/packages/binding-wotfirestore-browser-bundle/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "@hidetak/binding-wotfirestore-browser-bundle",
-	"version": "0.0.5",
+	"name": "@node-wot/binding-wotfirestore-browser-bundle",
+	"version": "0.7.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/binding-wotfirestore-browser-bundle/package.json
+++ b/packages/binding-wotfirestore-browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hidetak/binding-wotfirestore-browser-bundle",
-  "version": "0.0.5",
+  "name": "@node-wot/binding-wotfirestore-browser-bundle",
+  "version": "0.7.8",
   "description": "A binding-wotfirestore bundle that can run in a web browser",
   "repository": "https://github.com/hidetak/thingweb.node-wot",
   "author": "hidetak",
@@ -17,7 +17,7 @@
     "tinyify": "^2.5.2"
   },
   "dependencies": {
-    "@hidetak/binding-wotfirestore": "0.0.5"
+    "@node-wot/binding-wotfirestore": "0.7.8"
   },
   "scripts": {
     "build": "browserify -r vm:vm2 index.js --external coffee-script -o dist/binding-wotfirestore-bundle.js"

--- a/packages/binding-wotfirestore/README.md
+++ b/packages/binding-wotfirestore/README.md
@@ -58,7 +58,7 @@ To prepare for creating a nodejs app, execute `npm install`.
 After executing `npm init`, install the following modules.
 
 - `npm install @node-wot/core`
-- `npm install @hidetak/binding-wotfirestore`
+- `npm install @node-wot/binding-wotfirestore`
 
 ### Creating configuration file
 
@@ -92,10 +92,10 @@ The ThingDescription registered by `example-server.js`.
 // example-client.js
 const Servient = require('@node-wot/core').Servient
 const WoTFirestoreClientFactory =
-  require('@hidetak/binding-wotfirestore').WoTFirestoreClientFactory
+  require('@node-wot/binding-wotfirestore').WoTFirestoreClientFactory
 const Helpers = require('@node-wot/core').Helpers
 const WoTFirestoreCodec =
-  require('@hidetak/binding-wotfirestore').WoTFirestoreCodec
+  require('@node-wot/binding-wotfirestore').WoTFirestoreCodec
 
 const firestoreConfig = require('./firestore-config.json')
 
@@ -138,9 +138,9 @@ The server example produces a thing that allows for setting a property `count`. 
 // example-server.js
 const Servient = require('@node-wot/core').Servient
 const WoTFirestoreServer =
-  require('@hidetak/binding-wotfirestore').WoTFirestoreServer
+  require('@node-wot/binding-wotfirestore').WoTFirestoreServer
 const WoTFirestoreCodec =
-  require('@hidetak/binding-wotfirestore').WoTFirestoreCodec
+  require('@node-wot/binding-wotfirestore').WoTFirestoreCodec
 
 const firestoreConfig = require('./firestore-config.json')
 

--- a/packages/binding-wotfirestore/package-lock.json
+++ b/packages/binding-wotfirestore/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "@hidetak/binding-wotfirestore",
-	"version": "0.0.5",
+	"name": "@node-wot/binding-wotfirestore",
+	"version": "0.7.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/binding-wotfirestore/package.json
+++ b/packages/binding-wotfirestore/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hidetak/binding-wotfirestore",
-  "version": "0.0.5",
+  "name": "@node-wot/binding-wotfirestore",
+  "version": "0.7.8",
   "description": "Firestore binding for node-wot",
   "repository": "https://github.com/hidetak/thingweb.node-wot",
   "main": "dist/wotfirestore.js",
@@ -14,8 +14,8 @@
   "author": "hidetak",
   "license": "EPL-2.0",
   "dependencies": {
-    "@node-wot/core": "0.7.7",
-    "@node-wot/td-tools": "0.7.7",
+    "@node-wot/core": "0.7.8",
+    "@node-wot/td-tools": "0.7.8",
     "buffer": "^5.5.0",
     "firebase": "^7.24.0",
     "uuid": "^7.0.3"


### PR DESCRIPTION
The package name has been changed to the following.
* @node-wot/binding-wotfirestore
* @node-wot/binding-wotfirestore-browser-bundle
The version was set to 0.7.8 to match the other versions of thingwot.

I have also changed the other packages of thingweb used by binding-wotfirestore to 0.7.8.