### PR TITLE
chore: update wot-typescript-definition

### DIFF
--- a/examples/templates/exposed-thing/package.json
+++ b/examples/templates/exposed-thing/package.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "devDependencies": {
         "typescript": "4.4.3",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
         "@types/node": "16.4.13",
         "tslint": "5.12.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "thingweb.node-wot",
             "license": "EPL-2.0 OR W3C-20150513",
             "workspaces": [
                 "./packages/td-tools",
@@ -12087,7 +12088,7 @@
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             },
             "devDependencies": {
                 "@testdeck/mocha": "^0.1.2",
@@ -12132,7 +12133,7 @@
                 "prettier": "^2.3.2",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/binding-http": {
@@ -12182,7 +12183,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/binding-mbus": {
@@ -12193,7 +12194,7 @@
                 "@node-wot/core": "0.8.0",
                 "@node-wot/td-tools": "0.8.0",
                 "node-mbus": "^1.2.2",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.18",
@@ -12228,7 +12229,7 @@
                 "@node-wot/td-tools": "0.8.0",
                 "modbus-serial": "^8.0.3",
                 "rxjs": "5.5.11",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.18",
@@ -12283,7 +12284,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/binding-netconf": {
@@ -12319,7 +12320,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/binding-opcua": {
@@ -12333,7 +12334,7 @@
                 "case-1.5.3": "npm:case@^1.5.3",
                 "rxjs": "5.5.11",
                 "url-parse": "^1.5.3",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
                 "xml-writer": "^1.7.0"
             },
             "devDependencies": {
@@ -12421,7 +12422,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/cli": {
@@ -12456,7 +12457,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             },
             "optionalDependencies": {
                 "ts-node": "10.1.0"
@@ -12535,7 +12536,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "packages/td-tools": {
@@ -12546,7 +12547,7 @@
                 "is-absolute-url": "3.0.3",
                 "url-toolkit": "2.1.6",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             },
             "devDependencies": {
                 "@testdeck/mocha": "^0.1.2",
@@ -13170,7 +13171,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-file": {
@@ -13191,7 +13192,7 @@
                 "prettier": "^2.3.2",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-http": {
@@ -13237,7 +13238,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-mbus": {
@@ -13267,7 +13268,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-modbus": {
@@ -13298,7 +13299,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-mqtt": {
@@ -13326,7 +13327,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-netconf": {
@@ -13358,7 +13359,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "url-parse": "^1.5.3",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/binding-opcua": {
@@ -13390,7 +13391,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "url-parse": "^1.5.3",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
                 "xml-writer": "^1.7.0"
             }
         },
@@ -13420,7 +13421,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
                 "ws": "^7.5.4"
             }
         },
@@ -13449,7 +13450,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/core": {
@@ -13517,7 +13518,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@node-wot/td-tools": {
@@ -13548,7 +13549,7 @@
                 "webpack": "^5.53.0",
                 "webpack-cli": "^4.8.0",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
-                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
             }
         },
         "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "check:versions": "node utils/check_package_version_consistency.js",
         "build:docker": "docker build -t wot-servient .",
         "clean:dist": "npm exec  --workspaces -- npx rimraf tsconfig.tsbuildinfo dist",
+        "update:wot-typescript-definitions": "npx npm-check-updates  -u -f \"wot-typescript-definitions\" --deep",
         "link": "npm link -ws"
     },
     "workspaces": [

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -41,7 +41,7 @@
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -28,7 +28,7 @@
         "prettier": "^2.3.2",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/core": "0.8.0"

--- a/packages/binding-firestore/package.json
+++ b/packages/binding-firestore/package.json
@@ -39,7 +39,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -45,7 +45,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/core": "0.8.0",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -40,7 +40,7 @@
         "@node-wot/core": "0.8.0",
         "@node-wot/td-tools": "0.8.0",
         "node-mbus": "^1.2.2",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -44,7 +44,7 @@
         "@node-wot/td-tools": "0.8.0",
         "modbus-serial": "^8.0.3",
         "rxjs": "5.5.11",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -32,7 +32,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/core": "0.8.0",

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -33,7 +33,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/td-tools": "0.8.0",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -42,7 +42,7 @@
         "case-1.5.3": "npm:case@^1.5.3",
         "rxjs": "5.5.11",
         "url-parse": "^1.5.3",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
         "xml-writer": "^1.7.0"
     },
     "scripts": {

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -34,7 +34,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/binding-http": "0.8.0",

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -19,7 +19,7 @@
         "browserify": "16.5.0",
         "tinyify": "2.5.2",
         "typescript": "4.4.3",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
         "build": "browserify -r vm:vm2 index.js --plugin tinyify --external coffee-script -o dist/wot-bundle.min.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
         "wot-thing-description-types": "^1.1.0-26-July-2021a",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "optionalDependencies": {
         "ts-node": "10.1.0"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -24,7 +24,7 @@
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
         "wot-thing-description-types": "^1.1.0-26-July-2021a",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "dependencies": {
         "@node-wot/binding-coap": "0.8.0",

--- a/packages/examples/src/security/oauth/package.json
+++ b/packages/examples/src/security/oauth/package.json
@@ -16,7 +16,7 @@
         "@types/express-oauth-server": "^2.0.2",
         "express-oauth-server": "^2.0.0",
         "@types/node": "16.4.13",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21",
         "cors": "^2.8.5",
         "ts-node": "10.1.0",
         "typescript": "4.4.3",

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -42,7 +42,7 @@
         "is-absolute-url": "3.0.3",
         "url-toolkit": "2.1.6",
         "wot-thing-description-types": "^1.1.0-26-July-2021a",
-        "wot-typescript-definitions": "^0.8.0-SNAPSHOT.18"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
         "build": "tsc -b && webpack",


### PR DESCRIPTION
update to latest "wot-typescript-definition" ( version 21) 
and use "pinned" versions to avoid subtle side effects when minor breaking changes are introduced in a patched version.
