### PR TITLE
Handle security scheme `name` in http binding

### DIFF
--- a/packages/binding-http/src/credential.ts
+++ b/packages/binding-http/src/credential.ts
@@ -33,7 +33,7 @@ export class BasicCredential extends Credential {
     /**
      *
      */
-    constructor({ username, password }: BasicCredentialConfiguration, options: BasicSecurityScheme) {
+    constructor({ username, password }: BasicCredentialConfiguration, options?: BasicSecurityScheme) {
         super();
         if (username === undefined || password === undefined || username === null || password === null) {
             throw new Error(`No Basic credentials for Thing`);
@@ -51,7 +51,7 @@ export class BasicCredential extends Credential {
             "Basic " + Buffer.from(this.username + ":" + this.password).toString("base64")
         );
         let headerName = "authorization";
-        if (this.options.in === "header" && this.options.name !== undefined) {
+        if (this.options !== undefined && this.options.in === "header" && this.options.name !== undefined) {
             headerName = this.options.name;
         }
         result.headers.set(headerName, "Basic " + Buffer.from(this.username + ":" + this.password).toString("base64"));

--- a/packages/binding-http/src/credential.ts
+++ b/packages/binding-http/src/credential.ts
@@ -1,3 +1,5 @@
+import { BearerSecurityScheme } from "./../../td-tools/dist/thing-description.d";
+import { BasicSecurityScheme, APIKeySecurityScheme } from "@node-wot/td-tools";
 /********************************************************************************
  * Copyright (c) 2020 - 2021 Contributors to the Eclipse Foundation
  *
@@ -13,7 +15,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { APIKeySecurityScheme } from "@node-wot/td-tools";
 import { Token } from "client-oauth2";
 import { Request } from "node-fetch";
 
@@ -28,10 +29,11 @@ export interface BasicCredentialConfiguration {
 export class BasicCredential extends Credential {
     private readonly username: string;
     private readonly password: string;
+    private readonly options: BasicSecurityScheme;
     /**
      *
      */
-    constructor({ username, password }: BasicCredentialConfiguration) {
+    constructor({ username, password }: BasicCredentialConfiguration, options: BasicSecurityScheme) {
         super();
         if (username === undefined || password === undefined || username === null || password === null) {
             throw new Error(`No Basic credentials for Thing`);
@@ -39,6 +41,7 @@ export class BasicCredential extends Credential {
 
         this.username = username;
         this.password = password;
+        this.options = options;
     }
 
     async sign(request: Request): Promise<Request> {
@@ -47,6 +50,11 @@ export class BasicCredential extends Credential {
             "authorization",
             "Basic " + Buffer.from(this.username + ":" + this.password).toString("base64")
         );
+        let headerName = "authorization";
+        if (this.options.in === "header" && this.options.name !== undefined) {
+            headerName = this.options.name;
+        }
+        result.headers.set(headerName, "Basic " + Buffer.from(this.username + ":" + this.password).toString("base64"));
         return result;
     }
 }
@@ -55,18 +63,24 @@ export interface BearerCredentialConfiguration {
 }
 export class BearerCredential extends Credential {
     private readonly token: string;
-    constructor({ token }: BearerCredentialConfiguration) {
+    private readonly options: BearerSecurityScheme;
+    constructor({ token }: BearerCredentialConfiguration, options: BearerSecurityScheme) {
         super();
         if (token === undefined || token === null) {
             throw new Error(`No Bearer credentionals for Thing`);
         }
 
         this.token = token;
+        this.options = options;
     }
 
     async sign(request: Request): Promise<Request> {
         const result = request.clone();
-        result.headers.set("authorization", "Bearer " + this.token);
+        let headerName = "authorization";
+        if (this.options.in === "header" && this.options.name !== undefined) {
+            headerName = this.options.name;
+        }
+        result.headers.set(headerName, "Bearer " + this.token);
         return result;
     }
 }

--- a/packages/binding-http/src/credential.ts
+++ b/packages/binding-http/src/credential.ts
@@ -46,10 +46,6 @@ export class BasicCredential extends Credential {
 
     async sign(request: Request): Promise<Request> {
         const result = request.clone();
-        result.headers.set(
-            "authorization",
-            "Basic " + Buffer.from(this.username + ":" + this.password).toString("base64")
-        );
         let headerName = "authorization";
         if (this.options !== undefined && this.options.in === "header" && this.options.name !== undefined) {
             headerName = this.options.name;

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -231,13 +231,18 @@ export default class HttpClient implements ProtocolClient {
         // TODO support for multiple security schemes
         const security: TD.SecurityScheme = metadata[0];
         switch (security.scheme) {
-            case "basic":
-                this.credential = new BasicCredential(credentials as BasicCredentialConfiguration);
+            case "basic": {
+                const securityBasic: TD.BasicSecurityScheme = <TD.BasicSecurityScheme>security;
+
+                this.credential = new BasicCredential(credentials as BasicCredentialConfiguration, securityBasic);
                 break;
-            case "bearer":
-                // TODO check security.in and adjust
-                this.credential = new BearerCredential(credentials as BearerCredentialConfiguration);
+            }
+            case "bearer": {
+                const securityBearer: TD.BearerSecurityScheme = <TD.BearerSecurityScheme>security;
+
+                this.credential = new BearerCredential(credentials as BearerCredentialConfiguration, securityBearer);
                 break;
+            }
             case "apikey": {
                 const securityAPIKey: TD.APIKeySecurityScheme = <TD.APIKeySecurityScheme>security;
 

--- a/packages/binding-http/test/credential-test.ts
+++ b/packages/binding-http/test/credential-test.ts
@@ -1,0 +1,95 @@
+import { BearerSecurityScheme } from "./../../td-tools/src/thing-description";
+import {
+    BasicCredential,
+    BasicCredentialConfiguration,
+    BearerCredential,
+    BearerCredentialConfiguration,
+    BasicKeyCredential,
+    BasicKeyCredentialConfiguration,
+} from "./../src/credential";
+/********************************************************************************
+ * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { suite, test } from "@testdeck/mocha";
+import { APIKeySecurityScheme, BasicSecurityScheme } from "@node-wot/td-tools";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { Request } from "node-fetch";
+
+chai.should();
+chai.use(chaiAsPromised);
+
+@suite("Credetials auth test suite")
+class CredentialTest {
+    @test async "should sign in with basic"(): Promise<void> {
+        const scheme: BasicSecurityScheme = {
+            scheme: "basic",
+            in: "header",
+            name: "testHeader",
+        };
+
+        const config: BasicCredentialConfiguration = {
+            username: "admin",
+            password: "password",
+        };
+
+        const request = new Request("http://test.com/");
+
+        const basic = new BasicCredential(config, scheme);
+        const response = await basic.sign(request);
+
+        response.headers
+            .get(scheme.name)
+            .should.be.equal("Basic " + Buffer.from(config.username + ":" + config.password).toString("base64"));
+    }
+
+    @test async "should sign in with bearer"(): Promise<void> {
+        const scheme: BearerSecurityScheme = {
+            scheme: "bearer",
+            in: "header",
+            name: "testHeader",
+        };
+
+        const config: BearerCredentialConfiguration = {
+            token: "token",
+        };
+
+        const request = new Request("http://test.com/");
+
+        const bearer = new BearerCredential(config, scheme);
+        const response = await bearer.sign(request);
+
+        response.headers.get(scheme.name).should.be.equal("Bearer " + config.token);
+    }
+
+    @test async "should sign in with basic key"(): Promise<void> {
+        const scheme: APIKeySecurityScheme = {
+            scheme: "apikey",
+            in: "header",
+            name: "testHeader",
+        };
+
+        const config: BasicKeyCredentialConfiguration = {
+            apiKey: "apiKey",
+        };
+
+        const request = new Request("http://test.com/");
+
+        const basic = new BasicKeyCredential(config, scheme);
+        const response = await basic.sign(request);
+
+        response.headers.get(scheme.name).should.be.equal(config.apiKey);
+    }
+}


### PR DESCRIPTION
With this changes the http-binding now correctly uses the information in `SecurityScheme` to configure a request object. In particular, they focus on handling correctly the parameter `name`. 


Fixes #631 
cc: @fillobotto 