### PR TITLE
chore(core): display info to better understand why schema validation …

### DIFF
--- a/packages/binding-opcua/src/opcua-client.ts
+++ b/packages/binding-opcua/src/opcua-client.ts
@@ -245,7 +245,7 @@ export default class OpcuaClient implements ProtocolClient {
             };
             const result = await this.session.call(methodToCall);
 
-            console.log("[binding-opcua]", "[invoke]", result.toString());
+            console.debug("[binding-opcua]", "[invoke]", result.toString());
 
             const statusCode = result.statusCode;
             if (statusCode !== StatusCodes.Good) {

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
+import * as util from "util";
 import * as WoT from "wot-typescript-definitions";
 import { ContentSerdes } from "./content-serdes";
 import { ProtocolHelpers } from "./core";
@@ -85,6 +85,9 @@ export class InteractionOutput implements WoT.InteractionOutput {
 
         // validate the schema
         if (!validate(value)) {
+            console.debug("[core]", "schema = ", util.inspect(this.schema, { depth: 10, colors: true }));
+            console.debug("[core]", "value: ", value);
+            console.debug("[core]", "Errror: ", validate.errors);
             throw new DataSchemaError("Invalid value according to DataSchema", value as WoT.DataSchemaValue);
         }
 


### PR DESCRIPTION
this PR adds a tactical message to the console to help investigate why the AJV schema validation has failed.
Prior to this change, there was no way to detect why the system was throwing an exception. 

I am happy to replace this with a better mechanism, as console.log is not always welcome in production code. 
Please advice.
