### PR TITLE
Fix coap binding with regards to counter example

### DIFF
--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -192,7 +192,7 @@ export default class CoapClient implements ProtocolClient {
     }
 
     public async stop(): Promise<void> {
-        this.agent.close();
+        // do nothing TODO: understand how to properly close coap agent
     }
 
     public setSecurity = (metadata: Array<TD.SecurityScheme>): boolean => true;

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -310,9 +310,9 @@ export default class CoapServer implements ProtocolServer {
                                     .catch((err) => {
                                         console.error(
                                             "[binding-coap]",
-                                            `CoapServer on port ${this.getPort()} got internal error on read '${
-                                                requestUri
-                                            }': ${err.message}`
+                                            `CoapServer on port ${this.getPort()} got internal error on read '${requestUri}': ${
+                                                err.message
+                                            }`
                                         );
                                         res.code = "5.00";
                                         res.end(err.message);
@@ -352,9 +352,9 @@ export default class CoapServer implements ProtocolServer {
                                         .catch((err) => {
                                             console.error(
                                                 "[binding-coap]",
-                                                `CoapServer on port ${this.getPort()} got internal error on read '${
-                                                    requestUri
-                                                }': ${err.message}`
+                                                `CoapServer on port ${this.getPort()} got internal error on read '${requestUri}': ${
+                                                    err.message
+                                                }`
                                             );
                                             res.code = "5.00";
                                             res.end(err.message);
@@ -391,9 +391,9 @@ export default class CoapServer implements ProtocolServer {
                                     .catch((err) => {
                                         console.error(
                                             "[binding-coap]",
-                                            `CoapServer on port ${this.getPort()} got internal error on write '${
-                                                requestUri
-                                            }': ${err.message}`
+                                            `CoapServer on port ${this.getPort()} got internal error on write '${requestUri}': ${
+                                                err.message
+                                            }`
                                         );
                                         res.code = "5.00";
                                         res.end(err.message);
@@ -449,7 +449,7 @@ export default class CoapServer implements ProtocolServer {
                                         );
                                         res.setOption("Content-Format", content.type);
                                         res.code = "2.05";
-                                        content.body.pipe(res,{end:true});
+                                        content.body.pipe(res, { end: true });
                                     } else {
                                         res.code = "2.04";
                                         res.end();
@@ -458,9 +458,9 @@ export default class CoapServer implements ProtocolServer {
                                 .catch((err) => {
                                     console.error(
                                         "[binding-coap]",
-                                        `CoapServer on port ${this.getPort()} got internal error on invoke '${
-                                            requestUri
-                                        }': ${err.message}`
+                                        `CoapServer on port ${this.getPort()} got internal error on invoke '${requestUri}': ${
+                                            err.message
+                                        }`
                                     );
                                     res.code = "5.00";
                                     res.end(err.message);

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -237,7 +237,7 @@ export default class CoapServer implements ProtocolServer {
         }
 
         // route request
-        const segments = decodeURI(requestUri.pathname).split("/");
+        const segments = decodeURI(requestUri).split("/");
 
         if (segments[1] === "") {
             // no path -> list all Things
@@ -311,7 +311,7 @@ export default class CoapServer implements ProtocolServer {
                                         console.error(
                                             "[binding-coap]",
                                             `CoapServer on port ${this.getPort()} got internal error on read '${
-                                                requestUri.pathname
+                                                requestUri
                                             }': ${err.message}`
                                         );
                                         res.code = "5.00";
@@ -353,7 +353,7 @@ export default class CoapServer implements ProtocolServer {
                                             console.error(
                                                 "[binding-coap]",
                                                 `CoapServer on port ${this.getPort()} got internal error on read '${
-                                                    requestUri.pathname
+                                                    requestUri
                                                 }': ${err.message}`
                                             );
                                             res.code = "5.00";
@@ -392,7 +392,7 @@ export default class CoapServer implements ProtocolServer {
                                         console.error(
                                             "[binding-coap]",
                                             `CoapServer on port ${this.getPort()} got internal error on write '${
-                                                requestUri.pathname
+                                                requestUri
                                             }': ${err.message}`
                                         );
                                         res.code = "5.00";
@@ -459,7 +459,7 @@ export default class CoapServer implements ProtocolServer {
                                     console.error(
                                         "[binding-coap]",
                                         `CoapServer on port ${this.getPort()} got internal error on invoke '${
-                                            requestUri.pathname
+                                            requestUri
                                         }': ${err.message}`
                                     );
                                     res.code = "5.00";

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -305,7 +305,7 @@ export default class CoapServer implements ProtocolServer {
                                         );
                                         res.setOption("Content-Format", content.type);
                                         res.code = "2.05";
-                                        res.end(content.body);
+                                        content.body.pipe(res, { end: true });
                                     })
                                     .catch((err) => {
                                         console.error(
@@ -336,7 +336,7 @@ export default class CoapServer implements ProtocolServer {
                                             );
                                             res.setOption("Content-Format", content.type);
                                             res.code = "2.05";
-                                            res.write(content.body);
+                                            content.body.pipe(res, { end: true });
 
                                             res.on("finish", (err: Error) => {
                                                 if (err) {
@@ -449,7 +449,7 @@ export default class CoapServer implements ProtocolServer {
                                         );
                                         res.setOption("Content-Format", content.type);
                                         res.code = "2.05";
-                                        res.end(content.body);
+                                        content.body.pipe(res,{end:true});
                                     } else {
                                         res.code = "2.04";
                                         res.end();


### PR DESCRIPTION
This PR tries to fix the issues when you want to try our counter example like the following:
`node packages/cli/dist/cli.js examples/scripts/counter.js` and `node packages/cli/dist/cli.js --clientonly examples/scripts/counter-client.js`. I've just fixed a small issue but there is more ahead, that's why the PR is in a draft status. 