### PR TITLE
chore(coap): update node-coap to version 1.x.x and fix type issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,6 +1104,11 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/capitalize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/capitalize/-/capitalize-2.0.0.tgz",
+            "integrity": "sha512-Jxz08Zch+/J+R3DUcPGmXZ4hNzZImd/FXXij32ByTfclrCQr15+geQjV5teTyFQb3zYPi7O5pRv2/YsyDfRmjA=="
+        },
         "node_modules/@types/caseless": {
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -1141,6 +1146,14 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "dependencies": {
+                "@types/ms": "*"
             }
         },
         "node_modules/@types/eslint": {
@@ -1225,6 +1238,11 @@
             "integrity": "sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ==",
             "dev": true
         },
+        "node_modules/@types/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+        },
         "node_modules/@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -1251,6 +1269,11 @@
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
             "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
             "dev": true
+        },
+        "node_modules/@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "node_modules/@types/node": {
             "version": "16.4.13",
@@ -2688,9 +2711,9 @@
             }
         },
         "node_modules/capitalize": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.3.tgz",
-            "integrity": "sha512-Qc5ksT1/zEJBbFYD05h99hCNEW0cgyD0zzE5WvkgisNnppJ+16zfaSk34evF0j6pGW8hejkRUeygJ5uN5k22SQ=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.4.tgz",
+            "integrity": "sha512-wcSyiFqXRYyCoqu0o0ekXzJAKCLMkqWS5QWGlgTJFJKwRmI6pzcN2hBl5VPq9RzLW5Uf4FF/V/lcFfjCtVak2w=="
         },
         "node_modules/case-1.5.3": {
             "name": "case",
@@ -2948,16 +2971,19 @@
             }
         },
         "node_modules/coap": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-0.26.0.tgz",
-            "integrity": "sha512-aRTrRToDLcZ68Ygxvbmc0/9XPQL3ypCeJQKMnitjH3HL/+ekh7REj7JZlG1mDsTwC7mDU2Zq9s4jo52BLNxAcg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.2.tgz",
+            "integrity": "sha512-8QJZMPFL4/D0tpodf36DVONfq8enfkFp0tneq863ON6FCUFYTyyh2ZxOHwRuwd0r4ip6fS1a+4CdBgYElKiA1g==",
             "dependencies": {
-                "@types/bl": "^5.0.1",
-                "@types/node": "^16.10.1",
+                "@types/bl": "^5.0.2",
+                "@types/capitalize": "^2.0.0",
+                "@types/debug": "^4.1.7",
+                "@types/lru-cache": "^5.1.1",
+                "@types/node": "^16.11.6",
                 "bl": "^5.0.0",
-                "capitalize": "^2.0.3",
-                "coap-packet": "^1.0.0",
-                "debug": "^4.3.2",
+                "capitalize": "^2.0.4",
+                "coap-packet": "^1.1.0",
+                "debug": "^4.3.3",
                 "fastseries": "^2.0.0",
                 "lru-cache": "^6.0.0",
                 "readable-stream": "^3.6.0"
@@ -3010,6 +3036,22 @@
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/coap/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/code-point-at": {
@@ -11907,7 +11949,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "@types/node": "16.4.13",
-                "coap": "^0.26.0",
+                "coap": "^1.0.2",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -12913,7 +12955,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "^0.26.0",
+                "coap": "^1.0.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -13219,7 +13261,7 @@
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/chai-as-promised": "^7.1.4",
-                "@types/chai-spies": "*",
+                "@types/chai-spies": "^1.0.3",
                 "@types/node": "16.4.13",
                 "@types/uritemplate": "^0.3.4",
                 "@types/uuid": "^8.3.1",
@@ -13247,7 +13289,7 @@
                 "vm2": "^3.9.4",
                 "web-streams-polyfill": "^3.0.1",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
+                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/examples": {
@@ -13579,6 +13621,11 @@
                 "@types/node": "*"
             }
         },
+        "@types/capitalize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/capitalize/-/capitalize-2.0.0.tgz",
+            "integrity": "sha512-Jxz08Zch+/J+R3DUcPGmXZ4hNzZImd/FXXij32ByTfclrCQr15+geQjV5teTyFQb3zYPi7O5pRv2/YsyDfRmjA=="
+        },
         "@types/caseless": {
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -13616,6 +13663,14 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "@types/debug": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "requires": {
+                "@types/ms": "*"
             }
         },
         "@types/eslint": {
@@ -13700,6 +13755,11 @@
             "integrity": "sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ==",
             "dev": true
         },
+        "@types/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+        },
         "@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -13726,6 +13786,11 @@
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
             "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
             "dev": true
+        },
+        "@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "@types/node": {
             "version": "16.4.13",
@@ -14872,9 +14937,9 @@
             "dev": true
         },
         "capitalize": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.3.tgz",
-            "integrity": "sha512-Qc5ksT1/zEJBbFYD05h99hCNEW0cgyD0zzE5WvkgisNnppJ+16zfaSk34evF0j6pGW8hejkRUeygJ5uN5k22SQ=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.4.tgz",
+            "integrity": "sha512-wcSyiFqXRYyCoqu0o0ekXzJAKCLMkqWS5QWGlgTJFJKwRmI6pzcN2hBl5VPq9RzLW5Uf4FF/V/lcFfjCtVak2w=="
         },
         "case-1.5.3": {
             "version": "npm:case@1.6.3",
@@ -15073,16 +15138,19 @@
             "dev": true
         },
         "coap": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-0.26.0.tgz",
-            "integrity": "sha512-aRTrRToDLcZ68Ygxvbmc0/9XPQL3ypCeJQKMnitjH3HL/+ekh7REj7JZlG1mDsTwC7mDU2Zq9s4jo52BLNxAcg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.2.tgz",
+            "integrity": "sha512-8QJZMPFL4/D0tpodf36DVONfq8enfkFp0tneq863ON6FCUFYTyyh2ZxOHwRuwd0r4ip6fS1a+4CdBgYElKiA1g==",
             "requires": {
-                "@types/bl": "^5.0.1",
-                "@types/node": "^16.10.1",
+                "@types/bl": "^5.0.2",
+                "@types/capitalize": "^2.0.0",
+                "@types/debug": "^4.1.7",
+                "@types/lru-cache": "^5.1.1",
+                "@types/node": "^16.11.6",
                 "bl": "^5.0.0",
-                "capitalize": "^2.0.3",
-                "coap-packet": "^1.0.0",
-                "debug": "^4.3.2",
+                "capitalize": "^2.0.4",
+                "coap-packet": "^1.1.0",
+                "debug": "^4.3.3",
                 "fastseries": "^2.0.0",
                 "lru-cache": "^6.0.0",
                 "readable-stream": "^3.6.0"
@@ -15110,6 +15178,14 @@
                     "requires": {
                         "base64-js": "^1.3.1",
                         "ieee754": "^1.2.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "requires": {
+                        "ms": "2.1.2"
                     }
                 }
             }

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -37,7 +37,7 @@
         "@node-wot/core": "0.8.0",
         "@node-wot/td-tools": "0.8.0",
         "@types/node": "16.4.13",
-        "coap": "^0.26.0",
+        "coap": "^1.0.2",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -187,7 +187,7 @@ export default class CoapClient implements ProtocolClient {
     }
 
     public async stop(): Promise<void> {
-        // do nothing TODO: understand how to properly close coap agent
+        this.agent.close();
     }
 
     public setSecurity = (metadata: Array<TD.SecurityScheme>): boolean => true;


### PR DESCRIPTION
This PR updates the `node-coap` dependency to the new major release. There are still a couple of minor issues that have to be resolved first, however (see https://github.com/mcollina/node-coap/pull/322), which is why I opened this PR as a draft for now.