### PR TITLE
fix(coap-server): remove type casting to unknown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "thingweb.node-wot",
             "license": "EPL-2.0 OR W3C-20150513",
             "workspaces": [
                 "./packages/td-tools",
@@ -3060,9 +3059,9 @@
             }
         },
         "node_modules/coap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.2.tgz",
-            "integrity": "sha512-8QJZMPFL4/D0tpodf36DVONfq8enfkFp0tneq863ON6FCUFYTyyh2ZxOHwRuwd0r4ip6fS1a+4CdBgYElKiA1g==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.3.tgz",
+            "integrity": "sha512-9l53XScrpWmSALz3RhbG1YiH3p2NlTv7hvctiIAYglmNbpNaq6s3SnI1y4t93xx/G6F/eARYfdk3danrNagUMw==",
             "dependencies": {
                 "@types/bl": "^5.0.2",
                 "@types/capitalize": "^2.0.0",
@@ -12076,7 +12075,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "@types/node": "16.4.13",
-                "coap": "^1.0.2",
+                "coap": "^1.0.3",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -15336,9 +15335,9 @@
             "dev": true
         },
         "coap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.2.tgz",
-            "integrity": "sha512-8QJZMPFL4/D0tpodf36DVONfq8enfkFp0tneq863ON6FCUFYTyyh2ZxOHwRuwd0r4ip6fS1a+4CdBgYElKiA1g==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.3.tgz",
+            "integrity": "sha512-9l53XScrpWmSALz3RhbG1YiH3p2NlTv7hvctiIAYglmNbpNaq6s3SnI1y4t93xx/G6F/eARYfdk3danrNagUMw==",
             "requires": {
                 "@types/bl": "^5.0.2",
                 "@types/capitalize": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@types/chai-as-promised": "^7.1.4",
                 "@types/mocha": "^9.0.0",
                 "@types/node": "16.4.13",
-                "@types/readable-stream": "^2.3.11",
+                "@types/readable-stream": "^2.3.13",
                 "@types/sinon": "^10.0.2",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
@@ -1403,9 +1403,9 @@
             "dev": true
         },
         "node_modules/@types/readable-stream": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.11.tgz",
-            "integrity": "sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+            "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
             "dependencies": {
                 "@types/node": "*",
                 "safe-buffer": "*"
@@ -12544,7 +12544,7 @@
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/node": "16.4.13",
-                "@types/readable-stream": "^2.3.11",
+                "@types/readable-stream": "^2.3.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
@@ -13146,7 +13146,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "^1.0.2",
+                "coap": "^1.0.3",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -13518,7 +13518,7 @@
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/node": "16.4.13",
-                "@types/readable-stream": "^2.3.11",
+                "@types/readable-stream": "^2.3.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
@@ -14031,9 +14031,9 @@
             "dev": true
         },
         "@types/readable-stream": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.11.tgz",
-            "integrity": "sha512-0z+/apYJwKFz/RHp6mOMxz/y7xOvWPYPevuCEyAY3gXsjtaac02E26RvxA+I96rfvmVH/dEMGXNvyJfViR1FSQ==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+            "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
             "requires": {
                 "@types/node": "*",
                 "safe-buffer": "*"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@types/chai-as-promised": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "16.4.13",
-        "@types/readable-stream": "^2.3.11",
+        "@types/readable-stream": "^2.3.13",
         "@types/sinon": "^10.0.2",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -37,7 +37,7 @@
         "@node-wot/core": "0.8.0",
         "@node-wot/td-tools": "0.8.0",
         "@types/node": "16.4.13",
-        "coap": "^1.0.2",
+        "coap": "^1.0.3",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -30,7 +30,6 @@ import { Socket } from "dgram";
 import { Server, createServer, registerFormat, IncomingMessage, OutgoingMessage } from "coap";
 import slugify from "slugify";
 import { Readable } from "stream";
-import { WriteStream } from "fs";
 
 export default class CoapServer implements ProtocolServer {
     public readonly scheme: string = "coap";
@@ -309,7 +308,7 @@ export default class CoapServer implements ProtocolServer {
                                     const content = await thing.handleReadProperty(segments[3], options);
                                     res.setOption("Content-Format", content.type);
                                     res.code = "2.05";
-                                    content.body.pipe(res as unknown as WriteStream);
+                                    content.body.pipe(res);
                                 } catch (err) {
                                     console.error(
                                         "[binding-coap]",
@@ -327,7 +326,7 @@ export default class CoapServer implements ProtocolServer {
                                         res.setOption("Content-Format", content.type);
                                         res.code = "2.05";
                                         // send event data
-                                        content.body.pipe(res as unknown as WriteStream, { end: true });
+                                        content.body.pipe(res, { end: true });
                                     } catch (err) {
                                         console.error(
                                             "[binding-coap]",
@@ -427,7 +426,7 @@ export default class CoapServer implements ProtocolServer {
                                 if (output) {
                                     res.setOption("Content-Format", output.type);
                                     res.code = "2.05";
-                                    output.body.pipe(res as unknown as WriteStream, { end: true });
+                                    output.body.pipe(res, { end: true });
                                 } else {
                                     res.code = "2.04";
                                     res.end();
@@ -498,7 +497,7 @@ export default class CoapServer implements ProtocolServer {
                                         );
                                         res.setOption("Content-Format", value.type);
                                         res.code = "2.05";
-                                        value.body.pipe(res as unknown as WriteStream);
+                                        value.body.pipe(res);
                                     } catch (err) {
                                         console.debug(
                                             "[binding-coap]",

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -20,7 +20,7 @@
         "@types/node": "16.4.13",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
-        "@types/readable-stream": "^2.3.11",
+        "@types/readable-stream": "^2.3.13",
         "chai": "^4.3.4",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
After the latest update of node-coap, the type-casting introduces by #634 can now be removed as the `OutgoingMessage` class now provides the correct type information regarding the interfaces it implements.

This PR updates node-coap to the latest version and removes the now obsolete type casting. Resolves https://github.com/eclipse/thingweb.node-wot/issues/642.