### PR TITLE
style(binding-netconf): resolve linting issues

### DIFF
--- a/packages/binding-netconf/src/codecs/netconf-codec.ts
+++ b/packages/binding-netconf/src/codecs/netconf-codec.ts
@@ -38,8 +38,8 @@ export default class NetconfCodec {
                 throw new Error(`The href specified in TD is missing the leaf node in the Xpath`);
             }
             const url = new Url(form.href);
-            const xpath_query = url.pathname;
-            const tree = xpath_query.split("/").map((value, index) => {
+            const xpathQuery = url.pathname;
+            const tree = xpathQuery.split("/").map((value, index) => {
                 const val = value.replace(/\[(.*?)\]/g, "").split(":");
                 return val[1] ? val[1] : val[0];
             });
@@ -50,21 +50,21 @@ export default class NetconfCodec {
                 }
                 value = value[el];
             }
-            const tmp_schema = <any>schema;
-            if (!("type" in tmp_schema)) {
+            const tmpSchema = schema;
+            if (!("type" in tmpSchema)) {
                 throw new Error(`TD is missing the schema type`);
             }
-            if (tmp_schema.type === "object") {
+            if (tmpSchema.type === "object") {
                 if (
-                    tmp_schema.properties &&
-                    tmp_schema["xml:container"] &&
-                    tmp_schema.properties.xmlns &&
-                    tmp_schema.properties.xmlns["xml:attribute"]
+                    tmpSchema.properties &&
+                    tmpSchema["xml:container"] &&
+                    tmpSchema.properties.xmlns &&
+                    tmpSchema.properties.xmlns["xml:attribute"]
                 ) {
                     // now check if it contains
                     parsed = {};
-                    const xmlns_key = Object.keys(value.$)[0];
-                    parsed.xmlns = value.$[xmlns_key];
+                    const xmlnsKey = Object.keys(value.$)[0];
+                    parsed.xmlns = value.$[xmlnsKey];
                     parsed.value = value._.split(":")[1];
                 }
             } else {
@@ -73,7 +73,7 @@ export default class NetconfCodec {
             // TODO check the schema!
         } catch (err) {
             if (err instanceof SyntaxError) {
-                if (bytes.byteLength == 0) {
+                if (bytes.byteLength === 0) {
                     // empty payload -> void/undefined
                     parsed = undefined;
                 } else {
@@ -100,8 +100,8 @@ export default class NetconfCodec {
             if (!leaf) {
                 throw new Error(`The href specified in TD is missing the leaf node in the Xpath`);
             }
-            const tmp_obj = this.getPayloadNamespaces(schema, value, NSs, false, leaf);
-            body = JSON.stringify(tmp_obj);
+            const tmpObj = this.getPayloadNamespaces(schema, value, NSs, false, leaf);
+            body = JSON.stringify(tmpObj);
         }
 
         return Buffer.from(body);
@@ -114,8 +114,8 @@ export default class NetconfCodec {
             if (!properties) {
                 throw new Error(`Missing "properties" field in TD`);
             }
-            let ns_found = false;
-            let alias_ns = "";
+            let nsFound = false;
+            let aliasNs = "";
             let value;
             for (const key in properties) {
                 const el = properties[key];
@@ -125,48 +125,48 @@ export default class NetconfCodec {
                 if (el["xml:attribute"] === true && payload[key]) {
                     // if (el.format && el.format === 'urn')
                     const ns = payload[key];
-                    alias_ns = ns.split(":")[ns.split(":").length - 1];
-                    NSs[alias_ns] = payload[key];
-                    ns_found = true;
+                    aliasNs = ns.split(":")[ns.split(":").length - 1];
+                    NSs[aliasNs] = payload[key];
+                    nsFound = true;
                 } else if (payload[key]) {
                     value = payload[key];
                 }
             }
-            if (!ns_found) {
+            if (!nsFound) {
                 throw new Error(`Namespace not found in the payload`);
             } else {
                 // change the payload in order to be parsed by the xpath2json library
-                payload = { [leaf]: alias_ns + "\\" + ":" + value };
+                payload = { [leaf]: aliasNs + "\\" + ":" + value };
             }
             return { payload, NSs }; // return objects
         }
 
         if (schema && schema.type && schema.type === "object" && schema.properties) {
             // nested object, go down
-            const tmp_hasNamespace = false;
-            let tmp_obj: any;
+            const tmpHasNamespace = false;
+            let tmpObj: any;
             if (schema.properties && schema["xml:container"]) {
                 // check the root level
-                tmp_obj = this.getPayloadNamespaces(schema, payload, NSs, true, leaf); // root case
+                tmpObj = this.getPayloadNamespaces(schema, payload, NSs, true, leaf); // root case
             } else {
-                tmp_obj = this.getPayloadNamespaces(schema.properties, payload, NSs, false, leaf);
+                tmpObj = this.getPayloadNamespaces(schema.properties, payload, NSs, false, leaf);
             }
 
-            payload = tmp_obj.payload;
-            NSs = { ...NSs, ...tmp_obj.NSs };
+            payload = tmpObj.payload;
+            NSs = { ...NSs, ...tmpObj.NSs };
         }
 
         // once here schema is properties
         for (const key in schema) {
             if ((schema[key].type && schema[key].type === "object") || hasNamespace) {
                 // go down only if it is a nested object or it has a namespace
-                let tmp_hasNamespace = false;
+                let tmpHasNamespace = false;
                 if (schema[key].properties && schema[key]["xml:container"]) {
-                    tmp_hasNamespace = true;
+                    tmpHasNamespace = true;
                 }
-                const tmp_obj = this.getPayloadNamespaces(schema[key], payload[key], NSs, tmp_hasNamespace, leaf);
-                payload[key] = tmp_obj.payload;
-                NSs = { ...NSs, ...tmp_obj.NSs };
+                const tmpObj = this.getPayloadNamespaces(schema[key], payload[key], NSs, tmpHasNamespace, leaf);
+                payload[key] = tmpObj.payload;
+                NSs = { ...NSs, ...tmpObj.NSs };
             }
         }
 
@@ -174,11 +174,11 @@ export default class NetconfCodec {
     }
 }
 
-function mapJsonToArray(obj: any) {
+export function mapJsonToArray(obj: any): void {
     if (typeof obj === "object") {
         console.debug("[binding-netconf]", obj);
         for (const k in obj) {
-            if (obj.hasOwnProperty(k)) {
+            if (Object.prototype.hasOwnProperty.call(k)) {
                 // recursive call to scan property
                 mapJsonToArray(obj[k]);
             }

--- a/packages/binding-netconf/src/netconf-client-factory.ts
+++ b/packages/binding-netconf/src/netconf-client-factory.ts
@@ -16,15 +16,13 @@
 /**
  * Netconf protocol binding
  */
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, ContentSerdes } from "@node-wot/core";
 import NetconfClient from "./netconf-client";
-import { ContentSerdes } from "@node-wot/core";
 import NetconfCodec from "./codecs/netconf-codec";
 
 export default class NetconfClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "netconf";
     public contentSerdes: ContentSerdes = ContentSerdes.get();
-    constructor() {}
 
     public getClient(): ProtocolClient {
         this.contentSerdes.addCodec(new NetconfCodec()); // add custom codec for NetConf
@@ -32,6 +30,6 @@ export default class NetconfClientFactory implements ProtocolClientFactory {
         return new NetconfClient();
     }
 
-    public init = () => true;
-    public destroy = () => true;
+    public init = (): boolean => true;
+    public destroy = (): boolean => true;
 }

--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -17,18 +17,17 @@
  * Protocol test suite to test protocol implementations
  */
 
-import { expect, should } from "chai";
+import chai, { expect, should } from "chai";
 
 import { ContentSerdes } from "@node-wot/core";
 
 import NetconfClient from "../src/netconf-client";
 import * as xpath2json from "../src/xpath2json";
 import { Readable } from "stream";
+import spies from "chai-spies";
+
 // should must be called to augment all variables
 should();
-
-const chai = require("chai");
-const spies = require("chai-spies");
 
 chai.use(spies);
 
@@ -63,7 +62,7 @@ describe("outer describe", function () {
             "nc:method": "GET-CONFIG",
         };
         try {
-            const res = await client.readResource(inputVector.form);
+            await client.readResource(inputVector.form);
         } catch (err) {
             expect(err.message).to.equal("connect ECONNREFUSED 127.0.0.1:6060");
         }
@@ -105,7 +104,7 @@ describe("outer describe", function () {
         } */
 
         try {
-            const res = await client.writeResource(inputVector.form, {
+            await client.writeResource(inputVector.form, {
                 type: ContentSerdes.DEFAULT,
                 body: Readable.from(Buffer.from(JSON.stringify(payload))),
             });
@@ -131,7 +130,7 @@ describe("outer describe", function () {
         const payload = "commit";
 
         try {
-            const res = await client.invokeResource(inputVector.form, {
+            await client.invokeResource(inputVector.form, {
                 type: ContentSerdes.DEFAULT,
                 body: Readable.from(Buffer.from(JSON.stringify(payload))),
             });
@@ -141,45 +140,45 @@ describe("outer describe", function () {
     });
 
     it("should properly add leaves to XPATH", async function () {
-        let xpath_query = "/ietf-interfaces:interfaces/interface/interface"; // the binding automatically adds again the leaf. addLeaves then removes it
+        let xpathQuery = "/ietf-interfaces:interfaces/interface/interface"; // the binding automatically adds again the leaf. addLeaves then removes it
         const payload = { name: "interface100" };
-        const valid_xpath_query = '/ietf-interfaces:interfaces/interface[name="interface100"]';
-        xpath_query = xpath2json.addLeaves(xpath_query, payload);
-        expect(xpath_query).to.equal(valid_xpath_query);
+        const validXpathQuery = '/ietf-interfaces:interfaces/interface[name="interface100"]';
+        xpathQuery = xpath2json.addLeaves(xpathQuery, payload);
+        expect(xpathQuery).to.equal(validXpathQuery);
     });
 
     it("should properly convert XPATH to JSON", async function () {
-        let xpath_query = "ietf-interfaces:interfaces/interface[name=interface100]";
+        let xpathQuery = "ietf-interfaces:interfaces/interface[name=interface100]";
         const NSs = {
             "ietf-interfaces": "urn:ietf:params:xml:ns:yang:ietf-interfaces",
             "iana-if-type": "urn:ietf:params:xml:ns:yang:iana-if-type",
         };
 
-        let obj_request = xpath2json.xpath2json(xpath_query, NSs);
-        let valid_object: any = {
+        let objRequest = xpath2json.xpath2json(xpathQuery, NSs);
+        let validObject: any = {
             "ietf-interfaces:interfaces": { interface: { name: "interface100" } },
         };
-        expect(JSON.stringify(obj_request)).to.equal(JSON.stringify(valid_object));
+        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject));
 
         const payload = { value: "modem" };
-        xpath_query = xpath2json.addLeaves(xpath_query, payload);
-        obj_request = xpath2json.xpath2json(xpath_query, NSs);
-        valid_object = {
+        xpathQuery = xpath2json.addLeaves(xpathQuery, payload);
+        objRequest = xpath2json.xpath2json(xpathQuery, NSs);
+        validObject = {
             "ietf-interfaces:interfaces": { interface: { name: "interface100", value: "modem" } },
         };
-        expect(JSON.stringify(obj_request)).to.equal(JSON.stringify(valid_object));
+        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject));
     });
 
     it("should properly convert JSON to XPATH", async function () {
-        const xpath_query = '/ietf-interfaces:interfaces/interface[name="interface100"][value="modem"]';
-        const object: any = {
+        const xpathQuery = '/ietf-interfaces:interfaces/interface[name="interface100"][value="modem"]';
+        const object = {
             "ietf-interfaces:interfaces": { interface: { name: "interface100", value: "modem" } },
         };
-        const json_string = xpath2json.json2xpath(object, 0, []);
-        let json_xpath = json_string[0] !== "[" ? "/" : ""; // let's check if the first argument is a leaf
-        for (let i = 0; i < json_string.length; i++) {
-            json_xpath += json_string[i];
+        const jsonString = xpath2json.json2xpath(object, 0, []);
+        let jsonXpath = jsonString[0] !== "[" ? "/" : ""; // let's check if the first argument is a leaf
+        for (let i = 0; i < jsonString.length; i++) {
+            jsonXpath += jsonString[i];
         }
-        expect(json_xpath).to.equal(xpath_query);
+        expect(jsonXpath).to.equal(xpathQuery);
     });
 });


### PR DESCRIPTION
This PR resolves most of the eslint errors and warnings in the `binding-netconf` package. Unfortunately, a number of `any`s had to be introduced as a number of parameters and types require a bit more work than expected. These should probably be introduced in a follow-up PR.