### PR TITLE
Add eslint workspaces import validator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,14 @@ module.exports = {
         project: ["./tsconfig.eslint.json"],
     },
     extends: ["eslint:recommended", "standard", "prettier", "plugin:@typescript-eslint/recommended"],
-    plugins: ["@typescript-eslint", "unused-imports"],
+    plugins: ["@typescript-eslint", "unused-imports", "workspaces"],
     env: {
         es6: true,
         node: true,
     },
     ignorePatterns: [".eslintrc.js", "dist", "node_modules", "/examples", "bin"],
     rules: {
+        "workspaces/no-relative-imports": "error",
         "@typescript-eslint/no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "eslint-plugin-node": "^11.1.0",
                 "eslint-plugin-promise": "^5.1.0",
                 "eslint-plugin-unused-imports": "^1.1.4",
+                "eslint-plugin-workspaces": "^0.7.0",
                 "husky": "^7.0.4",
                 "mocha": "^9.1.1",
                 "nyc": "^15.1.0",
@@ -698,6 +699,84 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@joshuajaco/get-monorepo-packages/-/get-monorepo-packages-1.2.1.tgz",
+            "integrity": "sha512-3I32bp/UB4UmLqEj/yrBEWTYuCzojn8nR34PZ9Jwb2OeHV95l4Kw0ax1xnnA4yYWU1E1krM2RIWghP3U725dGQ==",
+            "dev": true,
+            "dependencies": {
+                "globby": "^7.1.1",
+                "load-json-file": "^4.0.0"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "dependencies": {
+                "array-uniq": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/dir-glob": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+            "dev": true,
+            "dependencies": {
+                "path-type": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/globby": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/ignore": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+            "dev": true
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@joshuajaco/get-monorepo-packages/node_modules/slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/@node-wot/binding-coap": {
@@ -2046,6 +2125,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/array.prototype.flat": {
@@ -4042,6 +4130,18 @@
                 "@typescript-eslint/eslint-plugin": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-workspaces": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-workspaces/-/eslint-plugin-workspaces-0.7.0.tgz",
+            "integrity": "sha512-1+qzAM/iFFJ4MR3IOSY7n6Kw9XW/Fc+eVzWfN9nCcneDHr21rccZWUtGyMesk35bFnOWyp9dmJbYL0v5KYZ14w==",
+            "dev": true,
+            "dependencies": {
+                "@joshuajaco/get-monorepo-packages": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
             }
         },
         "node_modules/eslint-rule-composer": {
@@ -12891,6 +12991,71 @@
             "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
             "dev": true
         },
+        "@joshuajaco/get-monorepo-packages": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@joshuajaco/get-monorepo-packages/-/get-monorepo-packages-1.2.1.tgz",
+            "integrity": "sha512-3I32bp/UB4UmLqEj/yrBEWTYuCzojn8nR34PZ9Jwb2OeHV95l4Kw0ax1xnnA4yYWU1E1krM2RIWghP3U725dGQ==",
+            "dev": true,
+            "requires": {
+                "globby": "^7.1.1",
+                "load-json-file": "^4.0.0"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+                    "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "3.3.10",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+                    "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+                    "dev": true
+                }
+            }
+        },
         "@node-wot/binding-coap": {
             "version": "file:packages/binding-coap",
             "requires": {
@@ -13234,7 +13399,7 @@
                 "vm2": "^3.9.4",
                 "web-streams-polyfill": "^3.0.1",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
+                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/examples": {
@@ -14361,6 +14526,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
             "dev": true
         },
         "array.prototype.flat": {
@@ -15946,6 +16117,15 @@
             "dev": true,
             "requires": {
                 "eslint-rule-composer": "^0.3.0"
+            }
+        },
+        "eslint-plugin-workspaces": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-workspaces/-/eslint-plugin-workspaces-0.7.0.tgz",
+            "integrity": "sha512-1+qzAM/iFFJ4MR3IOSY7n6Kw9XW/Fc+eVzWfN9nCcneDHr21rccZWUtGyMesk35bFnOWyp9dmJbYL0v5KYZ14w==",
+            "dev": true,
+            "requires": {
+                "@joshuajaco/get-monorepo-packages": "^1.2.1"
             }
         },
         "eslint-rule-composer": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-unused-imports": "^1.1.4",
+        "eslint-plugin-workspaces": "^0.7.0",
         "husky": "^7.0.4",
         "mocha": "^9.1.1",
         "nyc": "^15.1.0",


### PR DESCRIPTION
In #635 I noticed that sometimes tools like vscode might use relative imports when working on one of the packages. To avoid problems down the road (i.e. after publication or build time) I've added this simple eslint that warns us if there are some wrong imports. It has just a small issue on windows that I fixed in https://github.com/joshuajaco/eslint-plugin-workspaces/pull/17, I hope to get it merged soon. 