### PR TITLE
Add support for streams in action handlers

### DIFF
--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -122,10 +122,10 @@ class HttpServerTest {
         expect(resp).to.equal("on");
 
         resp = await (await fetch(uri + "actions/try", { method: "POST", body: "toggle" })).text();
-        expect(resp).to.equal("TEST");
+        expect(resp).to.equal('"TEST"');
 
         resp = await (await fetch(uri + "actions/try", { method: "POST", body: undefined })).text();
-        expect(resp).to.equal("TEST");
+        expect(resp).to.equal('"TEST"');
 
         return httpServer.stop();
     }


### PR DESCRIPTION
This PR adds support for input/output roundtripping in exposed things with the new API. Notice that this is still a work in progress and we will need to change also al the other affordances and methods. 

The idea behind this PR is to provide protocol bindings a dedicated interface where they can communicate with the upper core level (i.e., exposed thing). Before `ConsumeThing` methods were used but I think it is better to provide a simpler interface where bindings just exchange `Content` instances. 