### PR TITLE
chore(binding-coap): bump node-coap to 0.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4338,9 +4338,9 @@
       }
     },
     "node_modules/coap": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/coap/-/coap-0.24.0.tgz",
-      "integrity": "sha512-8qn5JMHrbM8sX9PWIWsjZ4/WLJE3g/uvGMdS5v4rggL92+Cp5CReT81ohmF8US7CRD3KIAlWYrnJ3ghlu1WyXA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/coap/-/coap-0.25.0.tgz",
+      "integrity": "sha512-cSuTF/LjDStysP3ihJSoEYRUXGgevjPt4ft4l8tj+4QP/S/DXUOlzEfHwfG1VQZfoD2RV9kf/8QufKmQY9smMQ==",
       "dependencies": {
         "bl": "^4.0.2",
         "capitalize": "^2.0.3",
@@ -22145,7 +22145,7 @@
       "license": "EPL-2.0 OR W3C-20150513",
       "dependencies": {
         "@node-wot/core": "0.8.0",
-        "coap": "0.24.0",
+        "coap": "0.25.0",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",
@@ -25490,7 +25490,7 @@
         "@types/chai": "4.2.8",
         "@types/node": "13.7.0",
         "chai": "4.2.0",
-        "coap": "0.24.0",
+        "coap": "0.25.0",
         "mocha": "3.5.3",
         "mocha-typescript": "1.1.8",
         "node-coap-client": "1.0.8",
@@ -30118,9 +30118,9 @@
       "dev": true
     },
     "coap": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/coap/-/coap-0.24.0.tgz",
-      "integrity": "sha512-8qn5JMHrbM8sX9PWIWsjZ4/WLJE3g/uvGMdS5v4rggL92+Cp5CReT81ohmF8US7CRD3KIAlWYrnJ3ghlu1WyXA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/coap/-/coap-0.25.0.tgz",
+      "integrity": "sha512-cSuTF/LjDStysP3ihJSoEYRUXGgevjPt4ft4l8tj+4QP/S/DXUOlzEfHwfG1VQZfoD2RV9kf/8QufKmQY9smMQ==",
       "requires": {
         "bl": "^4.0.2",
         "capitalize": "^2.0.3",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@node-wot/core": "0.8.0",
-    "coap": "0.24.0",
+    "coap": "0.25.0",
     "node-coap-client": "1.0.8",
     "rxjs": "5.5.11",
     "slugify": "^1.4.5",


### PR DESCRIPTION
This PR updates the `coap` package used in the `binding-coap` package. As the new version now also supports the `application/td+json` Content-Format, this PR makes it possible to also fetch TDs which are provided as such without throwing an error.

This behavior fixed in the new version in general, so an invalid Content-Format cannot cause an application to crash anymore.