### PR TITLE
fix(binding-mqtt): fix 'TypeError: error is not a function"'

### DIFF
--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -67,13 +67,13 @@ export default class MqttClient implements ProtocolClient {
                 next({ type: contentType, body: Readable.from(payload) });
             }
         });
-        this.client.on("error", (error: any) => {
+        this.client.on("error", (err: any) => {
             if (this.client) {
                 this.client.end();
             }
             this.client == undefined;
             // TODO: error handling
-            error(error);
+            error(err);
         });
 
         return new Subscription(() => {


### PR DESCRIPTION
I found a minor bug in the `binding-mqtt/src/mqtt-client.js` lines 70 and 76 with a duplicate `error` definition (in subscribeResource() and then again in "error" handler).

This PR simply changes lines 70 and 76 to fix this.

This was throwing the following error:

```bash
[ERROR] 17:13:25 TypeError: error is not a function
```