### PR TITLE
fix(coap): Remove double registration of TD content-format

### DIFF
--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -43,10 +43,6 @@ export default class CoapClient implements ProtocolClient {
 
         // WoT-specific content formats
         coap.registerFormat(ContentSerdes.JSON_LD, 2100);
-        // TODO also register content fromat with IANA
-        // from experimental range for now
-        coap.registerFormat(ContentSerdes.TD, 65100);
-        // TODO need hook from ContentSerdes for runtime data formats
     }
 
     public toString(): string {

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -48,10 +48,6 @@ export default class CoapServer implements ProtocolServer {
 
         // WoT-specific content formats
         coap.registerFormat(ContentSerdes.JSON_LD, 2100);
-        // TODO also register content fromat with IANA
-        // from experimental range for now
-        coap.registerFormat(ContentSerdes.TD, 65100);
-        // TODO need hook from ContentSerdes for runtime data formats
     }
 
     public start(servient: Servient): Promise<void> {


### PR DESCRIPTION
This PR removes the unnecessary registration of the content-format `application/td+json` from the coap package. It is now supported [by default](https://github.com/mcollina/node-coap#coapregisterformatname-value) in `node-coap`, using the correct [IANA ID 432](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats).