### PR TITLE
use only one interface for Managed Streams

### DIFF
--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -199,7 +199,6 @@ export default class ProtocolHelpers {
     }
 
     public static toWoTStream(stream: NodeJS.ReadableStream | IManagedStream): ReadableStream | PolyfillStream {
-        // TODO USE CLASSES
         if (isManaged(stream)) {
             return stream.wotStream;
         }
@@ -227,7 +226,6 @@ export default class ProtocolHelpers {
     }
 
     public static toNodeStream(stream: ReadableStream | PolyfillStream | IManagedStream): Readable {
-        // TODO: use proper classes
         if (isManaged(stream)) {
             return stream.nodeStream;
         }


### PR DESCRIPTION
As the title says this PR want's to fix the double interface problem introduced in the latest changes. 

Fixes #567 

