### PR TITLE
fix(binding-file): remove default utf-8 encoding for binding-file and…

### DIFF
--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -30,7 +30,7 @@ export default class FileClient implements ProtocolClient {
     public readResource(form: Form): Promise<Content> {
         return new Promise<Content>((resolve, reject) => {
             const filepath = form.href.split("//");
-            const resource = fs.createReadStream(filepath[1], { encoding: "utf8" });
+            const resource = fs.createReadStream(filepath[1]);
             const extension = path.extname(filepath[1]);
             console.debug("[binding-file]", `FileClient found '${extension}' extension`);
             let contentType;

--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -251,7 +251,7 @@ export default class ProtocolHelpers {
 
         return result;
     }
-    
+
     static readStreamFully(stream: NodeJS.ReadableStream): Promise<Buffer> {
         return new Promise<Buffer>((resolve, reject) => {
             if (stream) {
@@ -264,7 +264,7 @@ export default class ProtocolHelpers {
                         (chunks[0] instanceof Array || chunks[0] instanceof Buffer || chunks[0] instanceof Uint8Array)
                     ) {
                         resolve(Buffer.concat(chunks as Array<Buffer | Uint8Array>));
-                    } else if (chunks[0] && (typeof chunks[0] === 'string')) {
+                    } else if (chunks[0] && typeof chunks[0] === "string") {
                         resolve(Buffer.from(chunks.join()));
                     } else {
                         resolve(Buffer.from(chunks as Array<number>));

--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -251,7 +251,7 @@ export default class ProtocolHelpers {
 
         return result;
     }
-
+    
     static readStreamFully(stream: NodeJS.ReadableStream): Promise<Buffer> {
         return new Promise<Buffer>((resolve, reject) => {
             if (stream) {
@@ -264,6 +264,8 @@ export default class ProtocolHelpers {
                         (chunks[0] instanceof Array || chunks[0] instanceof Buffer || chunks[0] instanceof Uint8Array)
                     ) {
                         resolve(Buffer.concat(chunks as Array<Buffer | Uint8Array>));
+                    } else if (chunks[0] && (typeof chunks[0] === 'string')) {
+                        resolve(Buffer.from(chunks.join()));
                     } else {
                         resolve(Buffer.from(chunks as Array<number>));
                     }


### PR DESCRIPTION
… improvements for readStreamFully in protocol-helpers

I think that the binding-file should let the specific contentserdes handle the encoding of the stream, while instead it is now forced to _utf8_. Furthermore, for properly handling strings in the _fetch_ operation, an  additional case is needed in the readStreamFully in protocol-helpers