### PR TITLE
chore: add `lint:fix` npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "coverage": "nyc --reporter=lcov npm run test",
         "coverage:only": "nyc --reporter=lcov npm run test:only",
         "lint": "npm run lint --silent --workspaces --if-present",
+        "lint:fix": "npm run lint:fix --silent --workspaces --if-present",
         "format": "prettier --write . && npm run format --silent --workspaces --if-present",
         "format:quick": "pretty-quick",
         "prepare": "husky install",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -47,6 +47,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register  --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -37,6 +37,7 @@
         "build": "tsc -b",
         "test": "",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -63,6 +63,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -46,6 +46,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -50,6 +50,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -44,6 +44,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -48,6 +48,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register test/netconf-client-test.ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -49,6 +49,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register test/opcua-client-test.ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -47,6 +47,7 @@
         "build": "tsc -b",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
         "start": "ts-node src/cli.ts",
         "debug": "node -r ts-node/register --inspect-brk=9229 src/cli.ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "scripts": {
         "build": "tsc -b",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\"",
         "test": "mocha --require ts-node/register --extension ts"
     },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -37,6 +37,7 @@
     "scripts": {
         "build": "tsc -b",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
     },
     "bugs": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -48,6 +48,7 @@
         "build": "tsc -b && webpack",
         "test": "mocha --require ts-node/register --extension ts",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"**/*.json\""
     },
     "bugs": {


### PR DESCRIPTION
This PR adds a `lint:fix` script to every package to automatically apply eslint fixes (if possible).