### PR TITLE
fix: http server reporting circular structure

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -749,20 +749,21 @@ export default class HttpServer implements ProtocolServer {
                                         .observeProperty(
                                             segments[3],
                                             async (value: InteractionOutput) => {
-                                                let content;
                                                 try {
                                                     const contentType = ProtocolHelpers.getPropertyContentType(
                                                         thing.getThingDescription(),
                                                         segments[3],
                                                         "http"
                                                     );
-                                                    content = ContentSerdes.get().valueToContent(
+                                                    const content = ContentSerdes.get().valueToContent(
                                                         value.data && !value.dataUsed
                                                             ? value.data
                                                             : await value.value(),
                                                         property.data,
                                                         contentType
                                                     );
+                                                    // send event data
+                                                    content.body.pipe(res);
                                                 } catch (err) {
                                                     console.warn(
                                                         "[binding-http]",
@@ -774,8 +775,6 @@ export default class HttpServer implements ProtocolServer {
                                                     res.end("Invalid Event Data");
                                                     return;
                                                 }
-                                                // send event data
-                                                content.body.pipe(res);
                                             },
                                             options
                                         )
@@ -979,18 +978,19 @@ export default class HttpServer implements ProtocolServer {
                                     .subscribeEvent(
                                         segments[3],
                                         async (value) => {
-                                            let content;
                                             try {
                                                 const contentType = ProtocolHelpers.getEventContentType(
                                                     thing.getThingDescription(),
                                                     segments[3],
                                                     "http"
                                                 );
-                                                content = ContentSerdes.get().valueToContent(
+                                                const content = ContentSerdes.get().valueToContent(
                                                     value.data && !value.dataUsed ? value.data : await value.value(),
                                                     event.data,
                                                     contentType
                                                 );
+                                                // send event data
+                                                content.body.pipe(res);
                                             } catch (err) {
                                                 console.warn(
                                                     "[binding-http]",
@@ -1002,8 +1002,6 @@ export default class HttpServer implements ProtocolServer {
                                                 res.end("Invalid Event Data");
                                                 return;
                                             }
-                                            // send event data
-                                            content.body.pipe(res);
                                         },
                                         options
                                     )

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -919,7 +919,7 @@ export default class HttpServer implements ProtocolServer {
                                     thing
                                         .invokeAction(segments[3], input, options)
                                         .then(async (output: InteractionOutput) => {
-                                            if (output) {
+                                            if (output && action.output) {
                                                 const contentType = ProtocolHelpers.getActionContentType(
                                                     thing.getThingDescription(),
                                                     segments[3],

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -26,10 +26,11 @@ import * as url from "url";
 import { AddressInfo } from "net";
 
 import * as TD from "@node-wot/td-tools";
-import Servient, { ProtocolServer, ContentSerdes, Helpers, ExposedThing, ProtocolHelpers } from "@node-wot/core";
+import Servient, { ProtocolServer, ContentSerdes, Helpers, ExposedThing, ProtocolHelpers, Content } from "@node-wot/core";
 import { HttpConfig, HttpForm, OAuth2ServerConfig } from "./http";
 import createValidator, { Validator } from "./oauth-token-validation";
 import { OAuth2SecurityScheme } from "@node-wot/td-tools";
+import { InteractionOutput } from "@node-wot/core/dist/interaction-output";
 
 export default class HttpServer implements ProtocolServer {
     public readonly scheme: "http" | "https";
@@ -769,21 +770,21 @@ export default class HttpServer implements ProtocolServer {
                                 } else {
                                     thing
                                         .readProperty(segments[3], options)
-                                        // property.read(options)
-                                        .then((value: any) => {
+                                        .then(async (value: InteractionOutput) => {
                                             const contentType = ProtocolHelpers.getPropertyContentType(
                                                 thing.getThingDescription(),
                                                 segments[3],
                                                 "http"
                                             );
-                                            const content = ContentSerdes.get().valueToContent(
+                                            /*const content = ContentSerdes.get().valueToContent(
                                                 value,
                                                 <any>property,
                                                 contentType
-                                            );
-                                            res.setHeader("Content-Type", content.type);
+                                            );*/
+                                            res.setHeader("Content-Type", contentType); // content.type);
                                             res.writeHead(200);
-                                            content.body.pipe(res);
+                                            res.end(await value.value() + "");
+                                            // content.body.pipe(res);
                                         })
                                         .catch((err) => {
                                             console.error(

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -26,7 +26,14 @@ import * as url from "url";
 import { AddressInfo } from "net";
 
 import * as TD from "@node-wot/td-tools";
-import Servient, { ProtocolServer, ContentSerdes, Helpers, ExposedThing, ProtocolHelpers, Content } from "@node-wot/core";
+import Servient, {
+    ProtocolServer,
+    ContentSerdes,
+    Helpers,
+    ExposedThing,
+    ProtocolHelpers,
+    Content,
+} from "@node-wot/core";
 import { HttpConfig, HttpForm, OAuth2ServerConfig } from "./http";
 import createValidator, { Validator } from "./oauth-token-validation";
 import { OAuth2SecurityScheme } from "@node-wot/td-tools";
@@ -783,7 +790,7 @@ export default class HttpServer implements ProtocolServer {
                                             );*/
                                             res.setHeader("Content-Type", contentType); // content.type);
                                             res.writeHead(200);
-                                            res.end(await value.value() + "");
+                                            res.end((await value.value()) + "");
                                             // content.body.pipe(res);
                                         })
                                         .catch((err) => {

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -112,6 +112,9 @@ class HttpServerTest {
         body = await (await fetch(uri + "properties/test")).text();
         expect(body).to.equal("off");
 
+        body = await (await fetch(uri + "all/properties")).text();
+        expect(body).to.equal('{"test":"off"}');
+
         body = await (await fetch(uri + "properties/test", { method: "PUT", body: "on" })).text();
         expect(body).to.equal("");
 

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -70,8 +70,7 @@ class HttpServerTest {
         await httpServer.stop();
     }
 
-    // TODO: unskip this test
-    @test.skip async "should change resource from 'off' to 'on' and try to invoke"() {
+    @test async "should change resource from 'off' to 'on' and try to invoke"() {
         const httpServer = new HttpServer({ port: 0 });
 
         await httpServer.start(null);
@@ -111,16 +110,16 @@ class HttpServerTest {
         console.log("Testing", uri);
 
         body = await (await fetch(uri + "properties/test")).text();
-        expect(body).to.equal('"off"');
+        expect(body).to.equal("off");
 
         body = await (await fetch(uri + "properties/test", { method: "PUT", body: "on" })).text();
         expect(body).to.equal("");
 
         body = await (await fetch(uri + "properties/test")).text();
-        expect(body).to.equal('"on"');
+        expect(body).to.equal("on");
 
         body = await (await fetch(uri + "actions/try", { method: "POST", body: "toggle" })).text();
-        expect(body).to.equal('"TEST"');
+        expect(body).to.equal("TEST");
 
         return httpServer.stop();
     }

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -95,7 +95,7 @@ class HttpServerTest {
         });
         await testThing.writeProperty("test", "off");
         testThing.properties.test.forms = [];
-        testThing.setActionHandler("try", (input) => {
+        testThing.setActionHandler("try", (input: WoT.InteractionOutput) => {
             return new Promise<string>((resolve, reject) => {
                 resolve("TEST");
             });
@@ -105,24 +105,27 @@ class HttpServerTest {
         await httpServer.expose(testThing);
 
         const uri = `http://localhost:${httpServer.getPort()}/test/`;
-        let body;
+        let resp;
 
         console.log("Testing", uri);
 
-        body = await (await fetch(uri + "properties/test")).text();
-        expect(body).to.equal("off");
+        resp = await (await fetch(uri + "properties/test")).text();
+        expect(resp).to.equal("off");
 
-        body = await (await fetch(uri + "all/properties")).text();
-        expect(body).to.equal('{"test":"off"}');
+        resp = await (await fetch(uri + "all/properties")).text();
+        expect(resp).to.equal('{"test":"off"}');
 
-        body = await (await fetch(uri + "properties/test", { method: "PUT", body: "on" })).text();
-        expect(body).to.equal("");
+        resp = await (await fetch(uri + "properties/test", { method: "PUT", body: "on" })).text();
+        expect(resp).to.equal("");
 
-        body = await (await fetch(uri + "properties/test")).text();
-        expect(body).to.equal("on");
+        resp = await (await fetch(uri + "properties/test")).text();
+        expect(resp).to.equal("on");
 
-        body = await (await fetch(uri + "actions/try", { method: "POST", body: "toggle" })).text();
-        expect(body).to.equal("TEST");
+        resp = await (await fetch(uri + "actions/try", { method: "POST", body: "toggle" })).text();
+        expect(resp).to.equal("TEST");
+
+        resp = await (await fetch(uri + "actions/try", { method: "POST", body: undefined })).text();
+        expect(resp).to.equal("TEST");
 
         return httpServer.stop();
     }

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -295,10 +295,8 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                     ps.readHandler(options)
                         .then((customValue) => {
                             const body = ExposedThing.interactionInputToReadable(customValue);
-                            let c : Content = {body : body, type: "application/json"};
-                            resolve(
-                                new InteractionOutput(c, undefined, this.properties[propertyName])
-                            );
+                            let c: Content = { body: body, type: "application/json" };
+                            resolve(new InteractionOutput(c, undefined, this.properties[propertyName]));
                         })
                         .catch((err) => {
                             reject(err);
@@ -309,7 +307,13 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                         `ExposedThing '${this.title}' gets internal value '${ps.value}' for Property '${propertyName}'`
                     );
                     const body = ExposedThing.interactionInputToReadable(ps.value);
-                    resolve(new InteractionOutput({ body, type: "application/json" }, undefined, this.properties[propertyName]));
+                    resolve(
+                        new InteractionOutput(
+                            { body, type: "application/json" },
+                            undefined,
+                            this.properties[propertyName]
+                        )
+                    );
                 }
             } else {
                 reject(new Error(`ExposedThing '${this.title}', no property found for '${propertyName}'`));
@@ -481,12 +485,20 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                 let body = ExposedThing.interactionInputToReadable(parameter);
 
                 const result = await as.handler(
-                    new InteractionOutput({ body, type: "application/json" }, undefined, this.actions[actionName].input),
+                    new InteractionOutput(
+                        { body, type: "application/json" },
+                        undefined,
+                        this.actions[actionName].input
+                    ),
                     options
                 );
 
                 body = ExposedThing.interactionInputToReadable(result);
-                return new InteractionOutput({ body, type: "application/json" }, undefined, this.actions[actionName].output);
+                return new InteractionOutput(
+                    { body, type: "application/json" },
+                    undefined,
+                    this.actions[actionName].output
+                );
             } else {
                 throw new Error(`ExposedThing '${this.title}' has no handler for Action '${actionName}'`);
             }

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -482,23 +482,23 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                     "[core/exposed-thing]",
                     `ExposedThing '${this.title}' calls registered handler for Action '${actionName}'`
                 );
-                let body = ExposedThing.interactionInputToReadable(parameter);
+                let bodyInput;
+                if (parameter) {
+                    bodyInput = ExposedThing.interactionInputToReadable(parameter);
+                }
 
+                let cInput: Content = { body: bodyInput, type: "application/json" };
                 const result = await as.handler(
-                    new InteractionOutput(
-                        { body, type: "application/json" },
-                        undefined,
-                        this.actions[actionName].input
-                    ),
+                    new InteractionOutput(cInput, undefined, this.actions[actionName].input),
                     options
                 );
 
-                body = ExposedThing.interactionInputToReadable(result);
-                return new InteractionOutput(
-                    { body, type: "application/json" },
-                    undefined,
-                    this.actions[actionName].output
-                );
+                let bodyOutput;
+                if (result) {
+                    bodyOutput = ExposedThing.interactionInputToReadable(result);
+                }
+                let cOutput: Content = { body: bodyOutput, type: "application/json" };
+                return new InteractionOutput(cOutput, undefined, this.actions[actionName].output);
             } else {
                 throw new Error(`ExposedThing '${this.title}' has no handler for Action '${actionName}'`);
             }

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -25,6 +25,7 @@ import { InteractionOutput } from "./interaction-output";
 import { Readable } from "stream";
 import ProtocolHelpers from "./protocol-helpers";
 import { ReadableStream as PolyfillStream } from "web-streams-polyfill/ponyfill/es2018";
+import { Content } from "./core";
 
 export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
     security: Array<string>;
@@ -294,8 +295,9 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                     ps.readHandler(options)
                         .then((customValue) => {
                             const body = ExposedThing.interactionInputToReadable(customValue);
+                            let c : Content = {body : body, type: "application/json"};
                             resolve(
-                                new InteractionOutput({ body, type: "application/json" }, this.properties[propertyName])
+                                new InteractionOutput(c, undefined, this.properties[propertyName])
                             );
                         })
                         .catch((err) => {
@@ -307,7 +309,7 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                         `ExposedThing '${this.title}' gets internal value '${ps.value}' for Property '${propertyName}'`
                     );
                     const body = ExposedThing.interactionInputToReadable(ps.value);
-                    resolve(new InteractionOutput({ body, type: "application/json" }, this.properties[propertyName]));
+                    resolve(new InteractionOutput({ body, type: "application/json" }, undefined, this.properties[propertyName]));
                 }
             } else {
                 reject(new Error(`ExposedThing '${this.title}', no property found for '${propertyName}'`));
@@ -479,12 +481,12 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                 let body = ExposedThing.interactionInputToReadable(parameter);
 
                 const result = await as.handler(
-                    new InteractionOutput({ body, type: "application/json" }, this.actions[actionName].input),
+                    new InteractionOutput({ body, type: "application/json" }, undefined, this.actions[actionName].input),
                     options
                 );
 
                 body = ExposedThing.interactionInputToReadable(result);
-                return new InteractionOutput({ body, type: "application/json" }, this.actions[actionName].output);
+                return new InteractionOutput({ body, type: "application/json" }, undefined, this.actions[actionName].output);
             } else {
                 throw new Error(`ExposedThing '${this.title}' has no handler for Action '${actionName}'`);
             }

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -68,11 +68,11 @@ export class InteractionOutput implements WoT.InteractionOutput {
 
         const validate = ajv.compile<T>(this.schema);
 
-        // is content type vaild?
-        if (!this.form || !ContentSerdes.get().isSupported(this.content.type)) {
+        // is content type valid?
+        /* if (!this.form || !ContentSerdes.get().isSupported(this.content.type)) {
             const message = !this.form ? "Missing form" : `Content type ${this.content.type} not supported`;
             throw new NotSupportedError(message);
-        }
+        } */
         // read fully the stream
 
         const data = await ProtocolHelpers.readStreamFully(this.content.body);

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -69,10 +69,10 @@ export class InteractionOutput implements WoT.InteractionOutput {
         const validate = ajv.compile<T>(this.schema);
 
         // is content type valid?
-        /* if (!this.form || !ContentSerdes.get().isSupported(this.content.type)) {
+        if (!this.form || !ContentSerdes.get().isSupported(this.content.type)) {
             const message = !this.form ? "Missing form" : `Content type ${this.content.type} not supported`;
             throw new NotSupportedError(message);
-        } */
+        }
         // read fully the stream
 
         const data = await ProtocolHelpers.readStreamFully(this.content.body);

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -42,7 +42,9 @@ export class InteractionOutput implements WoT.InteractionOutput {
         this.form = form;
         this.schema = schema;
 
-        this.data = ProtocolHelpers.toWoTStream(content.body);
+        if (content && content.body) {
+            this.data = ProtocolHelpers.toWoTStream(content.body);
+        }
     }
 
     async arrayBuffer(): Promise<ArrayBuffer> {


### PR DESCRIPTION
Note: this PR is not meant to be merged as is.

I just run the counter sample and with the current code I get

```
[binding-http] HttpServer on port 8080 got internal error on read '/counter/properties/count': Converting circular structure to JSON
    --> starting at object with constructor 'ReadableStream'
    |     property '_readableStreamController' -> object with constructor 'ReadableStreamDefaultController'
    --- property '_controlledReadableStream' closes the circle
```

I tried to fix it but I am not sure whether this is the right way...