### PR TITLE
chore: add missing eslint and prettier configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,10 +233,6 @@
             "resolved": "packages/binding-opcua",
             "link": true
         },
-        "node_modules/@node-wot/binding-opcua2": {
-            "resolved": "packages/binding-opcua2",
-            "link": true
-        },
         "node_modules/@node-wot/binding-oracle": {
             "resolved": "packages/binding-oracle",
             "link": true
@@ -9889,6 +9885,7 @@
                 "prettier": "^2.3.2",
                 "ts-node": "10.1.0",
                 "typescript": "4.1.3",
+                "typescript-standard": "^0.3.36",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
             }
         },
@@ -9949,6 +9946,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "modbus-serial": "^8.0.3",
+                "rxjs": "5.5.11",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
             },
             "devDependencies": {
@@ -10084,6 +10082,7 @@
         "packages/binding-opcua2": {
             "name": "@node-wot/binding-opcua2",
             "version": "0.8.0",
+            "extraneous": true,
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "@node-wot/core": "0.8.0",
@@ -10518,6 +10517,7 @@
                 "prettier": "^2.3.2",
                 "ts-node": "10.1.0",
                 "typescript": "4.1.3",
+                "typescript-standard": "^0.3.36",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
                 "ws": "^7.5.4"
             }
@@ -10591,6 +10591,7 @@
                 "mocha": "^9.1.1",
                 "modbus-serial": "^8.0.3",
                 "prettier": "^2.3.2",
+                "rxjs": "5.5.11",
                 "ts-node": "10.1.0",
                 "typescript": "4.1.3",
                 "typescript-standard": "^0.3.36",
@@ -10683,29 +10684,6 @@
                 "node-opcua-client": "~2.45.0",
                 "prettier": "^2.3.2",
                 "rxjs": "5.5.11",
-                "ts-node": "10.1.0",
-                "typescript": "4.1.3",
-                "typescript-standard": "^0.3.36",
-                "url-parse": "^1.5.3",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
-                "xml-writer": "^1.7.0"
-            }
-        },
-        "@node-wot/binding-opcua2": {
-            "version": "file:packages/binding-opcua2",
-            "requires": {
-                "@node-wot/core": "0.8.0",
-                "@node-wot/td-tools": "0.8.0",
-                "@types/chai": "^4.2.18",
-                "@types/mocha": "^9.0.0",
-                "@types/node": "16.4.13",
-                "@types/url-parse": "^1.4.3",
-                "case-1.5.3": "npm:case@^1.5.3",
-                "chai": "^4.3.4",
-                "chai-spies": "^1.0.0",
-                "mocha": "^9.1.1",
-                "node-opcua": "~2.45.0",
-                "node-opcua-client": "~2.45.0",
                 "ts-node": "10.1.0",
                 "typescript": "4.1.3",
                 "typescript-standard": "^0.3.36",

--- a/packages/binding-fujitsu/package.json
+++ b/packages/binding-fujitsu/package.json
@@ -28,6 +28,7 @@
         "prettier": "^2.3.2",
         "ts-node": "10.1.0",
         "typescript": "4.1.3",
+        "typescript-standard": "^0.3.36",
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
     },
     "dependencies": {
@@ -36,10 +37,20 @@
         "ws": "^7.5.4"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"
     },
-    "homepage": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-fujitsu#readme"
+    "homepage": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-fujitsu#readme",
+    "eslintConfig": {
+        "extends": "../../.eslintrc.json",
+        "parserOptions": {
+            "project": [
+                "./tsconfig.json"
+            ]
+        }
+    }
 }

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -18,10 +18,20 @@
         "@types/chai-as-promised": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "16.4.13",
+        "@typescript-eslint/eslint-plugin": "^4.30.0",
+        "@typescript-eslint/parser": "^4.30.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-config-standard": "^16.0.3",
+        "eslint-plugin-import": "^2.24.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^5.1.0",
+        "eslint-plugin-unused-imports": "^1.1.4",
         "mocha": "^9.1.1",
+        "prettier": "^2.3.2",
         "ts-node": "10.1.0",
         "typescript": "4.1.3",
         "typescript-standard": "^0.3.36"
@@ -34,7 +44,9 @@
     },
     "scripts": {
         "build": "tsc",
-        "test": "mocha --require ts-node/register test/*"
+        "test": "mocha --require ts-node/register test/*",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"
@@ -42,5 +54,8 @@
     "homepage": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-mbus#readme",
     "directories": {
         "test": "test"
+    },
+    "eslintConfig": {
+        "extends": "../../.eslintrc.json"
     }
 }

--- a/packages/binding-mqtt/.eslintrc.json
+++ b/packages/binding-mqtt/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    }
+}

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -42,7 +42,9 @@
     },
     "scripts": {
         "build": "tsc",
-        "test": "mocha --require ts-node/register --extension ts"
+        "test": "mocha --require ts-node/register --extension ts",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/binding-netconf/.eslintrc.json
+++ b/packages/binding-netconf/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    }
+}

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -46,7 +46,9 @@
     },
     "scripts": {
         "build": "tsc",
-        "test": "mocha --require ts-node/register test/netconf-client-test.ts"
+        "test": "mocha --require ts-node/register test/netconf-client-test.ts",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -49,7 +49,8 @@
     "scripts": {
         "build": "tsc",
         "test": "mocha --require ts-node/register test/opcua-client-test.ts",
-        "lint": "eslint src test"
+        "lint": "eslint src test",
+        "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/binding-oracle/.eslintrc.json
+++ b/packages/binding-oracle/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    }
+}

--- a/packages/binding-oracle/package.json
+++ b/packages/binding-oracle/package.json
@@ -30,7 +30,9 @@
         "iotcs-csl-js": "19.1.5"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/binding-websockets/.eslintrc.json
+++ b/packages/binding-websockets/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    }
+}

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -45,7 +45,9 @@
     },
     "scripts": {
         "build": "tsc",
-        "test": "mocha --require ts-node/register --extension ts"
+        "test": "mocha --require ts-node/register --extension ts",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/browser-bundle/.eslintrc.json
+++ b/packages/browser-bundle/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../.eslintrc.json"
+}

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -22,7 +22,9 @@
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
     },
     "scripts": {
-        "build": "browserify -r vm:vm2 index.js --plugin tinyify --external coffee-script -o dist/wot-bundle.min.js"
+        "build": "browserify -r vm:vm2 index.js --plugin tinyify --external coffee-script -o dist/wot-bundle.min.js",
+        "lint": "eslint .",
+        "format": "prettier --write index.js \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,5 +62,14 @@
     "directories": {
         "test": "test"
     },
-    "keywords": []
+    "keywords": [],
+    "eslintConfig": {
+        "extends": "../../.eslintrc.json",
+        "parserOptions": {
+            "project": [
+                "./tsconfig.json",
+                "./test.tsconfig.json"
+            ]
+        }
+    }
 }

--- a/packages/examples/.eslintrc.json
+++ b/packages/examples/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../.eslintrc.json",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    }
+}

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -37,7 +37,9 @@
         "rxjs": "5.5.11"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "lint": "eslint .",
+        "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"


### PR DESCRIPTION
This PR should resolve #530 by adding missing eslint and prettier configs. At the moment, I added the additional eslint configs to the package.json files as I thought it might make the packages cleaner in general. However, I now think it might be better to have separate `.eslintrc.json` files to make it easier to see if an eslint configuration exists. Let me know what you think about this :)

There is currently still an issue in the `examples` package where the `npm run lint` script fails with the following error message:

```
Oops! Something went wrong! :(

ESLint: 7.32.0

No files matching the pattern "." were found.
Please check for typing mistakes in the pattern.
```

Do you have an idea how to fix this?