### PR TITLE
Fix 606

### DIFF
--- a/examples/scripts/smart-coffee-machine-oauth.js
+++ b/examples/scripts/smart-coffee-machine-oauth.js
@@ -25,7 +25,7 @@ A complementary tutorial is available at http://www.thingweb.io/smart-coffee-mac
     securityDefinitions: {
         oauth2_sc: {
             scheme: "oauth2",
-            flow: "client_credentials",
+            flow: "client",
             token: "https://127.0.0.1:3000/token",
             scopes: ["limited"],
         },

--- a/examples/security/oauth/exposer.js
+++ b/examples/security/oauth/exposer.js
@@ -19,7 +19,7 @@ let td = {
     securityDefinitions: {
         oauth2_sc: {
             scheme: "oauth2",
-            flow: "client_credentials",
+            flow: "client",
             authorization: "https://example.com/authorization",
             token: "https://localhost:3000/token",
             scopes: ["limited", "special"],

--- a/examples/security/oauth/memory-model.js
+++ b/examples/security/oauth/memory-model.js
@@ -26,7 +26,7 @@ module.exports = class InMemoryModel {
                 clientId: "node-wot",
                 clientSecret: "isgreat!",
                 redirectUris: [""],
-                grants: ["client_credentials", "limited"],
+                grants: ["client", "limited"],
             },
         ];
         this.tokens = [];

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -29,7 +29,7 @@ import { ProtocolClient, Content } from "@node-wot/core";
 import { HttpForm, HttpHeader, HttpConfig, HTTPMethodName } from "./http";
 import fetch, { Request, RequestInit, Response } from "node-fetch";
 import { Buffer } from "buffer";
-import OAuthManager, { OAuthClientCredentialsConfiguration, OAuthResourceOwnerConfiguration } from "./oauth-manager";
+import OAuthManager, { OAuthClientConfiguration, OAuthResourceOwnerConfiguration } from "./oauth-manager";
 import {
     BasicCredential,
     Credential,
@@ -255,11 +255,9 @@ export default class HttpClient implements ProtocolClient {
             case "oauth2": {
                 const securityOAuth: TD.OAuth2SecurityScheme = <TD.OAuth2SecurityScheme>security;
 
-                if (securityOAuth.flow === "client_credentials") {
-                    this.credential = this.oauth.handleClientCredential(
-                        securityOAuth,
-                        credentials as OAuthClientCredentialsConfiguration
-                    );
+                if (securityOAuth.flow === "client") {
+                    securityOAuth.flow = "client_credentials";
+                    this.credential = this.oauth.handleClient(securityOAuth, credentials as OAuthClientConfiguration);
                 } else if (securityOAuth.flow === "password") {
                     this.credential = this.oauth.handleResourceOwnerCredential(
                         securityOAuth,

--- a/packages/binding-http/src/oauth-manager.ts
+++ b/packages/binding-http/src/oauth-manager.ts
@@ -64,21 +64,18 @@ function createRequestFunction(rejectUnauthorized: boolean) {
         });
     };
 }
-export interface OAuthClientCredentialsConfiguration {
+export interface OAuthClientConfiguration {
     clientId: string;
     clientSecret: string;
 }
-export interface OAuthResourceOwnerConfiguration extends OAuthClientCredentialsConfiguration {
+export interface OAuthResourceOwnerConfiguration extends OAuthClientConfiguration {
     username: string;
     password: string;
 }
 
 export default class OAuthManager {
     private tokenStore: Map<string, ClientOAuth2.Token> = new Map();
-    handleClientCredential(
-        securityScheme: OAuth2SecurityScheme,
-        credentials: OAuthClientCredentialsConfiguration
-    ): OAuthCredential {
+    handleClient(securityScheme: OAuth2SecurityScheme, credentials: OAuthClientConfiguration): OAuthCredential {
         const clientFlow: ClientOAuth2 = new ClientOAuth2(
             {
                 clientId: credentials.clientId,

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -76,10 +76,10 @@ class HttpClientOAuthTest {
         await this.client.stop();
     }
 
-    @test async "should authorize client with client_credentials flow"() {
+    @test async "should authorize client with client flow"() {
         const scheme: OAuth2SecurityScheme = {
             scheme: "oauth2",
-            flow: "client_credentials",
+            flow: "client",
             token: "https://localhost:3000/token",
             scopes: ["test"],
         };
@@ -114,7 +114,7 @@ class HttpClientOAuthTest {
     @test async "should refresh token"() {
         const scheme: OAuth2SecurityScheme = {
             scheme: "oauth2",
-            flow: "client_credentials",
+            flow: "client",
             token: "https://localhost:3000/token",
             scopes: ["test"],
         };

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -20,7 +20,7 @@ const td = {
     securityDefinitions: {
         oauth2_sc: {
             scheme: "oauth2",
-            flow: "client_credentials",
+            flow: "client",
             authorization: "https://example.com/authorization",
             token: "https://localhost:3000/token",
             scopes: ["limited", "special"],

--- a/packages/examples/src/security/oauth/memory-model.js
+++ b/packages/examples/src/security/oauth/memory-model.js
@@ -26,7 +26,7 @@ module.exports = class InMemoryModel {
                 clientId: "node-wot",
                 clientSecret: "isgreat!",
                 redirectUris: [""],
-                grants: ["client_credentials", "limited"],
+                grants: ["client", "limited"],
             },
         ];
         this.tokens = [];


### PR DESCRIPTION
Closes #606. Notice that the RFC defines the right name of the flow to be `client_credentials` but in the TD specification we choose shorten it in: `client`