### PR TITLE
chore: update copyright year in LICENSE file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+Copyright (c) 2018 - 2021 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.


### PR DESCRIPTION
This trivial PR updates the LICENSE file with the year 2021. 

As 2022 is not far away anymore: Maybe this file could also be updated in the copyright header script?