### PR TITLE
feat(coap): update type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "workspaces": [
                 "./packages/td-tools",
                 "./packages/core",
-                "./packages/binding-!(firestore-browser-bundle|mbus|firestore)",
+                "./packages/binding-!(firestore-browser-bundle|firestore)",
                 "./packages/cli",
                 "./packages/examples"
             ],
@@ -710,6 +710,10 @@
             "resolved": "packages/binding-http",
             "link": true
         },
+        "node_modules/@node-wot/binding-mbus": {
+            "resolved": "packages/binding-mbus",
+            "link": true
+        },
         "node_modules/@node-wot/binding-modbus": {
             "resolved": "packages/binding-modbus",
             "link": true
@@ -1064,6 +1068,15 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/bl": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
+            "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/readable-stream": "*"
+            }
+        },
         "node_modules/@types/bluebird": {
             "version": "3.5.36",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
@@ -1225,8 +1238,7 @@
         "node_modules/@types/node": {
             "version": "16.4.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-            "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
-            "dev": true
+            "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
         },
         "node_modules/@types/node-fetch": {
             "version": "2.5.12",
@@ -1275,7 +1287,6 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.11.tgz",
             "integrity": "sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "safe-buffer": "*"
@@ -2902,25 +2913,68 @@
             }
         },
         "node_modules/coap": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-0.25.0.tgz",
-            "integrity": "sha512-cSuTF/LjDStysP3ihJSoEYRUXGgevjPt4ft4l8tj+4QP/S/DXUOlzEfHwfG1VQZfoD2RV9kf/8QufKmQY9smMQ==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-0.26.0.tgz",
+            "integrity": "sha512-aRTrRToDLcZ68Ygxvbmc0/9XPQL3ypCeJQKMnitjH3HL/+ekh7REj7JZlG1mDsTwC7mDU2Zq9s4jo52BLNxAcg==",
             "dependencies": {
-                "bl": "^4.0.2",
+                "@types/bl": "^5.0.1",
+                "@types/node": "^16.10.1",
+                "bl": "^5.0.0",
                 "capitalize": "^2.0.3",
-                "coap-packet": "^0.1.14",
-                "debug": "^4.1.1",
+                "coap-packet": "^1.0.0",
+                "debug": "^4.3.2",
                 "fastseries": "^2.0.0",
-                "lru-cache": "^5.1.1",
+                "lru-cache": "^6.0.0",
                 "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/coap-packet": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/coap-packet/-/coap-packet-0.1.14.tgz",
-            "integrity": "sha1-OEgitnBau/MaDLxEnvejpkxPPlI=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/coap-packet/-/coap-packet-1.1.0.tgz",
+            "integrity": "sha512-7UrlPgj7ttnOEhmuxpWEQn4cRJlId7stJ2oMsQKFd9L8+Kt8tutssjwYhIHISPOvt9Td5IY/jk0LyDuhSpxsfw==",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/coap/node_modules/@types/node": {
+            "version": "16.11.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+            "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
+        },
+        "node_modules/coap/node_modules/bl": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+            "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+            "dependencies": {
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/coap/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/code-point-at": {
@@ -6248,11 +6302,14 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dependencies": {
-                "yallist": "^3.0.2"
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ltx": {
@@ -6709,8 +6766,7 @@
         "node_modules/nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "optional": true
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "node_modules/nanoid": {
             "version": "3.1.25",
@@ -6845,6 +6901,20 @@
             },
             "engines": {
                 "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/node-mbus": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/node-mbus/-/node-mbus-1.2.2.tgz",
+            "integrity": "sha512-Acc2Y04U5DHHQO3Bc05chUy0+vcsy07PeTU68HWV2KG8ckS44RNbXP1lfcPvb9ulwy0178pZpqWjO8f7Zp/WTg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "nan": "~2.14.2",
+                "xml2js": "^0.4.23"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/node-netconf": {
@@ -9623,22 +9693,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/semver/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        },
         "node_modules/send": {
             "version": "0.17.1",
             "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
@@ -11493,9 +11547,9 @@
             }
         },
         "node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -11625,7 +11679,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "@types/node": "16.4.13",
-                "coap": "0.25.0",
+                "coap": "^0.26.0",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -11725,6 +11779,39 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+            }
+        },
+        "packages/binding-mbus": {
+            "version": "0.8.0",
+            "license": "EPL-2.0 OR W3C-20150513",
+            "dependencies": {
+                "@node-wot/core": "0.8.0",
+                "@node-wot/td-tools": "0.8.0",
+                "node-mbus": "^1.2.2",
+                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+            },
+            "devDependencies": {
+                "@types/chai": "^4.2.18",
+                "@types/chai-as-promised": "^7.1.4",
+                "@types/mocha": "^9.0.0",
+                "@types/node": "16.4.13",
+                "@typescript-eslint/eslint-plugin": "^4.30.0",
+                "@typescript-eslint/parser": "^4.30.0",
+                "chai": "^4.3.4",
+                "chai-as-promised": "^7.1.1",
+                "chai-spies": "^1.0.0",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^8.3.0",
+                "eslint-config-standard": "^16.0.3",
+                "eslint-plugin-import": "^2.24.2",
+                "eslint-plugin-node": "^11.1.0",
+                "eslint-plugin-promise": "^5.1.0",
+                "eslint-plugin-unused-imports": "^1.1.4",
+                "mocha": "^9.1.1",
+                "prettier": "^2.3.2",
+                "ts-node": "10.1.0",
+                "typescript": "4.4.3",
+                "typescript-standard": "^0.3.36"
             }
         },
         "packages/binding-modbus": {
@@ -12595,7 +12682,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "0.25.0",
+                "coap": "^0.26.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -12641,7 +12728,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "@testdeck/mocha": "^0.1.2",
-                "@types/accept-language-parser": "*",
+                "@types/accept-language-parser": "^1.5.2",
                 "@types/basic-auth": "1.1.3",
                 "@types/chai": "^4.2.18",
                 "@types/chai-as-promised": "^7.1.4",
@@ -12675,6 +12762,36 @@
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
                 "ssestream": "1.0.0",
+                "ts-node": "10.1.0",
+                "typescript": "4.4.3",
+                "typescript-standard": "^0.3.36",
+                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+            }
+        },
+        "@node-wot/binding-mbus": {
+            "version": "file:packages/binding-mbus",
+            "requires": {
+                "@node-wot/core": "0.8.0",
+                "@node-wot/td-tools": "0.8.0",
+                "@types/chai": "^4.2.18",
+                "@types/chai-as-promised": "^7.1.4",
+                "@types/mocha": "^9.0.0",
+                "@types/node": "16.4.13",
+                "@typescript-eslint/eslint-plugin": "^4.30.0",
+                "@typescript-eslint/parser": "^4.30.0",
+                "chai": "^4.3.4",
+                "chai-as-promised": "^7.1.1",
+                "chai-spies": "^1.0.0",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^8.3.0",
+                "eslint-config-standard": "^16.0.3",
+                "eslint-plugin-import": "^2.24.2",
+                "eslint-plugin-node": "^11.1.0",
+                "eslint-plugin-promise": "^5.1.0",
+                "eslint-plugin-unused-imports": "^1.1.4",
+                "mocha": "^9.1.1",
+                "node-mbus": "^1.2.2",
+                "prettier": "^2.3.2",
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
@@ -13195,6 +13312,15 @@
                 "@types/node": "*"
             }
         },
+        "@types/bl": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
+            "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
+            "requires": {
+                "@types/node": "*",
+                "@types/readable-stream": "*"
+            }
+        },
         "@types/bluebird": {
             "version": "3.5.36",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
@@ -13356,8 +13482,7 @@
         "@types/node": {
             "version": "16.4.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-            "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
-            "dev": true
+            "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
         },
         "@types/node-fetch": {
             "version": "2.5.12",
@@ -13405,7 +13530,6 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.11.tgz",
             "integrity": "sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==",
-            "dev": true,
             "requires": {
                 "@types/node": "*",
                 "safe-buffer": "*"
@@ -14689,23 +14813,51 @@
             "dev": true
         },
         "coap": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-0.25.0.tgz",
-            "integrity": "sha512-cSuTF/LjDStysP3ihJSoEYRUXGgevjPt4ft4l8tj+4QP/S/DXUOlzEfHwfG1VQZfoD2RV9kf/8QufKmQY9smMQ==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-0.26.0.tgz",
+            "integrity": "sha512-aRTrRToDLcZ68Ygxvbmc0/9XPQL3ypCeJQKMnitjH3HL/+ekh7REj7JZlG1mDsTwC7mDU2Zq9s4jo52BLNxAcg==",
             "requires": {
-                "bl": "^4.0.2",
+                "@types/bl": "^5.0.1",
+                "@types/node": "^16.10.1",
+                "bl": "^5.0.0",
                 "capitalize": "^2.0.3",
-                "coap-packet": "^0.1.14",
-                "debug": "^4.1.1",
+                "coap-packet": "^1.0.0",
+                "debug": "^4.3.2",
                 "fastseries": "^2.0.0",
-                "lru-cache": "^5.1.1",
+                "lru-cache": "^6.0.0",
                 "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "16.11.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+                    "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
+                },
+                "bl": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+                    "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+                    "requires": {
+                        "buffer": "^6.0.3",
+                        "inherits": "^2.0.4",
+                        "readable-stream": "^3.4.0"
+                    }
+                },
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
+                }
             }
         },
         "coap-packet": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/coap-packet/-/coap-packet-0.1.14.tgz",
-            "integrity": "sha1-OEgitnBau/MaDLxEnvejpkxPPlI="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/coap-packet/-/coap-packet-1.1.0.tgz",
+            "integrity": "sha512-7UrlPgj7ttnOEhmuxpWEQn4cRJlId7stJ2oMsQKFd9L8+Kt8tutssjwYhIHISPOvt9Td5IY/jk0LyDuhSpxsfw=="
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -17227,11 +17379,11 @@
             "dev": true
         },
         "lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "requires": {
-                "yallist": "^3.0.2"
+                "yallist": "^4.0.0"
             }
         },
         "ltx": {
@@ -17579,8 +17731,7 @@
         "nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "optional": true
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "nanoid": {
             "version": "3.1.25",
@@ -17692,6 +17843,16 @@
             "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
             "requires": {
                 "whatwg-url": "^5.0.0"
+            }
+        },
+        "node-mbus": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/node-mbus/-/node-mbus-1.2.2.tgz",
+            "integrity": "sha512-Acc2Y04U5DHHQO3Bc05chUy0+vcsy07PeTU68HWV2KG8ckS44RNbXP1lfcPvb9ulwy0178pZpqWjO8f7Zp/WTg==",
+            "requires": {
+                "bindings": "^1.5.0",
+                "nan": "~2.14.2",
+                "xml2js": "^0.4.23"
             }
         },
         "node-netconf": {
@@ -20063,21 +20224,6 @@
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "requires": {
                 "lru-cache": "^6.0.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-                }
             }
         },
         "semver-diff": {
@@ -21494,9 +21640,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs": {
             "version": "16.2.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -34,10 +34,10 @@
         "typescript-standard": "^0.3.36"
     },
     "dependencies": {
-        "@types/node": "16.4.13",
-        "@node-wot/td-tools": "0.8.0",
         "@node-wot/core": "0.8.0",
-        "coap": "0.25.0",
+        "@node-wot/td-tools": "0.8.0",
+        "@types/node": "16.4.13",
+        "coap": "^0.26.0",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -26,32 +26,31 @@ import { Subscription } from "rxjs/Subscription";
 import * as TD from "@node-wot/td-tools";
 
 import { ProtocolClient, Content, ContentSerdes, ProtocolHelpers } from "@node-wot/core";
-import {
-    CoapForm,
-    CoapRequestConfig,
-    CoapOption,
-    CoapMethodName,
-    isSupportedCoapMethod,
-    isValidCoapMethod,
-} from "./coap";
+import { CoapForm, CoapOption, CoapMethodName, isSupportedCoapMethod, isValidCoapMethod } from "./coap";
 import CoapServer from "./coap-server";
 import { Readable } from "stream";
-import coap = require("coap");
+import {
+    Agent,
+    registerFormat,
+    AgentOptions,
+    CoapRequestParams,
+    IncomingMessage,
+    OutgoingMessage,
+    ObserveReadStream,
+} from "coap";
 
 export default class CoapClient implements ProtocolClient {
     // FIXME coap Agent closes socket when no messages in flight -> new socket with every request
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private agent: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly agentOptions: any;
+    private agent: Agent;
+    private readonly agentOptions: AgentOptions;
 
     constructor(server?: CoapServer) {
         // if server is passed, feed its socket into the CoAP agent for socket re-use
-        this.agent = new coap.Agent(server ? { socket: server.getSocket() } : undefined);
+        this.agent = new Agent(server ? { socket: server.getSocket() } : undefined);
         this.agentOptions = server ? { socket: server.getSocket() } : {};
 
         // WoT-specific content formats
-        coap.registerFormat(ContentSerdes.JSON_LD, 2100);
+        registerFormat(ContentSerdes.JSON_LD, 2100);
     }
 
     public toString(): string {
@@ -62,13 +61,12 @@ export default class CoapClient implements ProtocolClient {
         const req = await this.generateRequest(form, "GET");
         console.debug("[binding-coap]", `CoapClient sending ${req.statusCode} to ${form.href}`);
         return new Promise<Content>((resolve, reject) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            req.on("response", (res: any) => {
+            req.on("response", (res: ObserveReadStream) => {
                 console.debug("[binding-coap]", `CoapClient received ${res.code} from ${form.href}`);
                 console.debug("[binding-coap]", `CoapClient received Content-Format: ${res.headers["Content-Format"]}`);
 
                 // FIXME does not work with blockwise because of node-coap
-                let contentType = res.headers["Content-Format"];
+                let contentType = res.headers["Content-Format"] as string;
                 if (!contentType) contentType = form.contentType;
 
                 resolve({ type: contentType, body: Readable.from(res.payload) });
@@ -88,8 +86,7 @@ export default class CoapClient implements ProtocolClient {
 
                     console.debug("[binding-coap]", `CoapClient sending ${req.statusCode} to ${form.href}`);
 
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    req.on("response", (res: any) => {
+                    req.on("response", (res: IncomingMessage) => {
                         console.debug("[binding-coap]", `CoapClient received ${res.code} from ${form.href}`);
                         console.debug("[binding-coap]", `CoapClient received headers: ${JSON.stringify(res.headers)}`);
                         resolve();
@@ -109,12 +106,12 @@ export default class CoapClient implements ProtocolClient {
 
             console.debug("[binding-coap]", `CoapClient sending ${req.statusCode} to ${form.href}`);
 
-            req.on("response", (res: { code: string; headers: { "Content-Format"?: string }; payload: Buffer }) => {
+            req.on("response", (res: IncomingMessage) => {
                 console.debug("[binding-coap]", `CoapClient received ${res.code} from ${form.href}`);
                 console.debug("[binding-coap]", `CoapClient received Content-Format: ${res.headers["Content-Format"]}`);
                 console.debug("[binding-coap]", `CoapClient received headers: ${JSON.stringify(res.headers)}`);
-                const contentType = res.headers["Content-Format"];
-                resolve({ type: contentType || "", body: Readable.from(res.payload) });
+                const contentType = res.headers["Content-Format"] as string;
+                resolve({ type: contentType ?? "", body: Readable.from(res.payload) });
             });
             req.on("error", (err: Error) => reject(err));
             (async () => {
@@ -134,8 +131,7 @@ export default class CoapClient implements ProtocolClient {
 
             console.debug("[binding-coap]", `CoapClient sending ${req.statusCode} to ${form.href}`);
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            req.on("response", (res: any) => {
+            req.on("response", (res: IncomingMessage) => {
                 console.debug("[binding-coap]", `CoapClient received ${res.code} from ${form.href}`);
                 console.debug("[binding-coap]", `CoapClient received headers: ${JSON.stringify(res.headers)}`);
                 resolve();
@@ -156,8 +152,7 @@ export default class CoapClient implements ProtocolClient {
 
             console.debug("[binding-coap]", `CoapClient sending ${req.statusCode} to ${form.href}`);
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            req.on("response", (res: any) => {
+            req.on("response", (res: ObserveReadStream) => {
                 console.debug("[binding-coap]", `CoapClient received ${res.code} from ${form.href}`);
                 console.debug("[binding-coap]", `CoapClient received Content-Format: ${res.headers["Content-Format"]}`);
 
@@ -166,7 +161,7 @@ export default class CoapClient implements ProtocolClient {
                 if (!contentType) contentType = form.contentType;
 
                 res.on("data", (data: Buffer) => {
-                    next({ type: contentType, body: Readable.from(res.payload) });
+                    next({ type: `${contentType}`, body: Readable.from(res.payload) });
                 });
 
                 resolve(
@@ -197,14 +192,14 @@ export default class CoapClient implements ProtocolClient {
 
     public setSecurity = (metadata: Array<TD.SecurityScheme>): boolean => true;
 
-    private uriToOptions(uri: string): CoapRequestConfig {
+    private uriToOptions(uri: string): CoapRequestParams {
         // eslint-disable-next-line node/no-deprecated-api
         const requestUri = url.parse(uri);
         const agentOptions = this.agentOptions;
-        agentOptions.type = net.isIPv6(requestUri.hostname || "") ? "udp6" : "udp4";
-        this.agent = new coap.Agent(agentOptions);
+        agentOptions.type = net.isIPv6(requestUri.hostname ?? "") ? "udp6" : "udp4";
+        this.agent = new Agent(agentOptions);
 
-        const options: CoapRequestConfig = {
+        const options: CoapRequestParams = {
             agent: this.agent,
             hostname: requestUri.hostname || "",
             port: requestUri.port ? parseInt(requestUri.port, 10) : 5683,
@@ -220,7 +215,7 @@ export default class CoapClient implements ProtocolClient {
         return options;
     }
 
-    private determineRequestMethod(formMethod: CoapMethodName, defaultMethod: string) {
+    private determineRequestMethod(formMethod: CoapMethodName, defaultMethod: CoapMethodName): CoapMethodName {
         if (isSupportedCoapMethod(formMethod)) {
             return formMethod;
         } else if (isValidCoapMethod(formMethod)) {
@@ -240,9 +235,8 @@ export default class CoapClient implements ProtocolClient {
         return defaultMethod;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private generateRequest(form: CoapForm, defaultMethod: CoapMethodName, observable = false): any {
-        const options: CoapRequestConfig = this.uriToOptions(form.href);
+    private generateRequest(form: CoapForm, defaultMethod: CoapMethodName, observable = false): OutgoingMessage {
+        const options: CoapRequestParams = this.uriToOptions(form.href);
 
         if (form["cov:methodName"] != null) {
             const formMethodName = form["cov:methodName"];

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -192,7 +192,7 @@ export default class CoapClient implements ProtocolClient {
     }
 
     public async stop(): Promise<void> {
-        this.agent.close();
+        // do nothing TODO: understand how to properly close coap agent
     }
 
     public setSecurity = (metadata: Array<TD.SecurityScheme>): boolean => true;

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -19,9 +19,9 @@
 
 import * as TD from "@node-wot/td-tools";
 import Servient, { ProtocolServer, ContentSerdes, ExposedThing, Helpers, ProtocolHelpers } from "@node-wot/core";
-import coap = require("coap");
-import slugify from "slugify";
 import { Socket } from "dgram";
+import { Server, createServer, registerFormat, IncomingMessage, OutgoingMessage } from "coap";
+import slugify from "slugify";
 
 export default class CoapServer implements ProtocolServer {
     public readonly scheme: string = "coap";
@@ -32,9 +32,7 @@ export default class CoapServer implements ProtocolServer {
 
     private readonly port: number = 5683;
     private readonly address?: string = undefined;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly server: any = coap.createServer((req: any, res: any) => {
+    private readonly server: Server = createServer((req: IncomingMessage, res: OutgoingMessage) => {
         this.handleRequest(req, res);
     });
 
@@ -49,7 +47,7 @@ export default class CoapServer implements ProtocolServer {
         }
 
         // WoT-specific content formats
-        coap.registerFormat(ContentSerdes.JSON_LD, 2100);
+        registerFormat(ContentSerdes.JSON_LD, 2100);
     }
 
     public start(servient: Servient): Promise<void> {
@@ -198,8 +196,7 @@ export default class CoapServer implements ProtocolServer {
         });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private handleRequest(req: any, res: any) {
+    private handleRequest(req: IncomingMessage, res: OutgoingMessage) {
         console.debug(
             "[binding-coap]",
             `CoapServer on port ${this.getPort()} received '${req.method}(${req._packet.messageId}) ${
@@ -215,8 +212,8 @@ export default class CoapServer implements ProtocolServer {
             );
         });
 
-        const requestUri = req.url;
-        let contentType = req.options["Content-Format"];
+        const requestUri = new URL(req.url);
+        let contentType = req.headers["Content-Format"] as string;
 
         if (req.method === "PUT" || req.method === "POST") {
             if (!contentType && req.payload) {
@@ -242,7 +239,7 @@ export default class CoapServer implements ProtocolServer {
         if (segments[1] === "") {
             // no path -> list all Things
             if (req.method === "GET") {
-                res.setHeader("Content-Type", ContentSerdes.DEFAULT);
+                res.setHeader("Content-Format", ContentSerdes.DEFAULT);
                 res.code = "2.05";
                 const list = [];
                 for (const address of Helpers.getAddresses()) {
@@ -483,7 +480,7 @@ export default class CoapServer implements ProtocolServer {
                                 // (node-coap does not deduplicate when Observe is set)
                                 const packet = res._packet;
                                 packet.code = "0.00";
-                                packet.payload = "";
+                                packet.payload = Buffer.from("");
                                 packet.reset = false;
                                 packet.ack = true;
                                 packet.token = Buffer.alloc(0);

--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -14,6 +14,8 @@
  ********************************************************************************/
 
 import { Form } from "@node-wot/td-tools";
+import { OptionName } from "coap-packet";
+import { OptionValue } from "coap";
 
 export { default as CoapServer } from "./coap-server";
 export { default as CoapClientFactory } from "./coap-client-factory";
@@ -28,8 +30,8 @@ export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
 export class CoapOption {
-    public "cov:optionName": string;
-    public "cov:optionValue": string | number | Buffer;
+    public "cov:optionName": OptionName;
+    public "cov:optionValue": OptionValue;
 }
 
 export type CoapMethodName = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
@@ -61,16 +63,4 @@ export function isValidCoapMethod(methodName: CoapMethodName): methodName is Coa
  */
 export function isSupportedCoapMethod(methodName: CoapMethodName): methodName is CoapMethodName {
     return ["GET", "POST", "PUT", "DELETE"].includes(methodName);
-}
-
-export declare interface CoapRequestConfig {
-    agent?: Record<string, unknown>;
-    hostname?: string;
-    port?: number;
-    pathname?: string;
-    query?: string;
-    observe?: boolean;
-    multicast?: boolean;
-    confirmable?: boolean;
-    method?: string;
 }

--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -27,6 +27,18 @@ import { CoapForm } from "../src/coap";
 const port1 = 31833;
 const port2 = 31834;
 
+/**
+ * Helper function for waiting during tests.
+ *
+ * @param ms The time to wait in miliseconds.
+ * @returns A Promise that is resolved after the given time period.
+ */
+function sleep(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 @suite("CoAP client implementation")
 class CoapClientTest {
     @test async "should apply form information"() {
@@ -92,10 +104,10 @@ class CoapClientTest {
         const coapServer = new CoapServer(port2, "localhost");
         await coapServer.start(null);
         const coapClient = new CoapClient(coapServer);
-        const res = await coapClient.readResource({
+        await coapClient.readResource({
             href: `coap://localhost:${port2}/`,
         });
-        false && console.log(res);
+        await sleep(50); // Wait for client to send its ACK
         await coapServer.stop();
     }
 

--- a/packages/binding-coap/typings/coap/index.d.ts
+++ b/packages/binding-coap/typings/coap/index.d.ts
@@ -1,1 +1,0 @@
-declare module "coap";


### PR DESCRIPTION
This PR will update the `binding-coap` package with typescript declarations from `node-coap` (see https://github.com/mcollina/node-coap/pull/278) once a new version is released. It includes my local adjustments used for checking that the type declarations are actually usable. There are a small number of `any`s which still have to be fixed but other than that a large amount of code will be covered now with proper typing.

I also noticed ~~two bugs~~ one minor issue in the `coap` package due to the new type declarations for which I will open a separate PR for an immediate fix.