### PR TITLE
style(binding-modbus): resolve linting issues

### DIFF
--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -23,6 +23,6 @@ export default class ModbusClientFactory implements ProtocolClientFactory {
         return new ModbusClient();
     }
 
-    public init = () => true;
-    public destroy = () => true;
+    public init = (): boolean => true;
+    public destroy = (): boolean => true;
 }

--- a/packages/binding-modbus/src/modbus.ts
+++ b/packages/binding-modbus/src/modbus.ts
@@ -18,6 +18,32 @@ export { default as ModbusClient } from "./modbus-client";
 export * from "./modbus-client";
 export * from "./modbus-client-factory";
 
+export type ModbusEntity = "Coil" | "InputRegister" | "HoldingRegister" | "DiscreteInput";
+
+export enum ModbusFunction {
+    "readCoil" = 1,
+    "readDiscreteInput" = 2,
+    "readHoldingRegisters" = 3,
+    "readInputRegister" = 4,
+    "writeSingleCoil" = 5,
+    "writeSingleHoldingRegister" = 6,
+    "writeMultipleCoils" = 15,
+    "writeMultipleHoldingRegisters" = 16,
+}
+
+/**
+ * Different modbus function names as defined in
+ * https://en.wikipedia.org/wiki/Modbus.
+ */
+export type ModbusFunctionName =
+    | "readCoil"
+    | "readDiscreteInput"
+    | "readHoldingRegisters"
+    | "writeSingleCoil"
+    | "writeSingleHoldingRegister"
+    | "writeMultipleCoils"
+    | "writeMultipleHoldingRegisters";
+
 export class ModbusForm extends Form {
     /**
      * The modbus function issued in the request.
@@ -59,30 +85,6 @@ export class ModbusForm extends Form {
     public "modbus:pollingTime"?: number;
 }
 
-/**
- * Different modbus function names as defined in
- * https://en.wikipedia.org/wiki/Modbus.
- */
-export type ModbusFunctionName =
-    | "readCoil"
-    | "readDiscreteInput"
-    | "readHoldingRegisters"
-    | "writeSingleCoil"
-    | "writeSingleHoldingRegister"
-    | "writeMultipleCoils"
-    | "writeMultipleHoldingRegisters";
-
-export type ModbusEntity = "Coil" | "InputRegister" | "HoldingRegister" | "DiscreteInput";
-export enum ModbusFunction {
-    "readCoil" = 1,
-    "readDiscreteInput" = 2,
-    "readHoldingRegisters" = 3,
-    "readInputRegister" = 4,
-    "writeSingleCoil" = 5,
-    "writeSingleHoldingRegister" = 6,
-    "writeMultipleCoils" = 15,
-    "writeMultipleHoldingRegisters" = 16,
-}
 export enum ModbusEndianness {
     BIG_ENDIAN = "BIG_ENDIAN",
     LITTLE_ENDIAN = "LITTLE_ENDIAN",

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -32,8 +32,12 @@ describe("Modbus client test", () => {
 
     before(async () => {
         // Turn off logging to have a clean test log
-        console.debug = () => {};
-        console.warn = () => {};
+        console.debug = () => {
+            // Do nothing.
+        };
+        console.warn = () => {
+            // Do nothing.
+        };
 
         testServer = new ModbusServer(1);
         await testServer.start();
@@ -467,7 +471,9 @@ describe("Modbus client test", () => {
             };
 
             client
-                .subscribeResource(form, (value) => {})
+                .subscribeResource(form, (value) => {
+                    // Do nothing.
+                })
                 .then((subscription) => {
                     client.unlinkResource(form);
                     done();

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -39,6 +39,7 @@ describe("Modbus connection", () => {
     it("should connect", async () => {
         const connection = new ModbusConnection("127.0.0.1", 8502);
         await connection.connect();
+        // eslint-disable-next-line no-unused-expressions
         connection.client.isOpen.should.be.true;
     });
 


### PR DESCRIPTION
This PR fixes most of the eslint issues in the Modbus binding. There are still a couple of `any`s which will have to be revisited as well as some errors due to the order of interface definitions but those should (once more) be dealt with in a follow-up PR.