### PR TITLE
Use `eslint-plugin-notice` for license header policies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,21 @@ module.exports = {
         project: ["./tsconfig.eslint.json"],
     },
     extends: ["eslint:recommended", "standard", "prettier", "plugin:@typescript-eslint/recommended"],
-    plugins: ["@typescript-eslint", "unused-imports", "workspaces"],
+    plugins: ["@typescript-eslint", "unused-imports", "workspaces", "notice"],
     env: {
         es6: true,
         node: true,
     },
     ignorePatterns: [".eslintrc.js", "dist", "node_modules", "/examples", "bin"],
     rules: {
+        "notice/notice": [
+            "error",
+            {
+                mustMatch: "Copyright \\(c\\) [0-9]{0,4} Contributors to the Eclipse Foundation",
+                templateFile: __dirname + "/license.template.txt",
+                onNonMatchingHeader: "replace",
+            },
+        ],
         "workspaces/no-relative-imports": "error",
         "@typescript-eslint/no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
         "unused-imports/no-unused-imports": "error",

--- a/license.template.txt
+++ b/license.template.txt
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) <%= YEAR %> Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "eslint-config-standard": "^16.0.3",
                 "eslint-plugin-import": "^2.24.2",
                 "eslint-plugin-node": "^11.1.0",
+                "eslint-plugin-notice": "^0.9.10",
                 "eslint-plugin-promise": "^5.1.0",
                 "eslint-plugin-unused-imports": "^1.1.4",
                 "eslint-plugin-workspaces": "^0.7.0",
@@ -4150,6 +4151,20 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/eslint-plugin-notice": {
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-notice/-/eslint-plugin-notice-0.9.10.tgz",
+            "integrity": "sha512-rF79EuqdJKu9hhTmwUkNeSvLmmq03m/NXq/NHwUENHbdJ0wtoyOjxZBhW4QCug8v5xYE6cGe3AWkGqSIe9KUbQ==",
+            "dev": true,
+            "dependencies": {
+                "find-root": "^1.1.0",
+                "lodash": "^4.17.15",
+                "metric-lcs": "^0.1.2"
+            },
+            "peerDependencies": {
+                "eslint": ">=3.0.0"
+            }
+        },
         "node_modules/eslint-plugin-promise": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
@@ -4773,6 +4788,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
         },
         "node_modules/find-up": {
             "version": "2.1.0",
@@ -6631,6 +6652,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/metric-lcs": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz",
+            "integrity": "sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==",
+            "dev": true
         },
         "node_modules/micromatch": {
             "version": "4.0.4",
@@ -13120,7 +13147,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "^1.0.0",
+                "coap": "^1.0.2",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -16201,6 +16228,17 @@
                 }
             }
         },
+        "eslint-plugin-notice": {
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-notice/-/eslint-plugin-notice-0.9.10.tgz",
+            "integrity": "sha512-rF79EuqdJKu9hhTmwUkNeSvLmmq03m/NXq/NHwUENHbdJ0wtoyOjxZBhW4QCug8v5xYE6cGe3AWkGqSIe9KUbQ==",
+            "dev": true,
+            "requires": {
+                "find-root": "^1.1.0",
+                "lodash": "^4.17.15",
+                "metric-lcs": "^0.1.2"
+            }
+        },
         "eslint-plugin-promise": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
@@ -16639,6 +16677,12 @@
                     }
                 }
             }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
         },
         "find-up": {
             "version": "2.1.0",
@@ -18014,6 +18058,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
+        },
+        "metric-lcs": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz",
+            "integrity": "sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==",
             "dev": true
         },
         "micromatch": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-unused-imports": "^1.1.4",
         "eslint-plugin-workspaces": "^0.7.0",

--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -1,6 +1,6 @@
 import { ProtocolHelpers, ExposedThing } from "@node-wot/core";
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/credential-test.ts
+++ b/packages/binding-http/test/credential-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-client-basic-test.ts
+++ b/packages/binding-http/test/http-client-basic-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-client-test.ts
+++ b/packages/binding-http/test/http-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/memory-model.ts
+++ b/packages/binding-http/test/memory-model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/oauth-token-validation-tests.ts
+++ b/packages/binding-http/test/oauth-token-validation-tests.ts
@@ -1,3 +1,18 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 import { suite, test } from "@testdeck/mocha";
 import express from "express";
 import { should } from "chai";

--- a/packages/binding-mbus/src/node-mbus.d.ts
+++ b/packages/binding-mbus/src/node-mbus.d.ts
@@ -1,1 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 declare module "node-mbus";

--- a/packages/binding-mbus/test/mbus-client-test.ts
+++ b/packages/binding-mbus/test/mbus-client-test.ts
@@ -1,3 +1,17 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { should } from "chai";
 import * as chai from "chai";
 import MBusClient from "../src/mbus-client";

--- a/packages/binding-mbus/test/mbus-connection-test.ts
+++ b/packages/binding-mbus/test/mbus-connection-test.ts
@@ -1,3 +1,17 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { should } from "chai";
 import * as chai from "chai";
 import { MBusForm } from "../src/mbus";

--- a/packages/binding-mbus/test/test-servient.ts
+++ b/packages/binding-mbus/test/test-servient.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -1,3 +1,18 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 import { should } from "chai";
 import * as chai from "chai";
 import ModbusClient from "../src/modbus-client";

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -1,3 +1,17 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { ModbusEndianness } from "./../src/modbus";
 import { should } from "chai";
 import * as chai from "chai";

--- a/packages/binding-modbus/test/test-modbus-server.ts
+++ b/packages/binding-modbus/test/test-modbus-server.ts
@@ -1,3 +1,18 @@
+/********************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 import { ServerTCP } from "modbus-serial";
 
 export default class ModbusServer {

--- a/packages/binding-modbus/test/test-servient.ts
+++ b/packages/binding-modbus/test/test-servient.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/opcua-client-test.ts
+++ b/packages/binding-opcua/test/opcua-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/opcua-server.ts
+++ b/packages/binding-opcua/test/opcua-server.ts
@@ -1,3 +1,17 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { OPCUAServer, Variant, DataType, StatusCodes, MethodFunctorCallback, SessionContext } from "node-opcua";
 
 export class OpcuaServer {

--- a/packages/binding-websockets/test/ws-tests.ts
+++ b/packages/binding-websockets/test/ws-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/HelpersTest.ts
+++ b/packages/core/test/HelpersTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/InteractionOutputTest.ts
+++ b/packages/core/test/InteractionOutputTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 - 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ProtocolHelpersTest.ts
+++ b/packages/core/test/ProtocolHelpersTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/RuntimeTest.ts
+++ b/packages/core/test/RuntimeTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/examples/src/security/oauth/consumer.ts
+++ b/packages/examples/src/security/oauth/consumer.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/examples/src/security/oauth/memory-model.js
+++ b/packages/examples/src/security/oauth/memory-model.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/examples/src/security/oauth/server.js
+++ b/packages/examples/src/security/oauth/server.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/td-tools/test/TDParseTest.ts
+++ b/packages/td-tools/test/TDParseTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -122,7 +122,7 @@ const tdSampleLemonbeatBurlingame = `{
 			"readOnly": true,
 			"observable": true,
 			"forms": [{
-				"href" : "sensors/luminance", 
+				"href" : "sensors/luminance",
 				"contentType": "application/json"
 			}]
     },
@@ -133,7 +133,7 @@ const tdSampleLemonbeatBurlingame = `{
 			"readOnly": true,
 			"observable": true,
 			"forms": [{
-				"href" : "sensors/humidity", 
+				"href" : "sensors/humidity",
 				"contentType": "application/json"
 			}]
     },
@@ -144,7 +144,7 @@ const tdSampleLemonbeatBurlingame = `{
 			"readOnly": true,
 			"observable": true,
 			"forms": [{
-				"href" : "sensors/temperature", 
+				"href" : "sensors/temperature",
 				"contentType": "application/json"
 			}]
     },
@@ -165,14 +165,14 @@ const tdSampleLemonbeatBurlingame = `{
 			"forms": [{
 				"href" : "fan/turnon",
 				"contentType": "application/json"
-			}]									
+			}]
     },
     "turnOff": {
 			"@type": ["actuator:turnOff"],
 			"forms": [{
 				"href" : "fan/turnoff",
 				"contentType": "application/json"
-			}]									
+			}]
 		}
   }
 }`;


### PR DESCRIPTION
Fixes #645. Moreover, it fixes additional license headers error leftovers after #641. 