### PR TITLE
Allign websocket server with the new `ExposedThing` methods

### DIFF
--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -217,14 +217,8 @@ export default class WebSocketServer implements ProtocolServer {
                             `WebSocketServer on port ${this.getPort()} publishing to property '${propertyName}' `
                         );
 
-                        switch (content.type) {
-                            case "application/json":
-                            case "text/plain":
-                                ws.send(content.body.toString());
-                                break;
-                            default:
-                                ws.send(content.body);
-                                break;
+                        for await (const chunk of content.body) {
+                            ws.send(chunk);
                         }
                     };
 
@@ -299,15 +293,9 @@ export default class WebSocketServer implements ProtocolServer {
                         )}:${req.socket.remotePort}`
                     );
 
-                    const eventListener = (content: Content) => {
-                        switch (content.type) {
-                            case "application/json":
-                            case "text/plain":
-                                ws.send(content.body.toString());
-                                break;
-                            default:
-                                ws.send(content.body);
-                                break;
+                    const eventListener = async (content: Content) => {
+                        for await (const chunk of content.body) {
+                            ws.send(chunk);
                         }
                     };
 

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -231,14 +231,14 @@ export default class WebSocketServer implements ProtocolServer {
                     if (!property.writeOnly) {
                         for (let formIndex = 0; formIndex < thing.properties[propertyName].forms.length; formIndex++) {
                             thing
-                                .handleObserveProperty(propertyName, observeListener, { formIndex: formIndex })
+                                .handleObserveProperty(propertyName, observeListener, { formIndex })
                                 .catch((err: Error) => ws.close(-1, err.message));
                         }
                     }
 
                     ws.on("close", () => {
                         for (let formIndex = 0; formIndex < thing.properties[propertyName].forms.length; formIndex++) {
-                            thing.handleUnobserveProperty(propertyName, observeListener, { formIndex: formIndex });
+                            thing.handleUnobserveProperty(propertyName, observeListener, { formIndex });
                         }
                         console.debug(
                             "[binding-websockets]",
@@ -257,7 +257,7 @@ export default class WebSocketServer implements ProtocolServer {
                 const action = thing.actions[actionName];
 
                 for (const address of Helpers.getAddresses()) {
-                    const href = this.scheme + "://" + address + ":" + this.getPort() + path;
+                    const href = `${this.scheme}://${address}:${this.getPort()}${path}`;
                     const form = new TD.Form(href, ContentSerdes.DEFAULT);
                     form.op = ["invokeaction"];
                     thing.actions[actionName].forms.push(form);
@@ -313,13 +313,13 @@ export default class WebSocketServer implements ProtocolServer {
 
                     for (let formIndex = 0; formIndex < event.forms.length; formIndex++) {
                         thing
-                            .handleSubscribeEvent(eventName, eventListener, { formIndex: formIndex })
+                            .handleSubscribeEvent(eventName, eventListener, { formIndex })
                             .catch((err: Error) => ws.close(-1, err.message));
                     }
 
                     ws.on("close", () => {
                         for (let formIndex = 0; formIndex < event.forms.length; formIndex++) {
-                            thing.handleUnsubscribeEvent(eventName, eventListener, { formIndex: formIndex });
+                            thing.handleUnsubscribeEvent(eventName, eventListener, { formIndex });
                         }
                         console.debug(
                             "[binding-websockets]",

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -181,7 +181,7 @@ export default class WebSocketServer implements ProtocolServer {
 
                 // Populate forms related to the property
                 for (const address of Helpers.getAddresses()) {
-                    const href = this.scheme + "://" + address + ":" + this.getPort() + path;
+                    const href = `${this.scheme}://${address}:${this.getPort()}${path}`;
                     const form = new TD.Form(href, ContentSerdes.DEFAULT);
                     const ops = [];
                     if (!property.writeOnly) {

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -270,7 +270,7 @@ export default class WebSocketServer implements ProtocolServer {
 
                 // Populate forms related to the event
                 for (const address of Helpers.getAddresses()) {
-                    const href = this.scheme + "://" + address + ":" + this.getPort() + path;
+                    const href = `${this.scheme}://${address}:${this.getPort()}${path}`;
                     const form = new TD.Form(href, ContentSerdes.DEFAULT);
                     form.op = "subscribeevent";
                     event.forms.push(form);


### PR DESCRIPTION
Starting from #543 we introduced a new API for the `ExposedThing` this PR aligns the WebSocket server implementation with it. It contains also minor refactorings. 