### PR TITLE
fix: align CoAP vocabulary with current binding-templates

### DIFF
--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -27,14 +27,16 @@ export * from "./coap-client";
 export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
-export class CoapForm extends Form {
-    public "coap:methodCode"?: number; // 1=0.01=GET, 2=0.02=POST, 3=0.03=PUT, 4=0.04=DELETE
-    public "coap:options"?: Array<CoapOption> | CoapOption;
+export class CoapOption {
+    public "cov:optionName": number;
+    public "cov:optionValue": any;
 }
 
-export class CoapOption {
-    public "coap:optionCode": number;
-    public "coap:optionValue": any;
+export type CoapMethodName = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
+
+export class CoapForm extends Form {
+    public "cov:methodName"?: CoapMethodName;
+    public "cov:options"?: Array<CoapOption> | CoapOption;
 }
 
 export declare interface CoapRequestConfig {

--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -39,6 +39,30 @@ export class CoapForm extends Form {
     public "cov:options"?: Array<CoapOption> | CoapOption;
 }
 
+/**
+ * Checks if a given method name is valid against the CoAP binding templates.
+ *
+ * Valid method names are `GET`, `POST`, `PUT`, `DELETE`, `FETCH`, `PATCH`, and `iPATCH`.
+ *
+ * @param methodName The method name to check.
+ * @returns `true` if the given `methodName` is valid.
+ */
+export function isValidCoapMethod(methodName: CoapMethodName): methodName is CoapMethodName {
+    return ["GET", "POST", "PUT", "DELETE", "FETCH", "PATCH", "iPATCH"].includes(methodName);
+}
+
+/**
+ * Checks if a given method name is supported by the current CoAP implementation.
+ *
+ * Valid method names are `GET`, `POST`, `PUT`, and `DELETE`.
+ *
+ * @param methodName The method name to check.
+ * @returns `true` if the given `methodName` is supported.
+ */
+export function isSupportedCoapMethod(methodName: CoapMethodName): methodName is CoapMethodName {
+    return ["GET", "POST", "PUT", "DELETE"].includes(methodName);
+}
+
 export declare interface CoapRequestConfig {
     agent?: Object;
     hostname?: string;

--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -109,7 +109,7 @@ class CoapClientTest {
 
             const form: CoapForm = {
                 href: "coap://127.0.0.1:56834",
-                "coap:methodCode": 1,
+                "cov:methodName": "GET",
             };
 
             coapClient


### PR DESCRIPTION
While having a look at the current CoAP implementation in the context of #523, I noticed that the vocabulary that is being used is not up to date with the current binding-templates. This PR should fix this and should provide the basis for fixing #523.