### PR TITLE
fix: allow invokeResource without any parameter (CoAP client)

### DIFF
--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -270,7 +270,7 @@ export default class ProtocolHelpers {
             } else {
                 console.debug(
                     "[core/helpers]",
-                    `Protocol-Helper returns empty buffer for readStreamFully due to undefined strem`
+                    `Protocol-Helper returns empty buffer for readStreamFully due to undefined stream`
                 );
                 resolve(Buffer.alloc(0));
             }

--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -253,19 +253,27 @@ export default class ProtocolHelpers {
 
     static readStreamFully(stream: NodeJS.ReadableStream): Promise<Buffer> {
         return new Promise<Buffer>((resolve, reject) => {
-            const chunks: Array<unknown> = [];
-            stream.on("data", (data) => chunks.push(data));
-            stream.on("error", reject);
-            stream.on("end", () => {
-                if (
-                    chunks[0] &&
-                    (chunks[0] instanceof Array || chunks[0] instanceof Buffer || chunks[0] instanceof Uint8Array)
-                ) {
-                    resolve(Buffer.concat(chunks as Array<Buffer | Uint8Array>));
-                } else {
-                    resolve(Buffer.from(chunks as Array<number>));
-                }
-            });
+            if (stream) {
+                const chunks: Array<unknown> = [];
+                stream.on("data", (data) => chunks.push(data));
+                stream.on("error", reject);
+                stream.on("end", () => {
+                    if (
+                        chunks[0] &&
+                        (chunks[0] instanceof Array || chunks[0] instanceof Buffer || chunks[0] instanceof Uint8Array)
+                    ) {
+                        resolve(Buffer.concat(chunks as Array<Buffer | Uint8Array>));
+                    } else {
+                        resolve(Buffer.from(chunks as Array<number>));
+                    }
+                });
+            } else {
+                console.debug(
+                    "[core/helpers]",
+                    `Protocol-Helper returns empty buffer for readStreamFully due to undefined strem`
+                );
+                resolve(Buffer.alloc(0));
+            }
         });
     }
 }


### PR DESCRIPTION
fixes https://github.com/eclipse/thingweb.node-wot/issues/522

Note1: tested with counter sample using CoAP for all forms.

Note2: I would like to tackle https://github.com/eclipse/thingweb.node-wot/issues/523 in a separate PR.