### PR TITLE
fix(coap): use string type for option name

### DIFF
--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -28,7 +28,7 @@ export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
 export class CoapOption {
-    public "cov:optionName": number;
+    public "cov:optionName": string;
     public "cov:optionValue": any;
 }
 


### PR DESCRIPTION
This is a minor fix for the `coap` package replacing the wrong type  `number` of `cov:optionName` with `string`.