### PR TITLE
Thing model helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12015,6 +12015,12 @@
             "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-27-September-2021.tgz",
             "integrity": "sha512-DprWwVZKnEJSS5qNI0NHJSLYv6tmIkA3wSXjl9OskAXFMnQpxTwnlNT960f341XFDJF9pUBfi7nsD+7tnaFlvA=="
         },
+        "node_modules/wot-thing-model-types": {
+            "version": "1.1.0-3-February-2022",
+            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-3-February-2022.tgz",
+            "integrity": "sha512-IYetSr4Z7DmXESMg2OKDyIPTRwGSciIMuJBPyABNptNHodbwcMHx/48GO0kx6TpsDy9gBYkGO1SFXvt1/NZoMw==",
+            "dev": true
+        },
         "node_modules/wot-typescript-definitions": {
             "version": "0.8.0-SNAPSHOT.21",
             "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.21.tgz",
@@ -12704,6 +12710,7 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-model-types": "^1.1.0-3-February-2022",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.21"
             }
         },
@@ -13691,6 +13698,7 @@
                 "vm2": "^3.9.6",
                 "web-streams-polyfill": "^3.0.1",
                 "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-model-types": "1.1.0-3-February-2022",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.21"
             }
         },
@@ -22627,6 +22635,12 @@
             "version": "1.1.0-27-September-2021",
             "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-27-September-2021.tgz",
             "integrity": "sha512-DprWwVZKnEJSS5qNI0NHJSLYv6tmIkA3wSXjl9OskAXFMnQpxTwnlNT960f341XFDJF9pUBfi7nsD+7tnaFlvA=="
+        },
+        "wot-thing-model-types": {
+            "version": "1.1.0-3-February-2022",
+            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-3-February-2022.tgz",
+            "integrity": "sha512-IYetSr4Z7DmXESMg2OKDyIPTRwGSciIMuJBPyABNptNHodbwcMHx/48GO0kx6TpsDy9gBYkGO1SFXvt1/NZoMw==",
+            "dev": true
         },
         "wot-typescript-definitions": {
             "version": "0.8.0-SNAPSHOT.21",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
         "wot-thing-description-types": "^1.1.0-26-July-2021a",
+        "wot-thing-model-types": "^1.1.0-3-February-2022",
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.21"
     },
     "dependencies": {

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -37,6 +37,7 @@ import Ajv, { ValidateFunction, ErrorObject } from "ajv";
 import TDSchema from "wot-thing-description-types/schema/td-json-schema-validation.json";
 import { DataSchemaValue, ExposedThingInit } from "wot-typescript-definitions";
 import { SomeJSONSchema } from "ajv/dist/types/json-schema";
+import ThingModelHelpers from "./thing-model-helpers";
 
 const tdSchema = TDSchema;
 // RegExps take from https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts
@@ -228,41 +229,11 @@ export default class Helpers {
         return tdSchemaCopy;
     }
 
-    private static isThingModelThingDescription(data: Record<string, unknown>): boolean {
-        if (this.containsThingModelRef(data)) {
-            return true;
-        }
-
-        if (data.links !== undefined && Array.isArray(data.links)) {
-            let foundTmExtendsRel = false;
-            data.links.forEach((link) => {
-                if (link.rel !== undefined && link.rel === "tm:extends") foundTmExtendsRel = true;
-            });
-            if (foundTmExtendsRel) return true;
-        }
-
-        if (data.properties !== undefined) {
-            for (const prop in <Record<string, unknown>>data.properties) {
-                const properties = <Record<string, Record<string, unknown>>>data.properties;
-                if (this.isThingModelThingDescription(properties[prop])) return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static containsThingModelRef(data: Record<string, unknown>): boolean {
-        for (const key in data) {
-            if (key === "tm:ref") return true;
-        }
-        return false;
-    }
-
     /**
      * Helper function to validate an ExposedThingInit
      */
     public static validateExposedThingInit(data: ExposedThingInit): { valid: boolean; errors: string } {
-        if (data["@type"] === "tm:ThingModel" || this.isThingModelThingDescription(data)) {
+        if (data["@type"] === "tm:ThingModel" || ThingModelHelpers.isThingModel(data)) {
             return {
                 valid: false,
                 errors: "ThingModel declaration is not supported",

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -23,6 +23,7 @@ import ExposedThing from "./exposed-thing";
 import { ProtocolClientFactory, ProtocolServer, ProtocolClient } from "./protocol-interfaces";
 import ContentManager, { ContentCodec } from "./content-serdes";
 import { v4 } from "uuid";
+import ThingModelHelpers from "./thing-model-helpers";
 
 export interface ScriptOptions {
     argv?: Array<string>;
@@ -43,6 +44,7 @@ export default class Servient {
         const context = {
             WoT: new WoTImpl(this),
             WoTHelpers: new Helpers(this),
+            ModelHelpers: new ThingModelHelpers(this),
         };
 
         const vm = new NodeVM({
@@ -70,6 +72,7 @@ export default class Servient {
         const context = {
             WoT: new WoTImpl(this),
             WoTHelpers: new Helpers(this),
+            ModelHelpers: new ThingModelHelpers(this),
         };
 
         const vm = new NodeVM({

--- a/packages/core/src/thing-model-helpers.ts
+++ b/packages/core/src/thing-model-helpers.ts
@@ -1,0 +1,557 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import Ajv, { ValidateFunction, ErrorObject } from "ajv";
+import { LinkElement } from "wot-thing-description-types";
+import { DataSchema, ExposedThingInit } from "wot-typescript-definitions";
+import Servient, { Helpers } from "./core";
+import { ThingModel } from "wot-thing-model-types";
+import TMSchema from "wot-thing-model-types/schema/tm-json-schema-validation.json";
+
+const tmSchema = TMSchema;
+// RegExps take from https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts
+const ajv = new Ajv({ strict: false })
+    .addFormat(
+        "iri-reference",
+        /^(?:[a-z][a-z0-9+\-.]*:)?(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'"()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\?(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i
+    )
+    .addFormat(
+        "uri-reference",
+        /^(?:[a-z][a-z0-9+\-.]*:)?(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'"()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\?(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i
+    ) // TODO: check me
+    .addFormat("uri", /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/)
+    .addFormat("json-pointer", /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/) // TODO: check me
+    .addFormat(
+        "date-time",
+        /^\d\d\d\d-[0-1]\d-[0-3]\d[t\s](?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/
+    );
+
+export type LINK_TYPE = "tm:extends" | "tm:submodel";
+export type AFFORDANCE_TYPE = "properties" | "actions" | "events";
+export type COMPOSITION_TYPE = "extends" | "imports";
+export type ModelImportsInput = {
+    uri?: string;
+    type: AFFORDANCE_TYPE;
+    name: string;
+};
+
+export type CompositionOptions = {
+    baseUrl?: string;
+    selfComposition?: boolean;
+    map?: Record<string, unknown>;
+};
+export type modelComposeInput = {
+    extends?: ThingModel[];
+    imports?: (ModelImportsInput & { affordance: DataSchema })[];
+    submodel?: Record<string, ThingModel>;
+};
+
+export default class ThingModelHelpers {
+    static tsSchemaValidator = ajv.compile(tmSchema) as ValidateFunction;
+
+    private srv: Servient;
+    private helpers: Helpers;
+    private deps: string[] = [] as string[];
+
+    constructor(srv: Servient) {
+        this.srv = srv;
+        this.helpers = new Helpers(this.srv);
+    }
+
+    /**
+     * Checks if the input is a ThingModel.
+     *
+     * @param data - The record to be validated
+     * @returns a boolean: true if the input is a Thing Model, false otherwise
+     *
+     * @experimental
+     */
+    public static isThingModel(_data: unknown): _data is ThingModel {
+        if (_data === null || _data === undefined) {
+            return false;
+        }
+        if (!(typeof _data === "object") || Array.isArray(_data)) {
+            return false;
+        }
+        const data = _data as Record<string, unknown>;
+        if (Array.isArray(data["@type"])) {
+            const valid = data["@type"].filter((x) => x === "tm:ThingModel").length > 0;
+            if (valid) {
+                return true;
+            }
+        } else if (data["@type"] === "tm:ThingModel") {
+            return true;
+        }
+        if (Object.keys(this.getThingModelRef(data)).length > 0) {
+            // FIXME: different from specifications
+            return true;
+        }
+        if ("links" in data && Array.isArray(data.links)) {
+            const foundTmExtendsRel = data.links.find((link) => link.rel === "tm:extends");
+            if (foundTmExtendsRel) return true;
+        }
+
+        if (data.properties !== undefined) {
+            if (this.isThingModel(data.properties as Record<string, unknown>)) return true;
+        }
+
+        if (data.actions !== undefined) {
+            if (this.isThingModel(data.actions as Record<string, unknown>)) return true;
+        }
+
+        if (data.events !== undefined) {
+            if (this.isThingModel(data.events as Record<string, unknown>)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the version of the input Thing Model.
+     *
+     * @param data - the Thing Model where to get the version
+     * @returns the version of the Thing Model as string
+     *
+     * @experimental
+     */
+    public static getModelVersion(data: ThingModel): string {
+        if (!("version" in data) || !("model" in data.version)) {
+            return null;
+        }
+        return data.version.model as string;
+    }
+
+    /**
+     * Validates a Thing Model
+     *
+     * @param data - the Thing Model to be checked
+     * @returns an object with keys:
+     * -valid: the boolean for validity- and
+     * -errors: the string containing the errors occurred. Undefined if valid.
+     *
+     * @experimental
+     */
+    public static validateThingModel(data: ThingModel): { valid: boolean; errors: string } {
+        const isValid = ThingModelHelpers.tsSchemaValidator(data);
+        let errors;
+        if (!isValid) {
+            errors = ThingModelHelpers.tsSchemaValidator.errors.map((o: ErrorObject) => o.message).join("\n");
+        }
+        return {
+            valid: isValid,
+            errors: errors,
+        };
+    }
+
+    /**
+     * builds the partialTDs starting from a Thing Model.
+     *
+     * @param model - The Thing Model to start from
+     * @param options - Optional parameter of type CompositionOptions for passing
+     * further information to the building process.
+     * @returns an array of Partial TDs
+     *
+     * @experimental
+     */
+    public async getPartialTDs(model: unknown, options?: CompositionOptions): Promise<ExposedThingInit[]> {
+        const extendedModels = await this._getPartialTDs(model, options);
+        const extendedPartialTDs = extendedModels.map((_data) => {
+            const data = _data as ExposedThingInit;
+            // change the @type
+            console.log(data["@type"]);
+            if (data["@type"] instanceof Array) {
+                data["@type"] = data["@type"].map((el) => {
+                    if (el === "tm:ThingModel") {
+                        return "Thing";
+                    }
+                    return el;
+                });
+            } else {
+                data["@type"] = "Thing";
+            }
+            return data;
+        });
+        return extendedPartialTDs;
+    }
+
+    /**
+     * Retrieves the Thing Model from the given uri.
+     *
+     * @param uri - The uri from where to take the Thing Model
+     * @returns asynchronously a Thing Model
+     *
+     * @experimental
+     */
+    public async fetchModel(uri: string): Promise<ThingModel> {
+        this.addDependency(uri);
+        const tm = await this.helpers.fetch(uri);
+        if (!ThingModelHelpers.isThingModel(tm)) {
+            throw new Error(`Data at ${uri} is not a Thing Model`);
+        }
+        return tm;
+    }
+
+    private async _getPartialTDs(model: unknown, options?: CompositionOptions): Promise<ThingModel[]> {
+        if (!ThingModelHelpers.isThingModel(model)) {
+            throw new Error(`${model} is not a Thing Model`);
+        }
+        let isValid = ThingModelHelpers.validateThingModel(model);
+        if (isValid.valid === false || isValid.errors !== undefined) {
+            throw new Error(isValid.errors);
+        }
+        isValid = this.checkPlaceholderMap(model, options?.map);
+        if (isValid.valid === false || isValid.errors !== undefined) {
+            throw new Error(isValid.errors);
+        }
+
+        const modelInput = await this.fetchAffordances(model);
+        const extendedModels = await this.composeModel(model, modelInput, options);
+        return extendedModels;
+    }
+
+    /**
+     * Retrieves and fills asynchronously all the external references of a Thing Model.
+     *
+     * @param data - The Thing Model to be filled
+     * @returns asynchronously a modelComposeInput object containing all the retrieved data
+     *
+     * @experimental
+     */
+    private async fetchAffordances(data: ThingModel): Promise<modelComposeInput> {
+        const modelInput: modelComposeInput = {};
+        const extLinks = ThingModelHelpers.getThingModelLinks(data, "tm:extends");
+        if (extLinks.length > 0) {
+            modelInput.extends = [] as ThingModel[];
+            for (const s of extLinks) {
+                let source = await this.fetchModel(s.href);
+                [source] = await this._getPartialTDs(source);
+                modelInput.extends.push(source);
+            }
+        }
+        const affordanceTypes = ["properties", "actions", "events"];
+        modelInput.imports = [];
+        for (const affType of affordanceTypes) {
+            const affRefs = ThingModelHelpers.getThingModelRef(data[affType] as DataSchema);
+            if (Object.keys(affRefs).length > 0) {
+                for (const aff in affRefs) {
+                    const affUri = affRefs[aff] as string;
+                    const refObj = this.parseTmRef(affUri);
+                    let source = await this.fetchModel(refObj.uri);
+                    [source] = await this._getPartialTDs(source);
+                    delete (data[affType] as DataSchema)[aff]["tm:ref"];
+                    const importedAffordance = this.getRefAffordance(refObj, source);
+                    refObj.name = aff; // update the name of the affordance
+                    modelInput.imports.push({ affordance: importedAffordance, ...refObj });
+                }
+            }
+        }
+        const tmLinks = ThingModelHelpers.getThingModelLinks(data, "tm:submodel");
+        if (tmLinks.length > 0) {
+            modelInput.submodel = {} as Record<string, ThingModel>;
+            for (const l of tmLinks) {
+                const submodel = await this.fetchModel(l.href);
+                modelInput.submodel[l.href] = submodel;
+            }
+        }
+        return modelInput;
+    }
+
+    private async composeModel(
+        data: ThingModel,
+        modelObject: modelComposeInput,
+        options?: CompositionOptions
+    ): Promise<ThingModel[]> {
+        let tmpThingModels = [] as ThingModel[];
+        const title = data.title.replace(/ /g, "");
+        if (!options) {
+            options = {} as CompositionOptions;
+        }
+        if (!options.baseUrl) {
+            options.baseUrl = ".";
+        }
+        const newTMHref = this.returnNewTMHref(options.baseUrl, title);
+        const newTDHref = this.returnNewTDHref(options.baseUrl, title);
+        if ("extends" in modelObject) {
+            const extendObjs = modelObject.extends;
+            for (const key in extendObjs) {
+                const el = extendObjs[key];
+                data = ThingModelHelpers.extendThingModel(el, data);
+            }
+            // remove the tm:extends links
+            data.links = data.links.filter((link) => link.rel !== "tm:extends");
+        }
+        if ("imports" in modelObject) {
+            const importObjs = modelObject.imports;
+            for (const key in importObjs) {
+                const el = importObjs[key];
+                data = ThingModelHelpers.importAffordance(el.type, el.name, el.affordance, data);
+            }
+        }
+        if ("submodel" in modelObject) {
+            const submodelObj = modelObject.submodel;
+
+            for (const key in submodelObj) {
+                const sub = submodelObj[key];
+                if (options.selfComposition) {
+                    const index = data.links.findIndex((el) => el.href === key);
+                    const el = data.links[index];
+                    const instanceName = el.instanceName;
+                    if (!instanceName) {
+                        throw new Error("Self composition is not possible without instance names");
+                    }
+                    // self composition enabled, just one TD expected
+                    const [subPartialTD] = await this._getPartialTDs(sub, options);
+                    const affordanceTypes = ["properties", "actions", "events"];
+                    for (const affType of affordanceTypes) {
+                        for (const affKey in subPartialTD[affType] as DataSchema) {
+                            const newAffKey = `${instanceName}_${affKey}`;
+                            if (!(affType in data)) {
+                                data[affType] = {} as DataSchema;
+                            }
+                            (data[affType] as DataSchema)[newAffKey] = (subPartialTD[affType] as DataSchema)[
+                                affKey
+                            ] as DataSchema;
+                        }
+                    }
+                } else {
+                    const subTitle = sub.title.replace(/ /g, "");
+                    const subNewHref = this.returnNewTDHref(options.baseUrl, subTitle);
+                    if (!("links" in sub)) {
+                        sub.links = [];
+                    }
+                    sub.links.push({
+                        rel: "collection",
+                        href: newTDHref,
+                        type: "application/td+json",
+                    });
+                    const tmpPartialSubTDs = await this._getPartialTDs(sub, options);
+                    tmpThingModels.push(...tmpPartialSubTDs);
+                    data = ThingModelHelpers.formatSubmodelLink(data, key, subNewHref);
+                }
+            }
+        }
+        if (!("links" in data) || options.selfComposition) {
+            data.links = [];
+        }
+        // add reference to the thing model
+        data.links.push({
+            rel: "type",
+            href: newTMHref,
+            type: "application/tm+json",
+        });
+
+        if ("version" in data) {
+            delete data.version;
+        }
+        if (options.map) {
+            data = this.fillPlaceholder(data, options.map);
+        }
+        tmpThingModels.unshift(data); // put itself as first element
+        tmpThingModels = tmpThingModels.map((el) => this.fillPlaceholder(el, options.map)); // TODO: make more efficient, since repeated each recursive call
+        if (this.deps.length > 0) {
+            this.removeDependency();
+        }
+        return tmpThingModels;
+    }
+
+    private static getThingModelRef(data: Record<string, unknown>): Record<string, unknown> {
+        const refs = {} as Record<string, unknown>;
+        if (!data) {
+            return refs;
+        }
+        for (const key in data) {
+            for (const key1 in data[key] as Record<string, unknown>) {
+                if (key1 === "tm:ref") {
+                    refs[key] = (data[key] as Record<string, unknown>)["tm:ref"] as string;
+                }
+            }
+        }
+        return refs;
+    }
+
+    private static getThingModelLinks(data: Record<string, unknown>, type: LINK_TYPE): LinkElement[] {
+        let links = [] as LinkElement[];
+        if ("links" in data && Array.isArray(data.links)) {
+            links = data.links;
+        }
+        return links.filter((el) => el.rel === type);
+    }
+
+    private static extendThingModel(source: ThingModel, dest: ThingModel): ThingModel {
+        let extendedModel = {} as ThingModel;
+        const properties = source.properties;
+        const actions = source.actions;
+        const events = source.events;
+        extendedModel = { ...source, ...dest };
+        // TODO: implement validation for extending
+        if (properties) {
+            for (const key in properties) {
+                if (dest.properties && key in dest.properties) {
+                    extendedModel.properties[key] = { ...properties[key], ...dest.properties[key] };
+                } else {
+                    extendedModel.properties[key] = properties[key];
+                }
+            }
+            // extendedModel.properties = { ...properties, ...dest.properties };
+        }
+        if (actions) {
+            for (const key in actions) {
+                if (dest.actions && key in dest.actions) {
+                    extendedModel.actions[key] = { ...actions[key], ...dest.actions[key] };
+                } else {
+                    extendedModel.actions[key] = actions[key];
+                }
+            }
+            // extendedModel.actions = { ...actions, ...dest.actions };
+        }
+        if (events) {
+            for (const key in events) {
+                if (dest.events && key in dest.events) {
+                    extendedModel.events[key] = { ...events[key], ...dest.events[key] };
+                } else {
+                    extendedModel.events[key] = events[key];
+                }
+            }
+            // extendedModel.events = { ...events, ...dest.events };
+        }
+        return extendedModel;
+    }
+
+    private static importAffordance(
+        affordanceType: AFFORDANCE_TYPE,
+        affordanceName: string,
+        source: DataSchema,
+        dest: ThingModel
+    ): ThingModel {
+        const d = dest[affordanceType][affordanceName];
+        dest[affordanceType][affordanceName] = { ...source, ...d };
+        for (const key in dest[affordanceType][affordanceName]) {
+            if (dest[affordanceType][affordanceName][key] === null) {
+                delete dest[affordanceType][affordanceName][key];
+            }
+        }
+        return dest;
+    }
+
+    private static formatSubmodelLink(source: ThingModel, oldHref: string, newHref: string) {
+        const index = source.links.findIndex((el) => el.href === oldHref);
+        const el = source.links[index];
+        if ("instanceName" in el) {
+            delete el.instanceName;
+        }
+        source.links[index] = {
+            ...el,
+            href: newHref,
+            type: "application/td+json",
+            rel: "item",
+        };
+        return source;
+    }
+
+    private parseTmRef(value: string): ModelImportsInput {
+        const thingModelUri = value.split("#")[0];
+        const affordaceUri = value.split("#")[1];
+        const affordaceType = affordaceUri.split("/")[1] as AFFORDANCE_TYPE;
+        const affordaceName = affordaceUri.split("/")[2];
+        return { uri: thingModelUri, type: affordaceType, name: affordaceName };
+    }
+
+    private getRefAffordance(obj: ModelImportsInput, thing: ThingModel): DataSchema {
+        const affordanceType = obj.type;
+        const affordanceKey = obj.name;
+        if (!(affordanceType in thing)) {
+            return null;
+        }
+        const affordances = thing[affordanceType] as DataSchema;
+        if (!(affordanceKey in affordances)) {
+            return null;
+        }
+        return affordances[affordanceKey];
+    }
+
+    private fillPlaceholder(data: Record<string, unknown>, map: Record<string, unknown>): ThingModel {
+        let dataString = JSON.stringify(data);
+        for (const key in map) {
+            const value = map[key];
+            let word = `{{${key}}}`;
+            const instances = (dataString.match(new RegExp(word, "g")) || []).length;
+            for (let i = 0; i < instances; i++) {
+                word = `{{${key}}}`;
+                const re = `"(${word})"`;
+                const match = dataString.match(re);
+                if (match === null) {
+                    // word is included in another string/number/element. Keep that type
+                    dataString = dataString.replace(word, value as string);
+                } else {
+                    // keep the new value type
+                    if (typeof value !== "string") {
+                        word = `"{{${key}}}"`;
+                    }
+                    dataString = dataString.replace(word, value as string);
+                }
+            }
+        }
+        return JSON.parse(dataString);
+    }
+
+    private checkPlaceholderMap(model: ThingModel, map: Record<string, unknown>): { valid: boolean; errors: string } {
+        const regex = "{{.*?}}";
+        const modelString = JSON.stringify(model);
+        // first check if model needs map
+        let keys = modelString.match(new RegExp(regex, "g")) || [];
+        keys = keys.map((el) => el.replace("{{", "").replace("}}", ""));
+        let isValid = true;
+        let errors;
+        if (keys && keys.length > 0 && (map === undefined || map === null)) {
+            isValid = false;
+            errors = `No map provided for model ${model.title}`;
+        } else if (keys.length > 0) {
+            keys.every((key) => {
+                if (!(key in map)) {
+                    errors = `Missing required fields in map for model ${model.title}`;
+                    isValid = false;
+                    return false;
+                }
+                return true;
+            });
+        }
+        return {
+            valid: isValid,
+            errors: errors,
+        };
+    }
+
+    private returnNewTMHref(baseUrl: string, tdname: string) {
+        return `${baseUrl}/${tdname}.tm.jsonld`;
+    }
+
+    private returnNewTDHref(baseUrl: string, tdname: string) {
+        return `${baseUrl}/${tdname}.td.jsonld`;
+    }
+
+    private addDependency(dep: string) {
+        if (this.deps.indexOf(dep) > -1) {
+            throw new Error(`Circular dependency found for ${dep}`);
+        }
+        this.deps.push(dep);
+    }
+
+    private removeDependency(dep?: string) {
+        if (dep) {
+            this.deps = this.deps.filter((el) => el !== dep);
+        } else {
+            this.deps.pop();
+        }
+    }
+}

--- a/packages/core/test/HelpersTest.ts
+++ b/packages/core/test/HelpersTest.ts
@@ -66,12 +66,12 @@ class HelperTest {
         expect(validated.errors).to.be.undefined;
     }
 
-    @test "should reject ThingModel schema on validation"() {
+    @test "should reject ThingModel with extends on validation"() {
         const thing: ExposedThingInit = {
             title: "thingTest",
             links: [
                 {
-                    rel: "tm:extend",
+                    rel: "tm:extends",
                 },
             ],
             properties: {
@@ -85,6 +85,31 @@ class HelperTest {
         const validated = Helpers.validateExposedThingInit(thing);
 
         expect(thing).to.exist;
+        expect(validated.valid).to.be.false;
+    }
+
+    @test "should reject ThingModel with tm:refs on validation"() {
+        const thing: ExposedThingInit = {
+            title: "thingTest",
+            properties: {
+                myProp: {
+                    "tm:ref": "http://example.com/thingTest.tm.jsonld#/properties/myProp",
+                    type: "number",
+                },
+            },
+        };
+
+        let validated = Helpers.validateExposedThingInit(thing);
+        expect(validated.valid).to.be.false;
+
+        thing.properties = {};
+        thing.actions = { myAction: { "tm:ref": "http://example.com/thingTest.tm.jsonld#/actions/myAction" } };
+        validated = Helpers.validateExposedThingInit(thing);
+        expect(validated.valid).to.be.false;
+
+        thing.actions = {};
+        thing.events = { myEvent: { "tm:ref": "http://example.com/thingTest.tm.jsonld#/actions/myAction" } };
+        validated = Helpers.validateExposedThingInit(thing);
         expect(validated.valid).to.be.false;
     }
 }

--- a/packages/core/test/thing-model/ThingModelHelperCompositionTest.ts
+++ b/packages/core/test/thing-model/ThingModelHelperCompositionTest.ts
@@ -1,0 +1,177 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { expect } from "chai";
+
+import ThingModelHelpers, { CompositionOptions } from "../../src/thing-model-helpers";
+import Servient, { Helpers } from "../../src/core";
+import { HttpClientFactory } from "@node-wot/binding-http";
+import { FileClientFactory } from "@node-wot/binding-file";
+import { ExposedThingInit } from "wot-typescript-definitions";
+
+chai.use(chaiAsPromised);
+@suite("tests to verify the composition feature of Thing Model Helper")
+class ThingModelHelperCompositionTest {
+    private srv: Servient;
+    private thingModelHelpers: ThingModelHelpers;
+    private helpers: Helpers;
+    async before() {
+        this.srv = new Servient();
+        this.srv.addClientFactory(new HttpClientFactory());
+        this.srv.addClientFactory(new FileClientFactory());
+        this.thingModelHelpers = new ThingModelHelpers(this.srv);
+        this.helpers = new Helpers(this.srv);
+        await this.srv.start();
+    }
+
+    @test async "should correctly compose a Thing Model with multiple partialTDs"() {
+        const modelUri = "file://./test/thing-model/tmodels/SmartVentilator.tm.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+        const finalModelUri = "file://./test/thing-model/tmodels/SmartVentilator.composed.tm.jsonld";
+        const finalModel = await this.helpers.fetch(finalModelUri);
+        const finalModelUri1 = "file://./test/thing-model/tmodels/Ventilator.composed.tm.jsonld";
+        const finalModel1 = await this.helpers.fetch(finalModelUri1);
+        const finalModelUri2 = "file://./test/thing-model/tmodels/Led.composed.tm.jsonld";
+        const finalModel2 = await this.helpers.fetch(finalModelUri2);
+
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        // eslint-disable-next-line dot-notation
+        const extendedModel = await this.thingModelHelpers["composeModel"](model, modelInput, options);
+        expect(extendedModel.length).to.be.equal(3);
+        expect(extendedModel[0]).to.be.deep.equal(finalModel);
+        expect(extendedModel[1]).to.be.deep.equal(finalModel1);
+        expect(extendedModel[2]).to.be.deep.equal(finalModel2);
+    }
+
+    @test async "should correctly compose a Thing Model with multiple partialTDs and selfcomposition enabled"() {
+        const modelUri = "file://./test/thing-model/tmodels/SmartVentilator.tm.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+        const finalModelUri = "file://./test/thing-model/tmodels/SmartVentilator.composed.tm.jsonld";
+        const finalModel = (await this.helpers.fetch(finalModelUri)) as ExposedThingInit;
+        finalModel.links = [
+            {
+                rel: "type",
+                href: "http://test.com/SmartVentilator.tm.jsonld",
+                type: "application/tm+json",
+            },
+        ];
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: true,
+        };
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        // eslint-disable-next-line dot-notation
+        const extendedModel = await this.thingModelHelpers["composeModel"](model, modelInput, options);
+        expect(extendedModel.length).to.be.equal(1);
+        expect(extendedModel[0].links).to.be.deep.equal(finalModel.links);
+    }
+
+    @test async "should correctly compose a Thing Model with multiple partialTDs and extend/import"() {
+        const modelUri = "file://./test/thing-model/tmodels/SmartVentilatorSubExtend.tm.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+        const finalModelUri = "file://./test/thing-model/tmodels/SmartVentilatorSubExtend.composed.tm.jsonld";
+        const finalModel = await this.helpers.fetch(finalModelUri);
+        const finalModelUri1 = "file://./test/thing-model/tmodels/Ventilator.composed.tm.jsonld";
+        const finalModel1 = await this.helpers.fetch(finalModelUri1);
+        const finalModelUri2 = "file://./test/thing-model/tmodels/LedExtend.composed.tm.jsonld";
+        const finalModel2 = await this.helpers.fetch(finalModelUri2);
+
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        // eslint-disable-next-line dot-notation
+        const extendedModel = await this.thingModelHelpers["composeModel"](model, modelInput, options);
+        expect(extendedModel.length).to.be.equal(3);
+        expect(extendedModel[0]).to.be.deep.equal(finalModel);
+        expect(extendedModel[1]).to.be.deep.equal(finalModel1);
+        expect(extendedModel[2]).to.be.deep.equal(finalModel2);
+    }
+
+    @test async "should correctly compose recursively a Thing Model with multiple partialTDs and extend/import"() {
+        const modelUri = "file://./test/thing-model/tmodels/SmartVentilatorRecursive.tm.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+        const finalModelUri = "file://./test/thing-model/tmodels/SmartVentilatorRecursive.composed.tm.jsonld";
+        const finalModel = await this.helpers.fetch(finalModelUri);
+        const finalModelUri1 = "file://./test/thing-model/tmodels/VentilatorRecursive.composed.tm.jsonld";
+        const finalModel1 = await this.helpers.fetch(finalModelUri1);
+        const finalModelUri2 = "file://./test/thing-model/tmodels/LedExtend.composed.tm.jsonld";
+        const finalModel2 = (await this.helpers.fetch(finalModelUri2)) as ExposedThingInit;
+
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        finalModel2.links[0].href = "http://test.com/VentilatorThingModelRecursive.td.jsonld";
+        // eslint-disable-next-line dot-notation
+        const extendedModel = await this.thingModelHelpers["composeModel"](model, modelInput, options);
+        expect(extendedModel.length).to.be.equal(3);
+        expect(extendedModel[0]).to.be.deep.equal(finalModel);
+        expect(extendedModel[1]).to.be.deep.equal(finalModel1);
+        expect(extendedModel[2]).to.be.deep.equal(finalModel2);
+    }
+
+    @test async "should correctly throw an error because of a self circular dependency"() {
+        const modelUri = "file://./test/thing-model/tmodels/LedExtendLoop.tm.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        await expect(this.thingModelHelpers.getPartialTDs(model, options)).be.rejectedWith(
+            `Circular dependency found for ${modelUri}`
+        );
+    }
+
+    @test async "should correctly throw an error because of a circular dependency"() {
+        const modelUri = "file://./test/thing-model/tmodels/depsLoop/SmartLampControlImport.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        await expect(this.thingModelHelpers.getPartialTDs(model, options)).be.rejectedWith(
+            `Circular dependency found for ${modelUri}`
+        );
+    }
+
+    @test async "should correctly compose a model that does not have circular dependency"() {
+        const modelUri = "file://./test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.jsonld";
+        const model = await this.thingModelHelpers.fetchModel(modelUri);
+        const finalModelUri = "file://./test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.td.jsonld";
+        const finalModel = await this.helpers.fetch(finalModelUri);
+        const options: CompositionOptions = {
+            baseUrl: "http://test.com",
+            selfComposition: false,
+        };
+        const extendedModel = await this.thingModelHelpers.getPartialTDs(model, options);
+        expect(extendedModel[0]).to.be.deep.equal(finalModel);
+    }
+}

--- a/packages/core/test/thing-model/ThingModelHelperTest.ts
+++ b/packages/core/test/thing-model/ThingModelHelperTest.ts
@@ -1,0 +1,393 @@
+/* eslint-disable no-unused-expressions */
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { suite, test } from "@testdeck/mocha";
+import { expect } from "chai";
+import { ThingModel } from "wot-thing-model-types";
+
+import ThingModelHelpers, { CompositionOptions, modelComposeInput } from "../../src/thing-model-helpers";
+import { promises as fs } from "fs";
+import Servient from "../../src/core";
+import { HttpClientFactory } from "@node-wot/binding-http";
+import { FileClientFactory } from "@node-wot/binding-file";
+
+@suite("tests to verify the Thing Model Helper")
+class ThingModelHelperTest {
+    private srv: Servient;
+    private thingModelHelpers: ThingModelHelpers;
+    async before() {
+        this.srv = new Servient();
+        this.srv.addClientFactory(new HttpClientFactory());
+        this.srv.addClientFactory(new FileClientFactory());
+        this.thingModelHelpers = new ThingModelHelpers(this.srv);
+        await this.srv.start();
+    }
+
+    @test "should correctly validate tm schema with ThingModel in @type"() {
+        const model = {
+            "@context": ["http://www.w3.org/ns/td"],
+            title: "thingTest",
+            "@type": "tm:ThingModel",
+            properties: {
+                myProp: {
+                    type: "number",
+                },
+            },
+        };
+
+        const validated = ThingModelHelpers.validateExposedThingModelInit(model as unknown as ThingModel);
+
+        expect(model).to.exist;
+        expect(validated.valid).to.be.true;
+        expect(validated.errors).to.be.undefined;
+    }
+
+    @test "should correctly return the right links"() {
+        const thing = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": "tm:ThingModel",
+            links: [
+                {
+                    rel: "tm:submodel",
+                    href: "./Ventilation.tm.jsonld",
+                    type: "application/tm+json",
+                    instanceName: "ventilation",
+                },
+                {
+                    rel: "tm:submodel",
+                    href: "./LED.tm.jsonld",
+                    type: "application/tm+json",
+                    instanceName: "led",
+                },
+            ],
+        };
+
+        // eslint-disable-next-line dot-notation
+        const extLinks = ThingModelHelpers["getThingModelLinks"](thing, "tm:submodel");
+        expect(extLinks).to.have.lengthOf(2);
+    }
+
+    @test "should correctly validate tm schema with ThingModel in @type array "() {
+        const model = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+            properties: {
+                myProp: {
+                    type: "number",
+                },
+            },
+        };
+
+        const validated = ThingModelHelpers.validateExposedThingModelInit(model as unknown as ThingModel);
+
+        expect(model).to.exist;
+        expect(validated.valid).to.be.true;
+        expect(validated.errors).to.be.undefined;
+    }
+
+    @test "should reject schema on validation because missing ThingModel definition"() {
+        const model = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": "random:Type",
+            links: [
+                {
+                    rel: "tm:extend",
+                },
+            ],
+            properties: {
+                myProp: {
+                    "tm:ref": "http://example.com/thingTest.tm.jsonld#/properties/myProp",
+                    type: "number",
+                },
+            },
+        };
+
+        const validated = ThingModelHelpers.validateExposedThingModelInit(model as unknown as ThingModel);
+
+        expect(model).to.exist;
+        expect(validated.valid).to.be.false;
+    }
+
+    @test "should correctly return the model version"() {
+        let thing: ThingModel = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+            version: { model: "0.0.1" }, // TODO: check is version is valid
+        };
+
+        let version = ThingModelHelpers.getModelVersion(thing);
+
+        expect(version).to.be.equal("0.0.1");
+
+        thing = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+            version: {},
+        };
+
+        version = ThingModelHelpers.getModelVersion(thing);
+        expect(version).to.be.null;
+
+        thing = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+        };
+
+        version = ThingModelHelpers.getModelVersion(thing);
+        expect(version).to.be.null;
+    }
+
+    @test async "should correctly extend a thing model with properties"() {
+        const modelJSON = await fs.readFile("test/thing-model/tmodels/SmartLampControlExtend.jsonld");
+        const finalJSON = await fs.readFile("test/thing-model/tmodels/SmartLampControlExtended.jsonld");
+        const model = JSON.parse(modelJSON.toString()) as ThingModel;
+        const finalModel = JSON.parse(finalJSON.toString()) as ThingModel;
+
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        // eslint-disable-next-line dot-notation
+        const [extendedModel] = await this.thingModelHelpers["composeModel"](model, modelInput);
+        expect(extendedModel).to.be.deep.equal(finalModel);
+    }
+
+    @test async "should correctly extend a thing model with actions"() {
+        const modelJSON = await fs.readFile("test/thing-model/tmodels/SmartLampControlExtend.jsonld");
+        const model = JSON.parse(modelJSON.toString()) as ThingModel;
+        const finalModel = {
+            "@type": "tm:ThingModel",
+            "@context": ["http://www.w3.org/ns/td"],
+            title: "Smart Lamp Control with Dimming",
+            links: [
+                {
+                    rel: "type",
+                    href: "./SmartLampControlwithDimming.tm.jsonld",
+                    type: "application/tm+json",
+                },
+            ],
+            properties: {
+                dim: {
+                    title: "Dimming level",
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 100,
+                },
+            },
+            actions: {
+                toggle: { type: "boolean" },
+            },
+        };
+        const modelInput: modelComposeInput = {
+            extends: [
+                {
+                    "@type": "tm:ThingModel",
+                    "@context": ["http://www.w3.org/ns/td"],
+                    actions: {
+                        toggle: { type: "boolean" },
+                    },
+                },
+            ],
+        };
+        // eslint-disable-next-line dot-notation
+        const [extendedModel] = await this.thingModelHelpers["composeModel"](model, modelInput);
+        expect(extendedModel).to.be.deep.equal(finalModel);
+    }
+
+    @test async "should correctly import a property in a thing model"() {
+        const modelJSON = await fs.readFile("test/thing-model/tmodels/SmartLampControlImport.jsonld");
+        const finalJSON = await fs.readFile("test/thing-model/tmodels/SmartLampControlImported.jsonld");
+        const model = JSON.parse(modelJSON.toString()) as ThingModel;
+        const finalModel = JSON.parse(finalJSON.toString()) as ThingModel;
+        // const validated = ThingModelHelpers.validateExposedThingModelInit(model);
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](model);
+        // eslint-disable-next-line dot-notation
+        const [importedModel] = await this.thingModelHelpers["composeModel"](model, modelInput);
+        expect(importedModel).to.be.deep.equal(finalModel);
+    }
+
+    @test async "should correctly import a property and remove a field of the property"() {
+        const thingModel: ThingModel = {
+            title: "thingTest",
+            "@type": ["random:Type", "tm:ThingModel"],
+            "@context": ["http://www.w3.org/ns/td"],
+            properties: {
+                timestamp1: {
+                    "tm:ref": "file://./test/thing-model/tmodels/OnOff.jsonld#/properties/timestamp",
+                    description: null,
+                },
+            },
+        };
+
+        const finalThingModel = {
+            title: "thingTest",
+            "@type": ["random:Type", "tm:ThingModel"],
+            "@context": ["http://www.w3.org/ns/td"],
+            properties: {
+                timestamp1: {
+                    type: "number",
+                    minimum: 0,
+                    maximum: 300,
+                },
+            },
+            links: [
+                {
+                    rel: "type",
+                    href: "./thingTest.tm.jsonld",
+                    type: "application/tm+json",
+                },
+            ],
+        };
+        // eslint-disable-next-line dot-notation
+        const modelInput = await this.thingModelHelpers["fetchAffordances"](thingModel);
+        // eslint-disable-next-line dot-notation
+        const [importedModel] = await this.thingModelHelpers["composeModel"](thingModel, modelInput);
+        expect(importedModel).to.be.deep.equal(finalThingModel);
+    }
+
+    @test async "should correctly import an action and add a field to the action"() {
+        const thingModel: ThingModel = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+            actions: {
+                toggle1: {
+                    description: "This is a description",
+                },
+            },
+        };
+        const modelInput: modelComposeInput = {
+            imports: [
+                {
+                    affordance: { type: "boolean" },
+                    type: "actions",
+                    name: "toggle1",
+                },
+            ],
+        };
+
+        const finalThingModel = {
+            title: "thingTest",
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": ["random:Type", "tm:ThingModel"],
+            actions: {
+                toggle1: {
+                    type: "boolean",
+                    description: "This is a description",
+                },
+            },
+            links: [
+                {
+                    rel: "type",
+                    href: "./thingTest.tm.jsonld",
+                    type: "application/tm+json",
+                },
+            ],
+        };
+        // eslint-disable-next-line dot-notation
+        const [importedModel] = await this.thingModelHelpers["composeModel"](thingModel, modelInput);
+        expect(importedModel).to.be.deep.equal(finalThingModel);
+    }
+
+    @test async "should correctly fill placeholders"() {
+        const thing = {
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": "tm:ThingModel",
+            title: "Thermostate No. {{THERMOSTATE_NUMBER}}",
+            base: "mqtt://{{MQTT_BROKER_ADDRESS}}",
+            properties: {
+                temperature: {
+                    description: "Shows the current temperature value",
+                    type: "number",
+                    minimum: "{{THERMOSTATE_NUMBER}}",
+                    maximum: "{{THERMOSTATE_TEMPERATURE_MAXIMUM}}",
+                    observable: "{{THERMOSTATE_TEMPERATURE_OBSERVABLE}}",
+                },
+            },
+        } as unknown as ThingModel;
+        const map = {
+            THERMOSTATE_NUMBER: 4,
+            MQTT_BROKER_ADDRESS: "192.168.178.72:1883",
+            THERMOSTATE_TEMPERATURE_MAXIMUM: 47.7,
+            THERMOSTATE_TEMPERATURE_OBSERVABLE: true,
+        };
+        const finalJSON = {
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": "Thing",
+            title: "Thermostate No. 4",
+            base: "mqtt://192.168.178.72:1883",
+            links: [
+                {
+                    href: "./ThermostateNo.4.tm.jsonld",
+                    rel: "type",
+                    type: "application/tm+json",
+                },
+            ],
+            properties: {
+                temperature: {
+                    description: "Shows the current temperature value",
+                    type: "number",
+                    minimum: 4,
+                    maximum: 47.7,
+                    observable: true,
+                },
+            },
+        };
+        const options: CompositionOptions = {
+            map,
+            selfComposition: false,
+        };
+        const [partialTd] = await this.thingModelHelpers.getPartialTDs(thing, options);
+        expect(partialTd).to.be.deep.equal(finalJSON);
+    }
+
+    @test async "should reject fill placeholders because of missing fields in map"() {
+        const thing = {
+            "@context": ["http://www.w3.org/ns/td"],
+            "@type": "tm:ThingModel",
+            title: "Thermostate No. {{THERMOSTATE_NUMBER}}",
+            base: "mqtt://{{MQTT_BROKER_ADDRESS}}",
+            properties: {
+                temperature: {
+                    description: "Shows the current temperature value",
+                    type: "number",
+                    minimum: "{{THERMOSTATE_NUMBER}}",
+                    maximum: "{{THERMOSTATE_TEMPERATURE_MAXIMUM}}",
+                    observable: "{{THERMOSTATE_TEMPERATURE_OBSERVABLE}}",
+                },
+            },
+        } as unknown as ThingModel;
+        const map = {
+            // "THERMOSTATE_NUMBER": 4,
+            MQTT_BROKER_ADDRESS: "192.168.178.72:1883",
+            THERMOSTATE_TEMPERATURE_MAXIMUM: 47.7,
+            THERMOSTATE_TEMPERATURE_OBSERVABLE: true,
+        };
+        const options: CompositionOptions = {
+            map,
+            selfComposition: false,
+        };
+        // eslint-disable-next-line dot-notation
+        const validated = this.thingModelHelpers["checkPlaceholderMap"](thing, options.map);
+        expect(validated.valid).to.be.false;
+        expect(validated.errors).to.be.equal(`Missing required fields in map for model ${thing.title}`);
+    }
+}

--- a/packages/core/test/thing-model/tmodels/BasicOnOffTM.jsonld
+++ b/packages/core/test/thing-model/tmodels/BasicOnOffTM.jsonld
@@ -1,0 +1,11 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Basic On/Off Thing Model",
+    "links": [],
+    "properties": {
+        "onOff": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/Led.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/Led.composed.tm.jsonld
@@ -1,0 +1,47 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Led Thing Model",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "collection",
+            "href": "http://test.com/SmartVentilator.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/LedThingModel.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/Led.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/Led.tm.jsonld
@@ -1,0 +1,38 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Led Thing Model",
+    "version": {
+        "model": "1.0.0"
+    },
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/LedExtend.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/LedExtend.composed.tm.jsonld
@@ -1,0 +1,59 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Led Thing Model Extend",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "collection",
+            "href": "http://test.com/SmartVentilator.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/LedThingModelExtend.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        },
+        "onOff": {
+            "type": "boolean"
+        },
+        "timestamp": {
+            "description": "Last timestamp",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 300
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        },
+        "toggle": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/LedExtend.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/LedExtend.tm.jsonld
@@ -1,0 +1,45 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Led Thing Model Extend",
+    "version": {
+        "model": "1.0.0"
+    },
+    "links": [
+        {
+            "rel": "tm:extends",
+            "href": "file://./test/thing-model/tmodels/OnOff.jsonld",
+            "type": "application/td+json"
+        }
+    ],
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/LedExtendLoop.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/LedExtendLoop.tm.jsonld
@@ -1,0 +1,45 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Led Thing Model Extend",
+    "version": {
+        "model": "1.0.0"
+    },
+    "links": [
+        {
+            "rel": "tm:extends",
+            "href": "file://./test/thing-model/tmodels/LedExtendLoop.tm.jsonld",
+            "type": "application/td+json"
+        }
+    ],
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/OnOff.jsonld
+++ b/packages/core/test/thing-model/tmodels/OnOff.jsonld
@@ -1,0 +1,21 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Basic On/Off Thing Model",
+    "properties": {
+        "onOff": {
+            "type": "boolean"
+        },
+        "timestamp": {
+            "description": "Last timestamp",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 300
+        }
+    },
+    "actions": {
+        "toggle": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartLampControlExtend.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartLampControlExtend.jsonld
@@ -1,0 +1,20 @@
+{
+    "@type": "tm:ThingModel",
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Smart Lamp Control with Dimming",
+    "links": [
+        {
+            "rel": "tm:extends",
+            "href": "file://./test/thing-model/tmodels/BasicOnOffTM.jsonld",
+            "type": "application/td+json"
+        }
+    ],
+    "properties": {
+        "dim": {
+            "title": "Dimming level",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartLampControlExtended.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartLampControlExtended.jsonld
@@ -1,0 +1,23 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Smart Lamp Control with Dimming",
+    "links": [
+        {
+            "rel": "type",
+            "href": "./SmartLampControlwithDimming.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "dim": {
+            "title": "Dimming level",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "onOff": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartLampControlImport.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartLampControlImport.jsonld
@@ -1,0 +1,10 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type" : "tm:ThingModel",
+    "title": "Smart Lamp Control",
+    "properties" : {
+        "switch" : {
+            "tm:ref" :"file://./test/thing-model/tmodels/BasicOnOffTM.jsonld#/properties/onOff"
+        }
+   }
+}

--- a/packages/core/test/thing-model/tmodels/SmartLampControlImported.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartLampControlImported.jsonld
@@ -1,0 +1,18 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Smart Lamp Control",
+    "properties" : {
+        "switch" : {
+            "type": "boolean"
+        }
+   },
+   "links": [
+        {
+          "href": "./SmartLampControl.tm.jsonld",
+          "rel": "type",
+          "type": "application/tm+json"
+        }
+      ]
+
+}

--- a/packages/core/test/thing-model/tmodels/SmartVentilator.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilator.composed.tm.jsonld
@@ -1,0 +1,32 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Smart Ventilator",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "item",
+            "href": "http://test.com/VentilatorThingModel.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "item",
+            "href": "http://test.com/LedThingModel.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/SmartVentilator.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "On",
+                "Off",
+                "Error"
+            ]
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartVentilator.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilator.tm.jsonld
@@ -1,0 +1,23 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Smart Ventilator",
+    "version" : { "model" : "1.0.0" },
+    "links": [
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/Ventilator.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "ventilation"
+      },
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/Led.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "led"
+      }
+    ],
+    "properties" : {
+        "status" : {"type": "string", "enum": ["On", "Off", "Error"]}
+    }
+  }

--- a/packages/core/test/thing-model/tmodels/SmartVentilatorRecursive.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilatorRecursive.composed.tm.jsonld
@@ -1,0 +1,27 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Smart Ventilator Recursive",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "item",
+            "href": "http://test.com/VentilatorThingModelRecursive.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/SmartVentilatorRecursive.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "On",
+                "Off",
+                "Error"
+            ]
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartVentilatorRecursive.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilatorRecursive.tm.jsonld
@@ -1,0 +1,17 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Smart Ventilator Recursive",
+    "version" : { "model" : "1.0.0" },
+    "links": [
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/VentilatorRecursive.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "ventilation"
+      }
+    ],
+    "properties" : {
+        "status" : {"type": "string", "enum": ["On", "Off", "Error"]}
+    }
+  }

--- a/packages/core/test/thing-model/tmodels/SmartVentilatorSubExtend.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilatorSubExtend.composed.tm.jsonld
@@ -1,0 +1,32 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Smart Ventilator",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "item",
+            "href": "http://test.com/VentilatorThingModel.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "item",
+            "href": "http://test.com/LedThingModelExtend.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/SmartVentilator.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "On",
+                "Off",
+                "Error"
+            ]
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/SmartVentilatorSubExtend.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/SmartVentilatorSubExtend.tm.jsonld
@@ -1,0 +1,23 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Smart Ventilator",
+    "version" : { "model" : "1.0.0" },
+    "links": [
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/Ventilator.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "ventilation"
+      },
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/LedExtend.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "led"
+      }
+    ],
+    "properties" : {
+        "status" : {"type": "string", "enum": ["On", "Off", "Error"]}
+    }
+  }

--- a/packages/core/test/thing-model/tmodels/Ventilator.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/Ventilator.composed.tm.jsonld
@@ -1,0 +1,28 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Ventilator Thing Model",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "collection",
+            "href": "http://test.com/SmartVentilator.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/VentilatorThingModel.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "switch": {
+            "type": "boolean",
+            "description": "True=On; False=Off"
+        },
+        "adjustRpm": {
+            "type": "number",
+            "minimum": 200,
+            "maximum": 1200
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/Ventilator.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/Ventilator.tm.jsonld
@@ -1,0 +1,19 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Ventilator Thing Model",
+    "version": {
+        "model": "1.0.0"
+    },
+    "properties": {
+        "switch": {
+            "type": "boolean",
+            "description": "True=On; False=Off"
+        },
+        "adjustRpm": {
+            "type": "number",
+            "minimum": 200,
+            "maximum": 1200
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/VentilatorRecursive.composed.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/VentilatorRecursive.composed.tm.jsonld
@@ -1,0 +1,33 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "Ventilator Thing Model Recursive",
+    "@type": "tm:ThingModel",
+    "links": [
+        {
+            "rel": "item",
+            "href": "http://test.com/LedThingModelExtend.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "collection",
+            "href": "http://test.com/SmartVentilatorRecursive.td.jsonld",
+            "type": "application/td+json"
+        },
+        {
+            "rel": "type",
+            "href": "http://test.com/VentilatorThingModelRecursive.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "switch": {
+            "type": "boolean",
+            "description": "True=On; False=Off"
+        },
+        "adjustRpm": {
+            "type": "number",
+            "minimum": 200,
+            "maximum": 1200
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/VentilatorRecursive.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/VentilatorRecursive.tm.jsonld
@@ -1,0 +1,27 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Ventilator Thing Model Recursive",
+    "version": {
+        "model": "1.0.0"
+    },
+    "links": [
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/LedExtend.tm.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "led"
+      }
+    ],
+    "properties": {
+        "switch": {
+            "type": "boolean",
+            "description": "True=On; False=Off"
+        },
+        "adjustRpm": {
+            "type": "number",
+            "minimum": 200,
+            "maximum": 1200
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/depsLoop/BasicOnOffTM.jsonld
+++ b/packages/core/test/thing-model/tmodels/depsLoop/BasicOnOffTM.jsonld
@@ -1,0 +1,18 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Basic On/Off Thing Model",
+    "links": [
+      {
+        "rel": "tm:submodel",
+        "href": "file://./test/thing-model/tmodels/depsLoop/SmartLampControlImport.jsonld",
+        "type": "application/tm+json",
+        "instanceName": "ventilation"
+      }
+    ],
+    "properties": {
+        "onOff": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/depsLoop/OnOff.jsonld
+++ b/packages/core/test/thing-model/tmodels/depsLoop/OnOff.jsonld
@@ -1,0 +1,28 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Basic On/Off Thing Model",
+    "links": [
+      {
+        "rel": "tm:extends",
+        "href": "file://./test/thing-model/tmodels/depsLoop/BasicOnOffTM.jsonld",
+        "type": "application/tm+json"
+      }
+    ],
+    "properties": {
+        "onOff": {
+            "type": "boolean"
+        },
+        "timestamp": {
+            "description": "Last timestamp",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 300
+        }
+    },
+    "actions": {
+        "toggle": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/depsLoop/SmartLampControlImport.jsonld
+++ b/packages/core/test/thing-model/tmodels/depsLoop/SmartLampControlImport.jsonld
@@ -1,0 +1,11 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type" : "tm:ThingModel",
+    "title": "Smart Lamp Control",
+
+    "properties" : {
+        "switch" : {
+            "tm:ref" :"file://./test/thing-model/tmodels/depsLoop/OnOff.jsonld#/properties/onOff"
+        }
+   }
+}

--- a/packages/core/test/thing-model/tmodels/noDepsLoop/BasicOnOffTM.jsonld
+++ b/packages/core/test/thing-model/tmodels/noDepsLoop/BasicOnOffTM.jsonld
@@ -1,0 +1,16 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Basic On/Off Thing Model",
+    "properties": {
+        "onOff": {
+            "type": "boolean",
+            "description": "Status of the Thing"
+        }
+    },
+    "actions" : {
+        "fade" : {
+            "tm:ref" :"file://./test/thing-model/tmodels/noDepsLoop/Led.tm.jsonld#/actions/fadeOut"
+        }
+   }
+}

--- a/packages/core/test/thing-model/tmodels/noDepsLoop/Led.tm.jsonld
+++ b/packages/core/test/thing-model/tmodels/noDepsLoop/Led.tm.jsonld
@@ -1,0 +1,38 @@
+{
+    "@context": ["http://www.w3.org/ns/td"],
+    "@type": "tm:ThingModel",
+    "title": "Led Thing Model",
+    "version": {
+        "model": "1.0.0"
+    },
+    "properties": {
+        "R": {
+            "type": "number",
+            "description": "Red color"
+        },
+        "G": {
+            "type": "number",
+            "description": "Green color"
+        },
+        "B": {
+            "type": "number",
+            "description": "Blue color"
+        }
+    },
+    "actions": {
+        "fadeIn": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        },
+        "fadeOut": {
+            "title": "fadeOut",
+            "input": {
+                "type": "number",
+                "description": "fadeOut in ms"
+            }
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/noDepsLoop/OnOff.jsonld
+++ b/packages/core/test/thing-model/tmodels/noDepsLoop/OnOff.jsonld
@@ -1,0 +1,28 @@
+{
+    "@type": "tm:ThingModel",
+    "@context": ["http://www.w3.org/ns/td"],
+    "title": "On/Off Thing Model",
+    "links": [
+      {
+        "rel": "tm:extends",
+        "href": "file://./test/thing-model/tmodels/noDepsLoop/BasicOnOffTM.jsonld",
+        "type": "application/tm+json"
+      }
+    ],
+    "properties": {
+        "onOff": {
+            "type": "number"
+        },
+        "timestamp": {
+            "description": "Last timestamp",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 300
+        }
+    },
+    "actions": {
+        "toggle": {
+            "type": "boolean"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.jsonld
+++ b/packages/core/test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.jsonld
@@ -1,0 +1,17 @@
+{
+    "@context": [
+        "http://www.w3.org/ns/td"
+    ],
+    "@type": "tm:ThingModel",
+    "title": "Smart Lamp Control",
+    "properties": {
+        "switch": {
+            "tm:ref": "file://./test/thing-model/tmodels/noDepsLoop/OnOff.jsonld#/properties/onOff"
+        }
+    },
+    "actions": {
+        "fade": {
+            "tm:ref": "file://./test/thing-model/tmodels/noDepsLoop/Led.tm.jsonld#/actions/fadeIn"
+        }
+    }
+}

--- a/packages/core/test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.td.jsonld
+++ b/packages/core/test/thing-model/tmodels/noDepsLoop/SmartLampControlImport.td.jsonld
@@ -1,0 +1,29 @@
+{
+    "@context": [
+        "http://www.w3.org/ns/td"
+    ],
+    "title": "Smart Lamp Control",
+    "@type": "Thing",
+    "links": [
+        {
+            "href": "http://test.com/SmartLampControl.tm.jsonld",
+            "rel": "type",
+            "type": "application/tm+json"
+        }
+    ],
+    "properties": {
+        "switch": {
+            "type": "number",
+            "description": "Status of the Thing"
+        }
+    },
+    "actions": {
+        "fade": {
+            "title": "fadeIn",
+            "input": {
+                "type": "number",
+                "description": "fadeIn in ms"
+            }
+        }
+    }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,6 @@
         "outDir": "dist",
         "rootDir": "src"
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "src/tm-json-schema-validation.json"],
     "references": [{ "path": "../td-tools" }]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,6 @@
         "outDir": "dist",
         "rootDir": "src"
     },
-    "include": ["src/**/*", "src/tm-json-schema-validation.json"],
+    "include": ["src/**/*"],
     "references": [{ "path": "../td-tools" }]
 }


### PR DESCRIPTION
This PR adds a set of helpers functions to handle [Thing Models](https://w3c.github.io/wot-thing-description/#thing-model). The changes might be a little intimidating but the core contribution is contained `thing-model-helpers.ts`. There we added three public functions:
1. `public static isThingModel(_data: unknown): _data is ThingModel`: simply checks that the data is "castable" to a ThingModel. This is useful when loading TMs from files or raw json strings. Its main benefit is to automatically cast _data to ThingModel and do a runtime check. 
2. `public static validateThingModel(data: ThingModel): { valid: boolean; errors: string }`: validate a ThingModel instance accordingly to W3C ThingModel json schema
3. `public async getPartialTDs(model: unknown, options?: CompositionOptions): Promise<ExposedThingInit[]>`: the main function of the helper class. It basically instantiates a Thing Description from a model. It returns an array because in the case of composed Thing Models we choose to use the approach of linking to other sub TDs, instead of flattening everything. Notice that model is `unknown` to easily plug in raw json data. 
4. `public static getModelVersion(data: ThingModel): string`: utility function to retrieve the version. 
5.  `public async fetchModel(uri: string): Promise<ThingModel> `: download a ThingModel

For further explanation about how to use these new functions, I suggest giving a look at `ThingModelHelperCompositionTest.ts` and `ThingModelHelperTest.ts`. 

We tried to follow the directions described in the spec please advise if you find anything off: I'm looking forward for your feedback! 

Open issues:
- I would prefer to have the validation functions inside the td-tools package. Consequently, I'd like to rename it wot-tools to capture the fact that contains functions to handle also TMs and in the future maybe other utilities. 
- What I don't like too much about this implementation is the dependency on `Servient`. The servient is needed for fetching linked TMs. However, in the future, we can define a `Resolver` interface and break the direct dependency with  `Servient`. 
- the `fetchModel` function contains a side-effect that records the URLs for dependency cycle detection. I would say that it would be better to remove this side-effect and handle the cycle detection differently. A solution could be TM hashing, this would be independent of the TM URL but it makes the instantiation algorithm more CPU intensive. 
- The tool does not handle placeholders that contains objects