### PR TITLE
chore: Add linting and code style checks to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,3 +47,19 @@ jobs:
       uses: icrawl/action-eslint@v1
       with:
         custom-glob: packages
+
+  prettier:
+    name: Check coding style
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install node v12
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: yarn install
+      run: yarn install
+    - name: Prettify code
+      uses: creyD/prettier_action@v4.0
+      with:
+        dry: True

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,19 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install node v12
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: yarn install
+      run: yarn install
+    - name: eslint
+      uses: icrawl/action-eslint@v1
+      with:
+        custom-glob: packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,13 @@ Simplify the API by reducing the number of functions.
 
 Closes #110
 BREAKING CHANGE: Change all calls to the API to the new `do()` function.
-``` 
+```
+
+## Coding Style
+
+Eclipse Thingweb uses `eslint` and `prettier` to enforce a consistent coding style.
+A Github Actions workflow checks for each Pull Request if the coding style is followed and creates annotations in the "files changed" tab for each warning that is emitted during this linting process.
+To avoid such warnings, please use `npm run lint` for linting your code and `npm run format` to automatically apply fixes before committing any changes.
 
 ## Pull Requests and Feature Branches
 


### PR DESCRIPTION
This PR is intended to be a follow-up to #493 and adds both a linting action (using eslint) and style check action (using prettier) to the CI. Both actions are currently failing because there the code base is not yet formatted correctly but once #493 is completed all checks will hopefully turn green :)

I am not sure yet, however, if the prettier action is configured correctly (or if it should be swapped out for a similar prettier action) as it does not add annotations in the "files changed" tab yet. I will have a look into that.