### PR TITLE
chore: ignore dist folder in formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package-lock.json
+**/dist


### PR DESCRIPTION
A trivial PR that just ignore dist folders for prettier