### PR TITLE
feat(binding-websockets): add handlers for properties and actions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,41 +1,37 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib",
-    "typescript.referencesCodeLens.enabled": true,
-    "fileHeaderComment.parameter":{
-    "*":{
-        "author": "the thingweb community",
-        "license_w3c":[
-            "/********************************************************************************",
-			" * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation",
-            " *",
-            " * See the NOTICE file(s) distributed with this work for additional",
-            " * information regarding copyright ownership.",
-            " *",
-            " * This program and the accompanying materials are made available under the",
-            " * terms of the Eclipse Public License v. 2.0 which is available at",
-            " * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and",
-            " * Document License (2015-05-13) which is available at",
-            " * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.",
-            " *",
-            " * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513",
-            " ********************************************************************************/"
-        ]
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.referencesCodeLens.enabled": true,
+  "fileHeaderComment.parameter": {
+    "*": {
+      "author": "the thingweb community",
+      "license_w3c": [
+        "/********************************************************************************",
+        " * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation",
+        " *",
+        " * See the NOTICE file(s) distributed with this work for additional",
+        " * information regarding copyright ownership.",
+        " *",
+        " * This program and the accompanying materials are made available under the",
+        " * terms of the Eclipse Public License v. 2.0 which is available at",
+        " * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and",
+        " * Document License (2015-05-13) which is available at",
+        " * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.",
+        " *",
+        " * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513",
+        " ********************************************************************************/"
+      ]
     }
-},
-"fileHeaderComment.template":{
-    "*":[
-        "${commentbegin}",
-        "${commentprefix} ${license_w3c}",
-        "${commentend}"
-    ]
-},
+  },
+  "fileHeaderComment.template": {
+    "*": ["${commentbegin}", "${commentprefix} ${license_w3c}", "${commentend}"]
+  },
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
     "**/.hg": true,
     "**/.DS_Store": true,
-    "src/**/*.js" : true,
-    "test/**/*.js" : true
-  }
-  
+    "src/**/*.js": true,
+    "test/**/*.js": true
+  },
+  "prettier.singleQuote": false
 }


### PR DESCRIPTION
This PR adds (provisional) support for properties and actions (see #476). From here we can continue implementing a websocket subprotocol as described in #476 and taking both the discussions over at [wot-profile](https://github.com/w3c/wot-profile) and [Web Thing Protocol](https://iot.mozilla.org/wot/#web-thing-websocket-api) into consideration.

Note: I directly edited the .vscode/settings.json to add a rule to disable singleQuotes (override my own vscode settings) and prevent noisy commits. The commit was however still noisy due to difference in tabs and spaces (sorry for that). Maybe #239  could be revisited as the project settings did not override my own users settings as it should be. Maybe I missed some setup.

Regarding testing, I couldn't get it to work on my machine (throwing several build errors). Code might therefore need some refinement but I decided to push anyways as to progressively work on (and test) this PR. 