### PR TITLE
Improve readme of all packages

### DIFF
--- a/packages/binding-coap/README.md
+++ b/packages/binding-coap/README.md
@@ -1,8 +1,12 @@
 # CoAP Protocol Binding of node-wot
 
+## Protocol specifier
+
+The protocol prefix handled by this binding is `coap://` or `coaps://`.
+
 ## Getting Started
 
-In the following examples it is shown how to use the CoAP binding of node-wot.
+In the following examples, how to use the CoAP binding of node-wot is shown.
 
 ### Prerequisites
 
@@ -11,11 +15,12 @@ In the following examples it is shown how to use the CoAP binding of node-wot.
 
 ### Client Example
 
-The client example tries to connect to a TestThing via CoAP and reads a property `string`. The ThingDescription is located under the follwing CoAP uri coap://plugfest.thingweb.io:5683/testthing.
+The client example tries to connect to a TestThing via CoAP and read the `string` property.
+The Thing Description is located under the following CoAP URI `coap://plugfest.thingweb.io:5683/testthing`.
 
 `node example-client.js`
 
-```
+```js
 // example-client.js
 Servient = require("@node-wot/core").Servient
 CoapClientFactory = require("@node-wot/binding-coap").CoapClientFactory
@@ -46,11 +51,11 @@ wotHelper.fetch("coap://plugfest.thingweb.io:5683/testthing").then(async (td) =>
 
 ### Server Example
 
-The server example produces a thing that allows for setting a property `count`. The thing is reachable through CoAP. Additional additional handlers could be added.
+The server example produces a thing that allows for setting a property `count`. The thing is reachable through CoAP.
 
 `node example-server.js`
 
-```
+```js
 // example-server.js
 Servient = require("@node-wot/core").Servient
 CoapServer = require("@node-wot/binding-coap").CoapServer
@@ -66,8 +71,8 @@ servient.start().then((WoT) => {
         "@context": "https://www.w3.org/2019/wot/td/v1",
         title: "MyCounter",
         properties: {
-			count: {
-				type: "integer"
+            count: {
+                type: "integer"
             }
         }
     }).then((thing) => {
@@ -78,7 +83,7 @@ servient.start().then((WoT) => {
             console.info(thing.getThingDescription().title + " ready");
             console.info("TD : " + JSON.stringify(thing.getThingDescription()));
             thing.readProperty("count").then((c) => {
-                console.log("cound is " + c);
+                console.log("count is " + c);
             });
         });
     });
@@ -87,4 +92,4 @@ servient.start().then((WoT) => {
 
 ### More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-coap/README.md
+++ b/packages/binding-coap/README.md
@@ -1,5 +1,7 @@
 # CoAP Protocol Binding of node-wot
 
+W3C WoT Binding Template specification for CoAP can be found [here](https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html).
+
 ## Protocol specifier
 
 The protocol prefix handled by this binding is `coap://` or `coaps://`.

--- a/packages/binding-file/README.md
+++ b/packages/binding-file/README.md
@@ -1,8 +1,12 @@
 # File Binding of node-wot
 
+## Protocol specifier
+
+The protocol prefix handled by this binding is `file://`.
+
 ## Getting Started
 
-In the following examples it is shown how to use the File binding of node-wot.
+In the following examples, how to use the File binding of node-wot is shown.
 
 ### Prerequisites
 
@@ -12,7 +16,7 @@ In the following examples it is shown how to use the File binding of node-wot.
 
 ### Example 1
 
-The example tries to load an internal TestThing TD and reads a property `fileContent` which exposes the content of the file `test.txt`.
+The example tries to load an internal TestThing TD and reads the `fileContent` property, which exposes the content of the file `test.txt`.
 
 `node example1.js`
 
@@ -69,7 +73,7 @@ try {
 
 ### Example 2
 
-The example tries to load a locally stored TestThing TD and reads a property `fileContent` which exposes the content of the file `test.txt`.
+The example tries to load a locally stored TestThing TD and reads the `fileContent` property, which exposes the content of the file `test.txt`.
 
 ### Prerequisites
 
@@ -113,4 +117,4 @@ wotHelper
 
 ## More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-firestore-browser-bundle/README.md
+++ b/packages/binding-firestore-browser-bundle/README.md
@@ -1,8 +1,8 @@
-# Browser Bundle of Firestore Binding
+# Browser Bundle of Firestore Binding of node-wot
 
-Bundle to run Firestore Binding as browser-side library.
+Bundle to run [Firestore Binding](https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-firestore) as a browser-side library.
 
-## Supported bindings
+## Supported Protocols
 
 HTTP / HTTPS / WebSockets
 
@@ -14,7 +14,7 @@ Include the following script tag in your html
 <script src="https://cdn.jsdelivr.net/npm/@node-wot/binding-firestore-browser-bundle@latest/dist/binding-firestore-bundle.js"></script>
 ```
 
-You can access all binding-firestore functionality through the "BindingFirestore" global object:
+You can access all [binding-firestore](https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-firestore) functionality through the "BindingFirestore" global object:
 
 ```js
 var FirestoreClientFactory = BindingFirestore.FirestoreClientFactory;

--- a/packages/binding-firestore/README.md
+++ b/packages/binding-firestore/README.md
@@ -4,13 +4,13 @@
 
 Firestore Binding is an implementation of the [W3C Web of Things](https://www.w3.org/WoT/) Binding using Firestore, which can be used with [Eclipse Thingweb node-wot](https://github.com/eclipse/thingweb.node-wot/) to embody the Web of Things.
 
-Firestore has the ability to subscribe to written data, and Firestore Binding uses this to perform communication between the Thing and the Client.  
+Firestore has the ability to subscribe to written data, and Firestore Binding uses this to perform communication between the Thing and the Client.
 This Binding provides a storage location (Reference) in Firestore for data corresponding to a Thing's properties, actions, and events. By writing data to the Reference, communication between the Thing or Client that subscribes to the data is realized.
 
-In addition, when you do an Expose thing in a Server program that uses this Binding, the exposed Thing Description will be saved in Firestore.  
+In addition, when you do an Expose thing in a Server program that uses this Binding, the exposed Thing Description will be saved in Firestore.
 This Thing Description can be accessed by the Client as follows.
 
-```
+```js
 wotHelper.fetch("firestore://sample-host/MyCounter").then((td) => {
     // do something
 }
@@ -24,7 +24,7 @@ The protocol prefix handled by this binding is `firestore://`.
 
 ## Getting Started
 
-In the following examples it is shown how to use the Firestore binding of node-wot.
+In the following examples, how to use the Firestore binding of node-wot is shown.
 
 You must have a Firebase account to use this binding.
 
@@ -50,7 +50,7 @@ Perform the following setup from the [Firestore console](https://console.firebas
     ```
 1. Select `Project Settings` from the top left gear and confirm the Project ID (B) and Web Api Key (C).
 
-The values defined in (A), (B) and (C) will be written in the configuration file shown in `Confiuration` chapter.
+The values defined in (A), (B) and (C) will be written in the configuration file shown in `Configuration` chapter.
 
 ### Advance preparation
 
@@ -83,8 +83,9 @@ The information needed to create the configuration file can be found at [Firesto
 
 ### Client Example
 
-The client example tries to connect to `MyCounter` thing via Firestore and reads a property `count`. The ThingDescription is stored in Firebase which can be access by client as `firestore://sample-host/MyCounter`.
-The ThingDescription registered by `example-server.js`.
+The client example tries to connect to `MyCounter` thing via Firestore and read the `count` property .
+The Thing Description is stored in Firebase which can be access by client as `firestore://sample-host/MyCounter`.
+The Thing Description is registered by `example-server.js`.
 
 `node example-client.js`
 
@@ -180,17 +181,17 @@ servient.start().then((WoT) => {
 
 This Binding realizes the interaction between Client and Server for Property, Action, and Event by storing data in the following reference.
 
--   things/\<hostName\>%2F\<title of Thing Description\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>
     Stores the Thing Description that the Server program exposes.
--   things/\<hostName\>%2F\<title of Thing Description\>%2Fproperties%2F\<name of property\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>%2Fproperties%2F\<name of property\>
     Stores the value of the Property when it is changed by the Server.
--   things/\<hostName\>%2F\<title of Thing Description\>%2FpropertyWriteReq%2F\<name of property\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>%2FpropertyWriteReq%2F\<name of property\>
     Stores the value of the Property when it is changed by the Client.
--   things/\<hostName\>%2F\<title of Thing Description\>%2Factions%2F\<name of action\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>%2Factions%2F\<name of action\>
     Stores the action calling information when the Client invokes an Action.
--   things/\<hostName\>%2F\<title of Thing Description\>%2FactionResults%2F\<name of action\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>%2FactionResults%2F\<name of action\>
     Stores the result of an Action executed by the Server.
--   things/\<hostName\>%2F\<title of Thing Description\>%events%2F\<name of event\>  
+-   things/\<hostName\>%2F\<title of Thing Description\>%events%2F\<name of event\>
     Stores the emitted events.
 
 Data will always be overwritten and no history will be retained.
@@ -218,3 +219,7 @@ The WoT operations that can be implemented for Client as follows.
 Because communication with Firestore occurs, you may be charged for using Firebase.
 In order to avoid unexpected charges, please check your usage.
 You can check it at [Firebase console](https://console.firebase.google.com/).
+
+## More Details
+
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-http/README.md
+++ b/packages/binding-http/README.md
@@ -6,7 +6,7 @@ The protocol prefix handled by this binding is `http://` or `https://`.
 
 ## Getting Started
 
-In the following examples it is shown how to use the HTTP binding of node-wot.
+In the following examples, how to use the HTTP binding of node-wot is shown.
 
 ### Prerequisites
 
@@ -15,7 +15,8 @@ In the following examples it is shown how to use the HTTP binding of node-wot.
 
 ### Client Example
 
-The client example tries to connect to a TestThing via HTTP and reads a property `string`. The ThingDescription is located under the follwing uri http://plugfest.thingweb.io:8083/testthing.
+The client example tries to connect to a TestThing via HTTP and reads the `string` property.
+The Thing Description is located under the following uri <http://plugfest.thingweb.io:8083/testthing>.
 
 `node example-client.js`
 
@@ -55,7 +56,7 @@ wotHelper
 
 ### Server Example
 
-The server example produces a thing that allows for setting a property `count`. The thing is reachable through HTTP. Additional additional handlers could be added.
+The server example produces a thing that allows for setting a property `count`. The thing is reachable through HTTP.
 
 `node example-server.js`
 
@@ -80,9 +81,9 @@ servient.start().then((WoT) => {
         title: "MyCounter",
         properties: {
             count: {
-                type: "integer",
-            },
-        },
+                type: "integer"
+            }
+        }
     }).then((thing) => {
         console.log("Produced " + thing.getThingDescription().title);
         thing.writeProperty("count", 0);
@@ -91,14 +92,14 @@ servient.start().then((WoT) => {
             console.info(thing.getThingDescription().title + " ready");
             console.info("TD : " + JSON.stringify(thing.getThingDescription()));
             thing.readProperty("count").then((c) => {
-                console.log("cound is " + c);
+                console.log("count is " + c);
             });
         });
     });
 });
 ```
 
-The _secure_ server example shows how to add credentials and how to setup HTTPS.
+The _secure_ server example shows how to add credentials and how to set up HTTPS.
 
 `node example-server-secure.js`
 
@@ -116,7 +117,7 @@ servient.addCredentials({
         username: "node-wot",
         password: "hello",
         // token: "1/mZ1edKKACtPAb7zGlwSzvs72PvhAbGmB8K1ZrGxpcNM"
-    },
+    }
 });
 let httpConfig = {
     allowSelfSigned: true, // client configuration
@@ -124,7 +125,7 @@ let httpConfig = {
     serverCert: "certificate.pem",
     security: {
         scheme: "basic", // (username & password)
-    },
+    }
 };
 // add HTTPS binding with configuration
 servient.addServer(new HttpServer(httpConfig));
@@ -136,9 +137,9 @@ servient.start().then((WoT) => {
         title: "MyCounter",
         properties: {
             count: {
-                type: "integer",
-            },
-        },
+                type: "integer"
+            }
+        }
     }).then((thing) => {
         console.log("Produced " + thing.getThingDescription().title);
         thing.writeProperty("count", 0);
@@ -147,7 +148,7 @@ servient.start().then((WoT) => {
             console.info(thing.getThingDescription().title + " ready");
             console.info("TD : " + JSON.stringify(thing.getThingDescription()));
             thing.readProperty("count").then((c) => {
-                console.log("cound is " + c);
+                console.log("count is " + c);
             });
         });
     });

--- a/packages/binding-http/README.md
+++ b/packages/binding-http/README.md
@@ -1,5 +1,7 @@
 # HTTP Protocol Binding of node-wot
 
+W3C WoT Binding Template specification for HTTP can be found [here](https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html).
+
 ## Protocol specifier
 
 The protocol prefix handled by this binding is `http://` or `https://`.

--- a/packages/binding-mbus/README.md
+++ b/packages/binding-mbus/README.md
@@ -1,6 +1,10 @@
-# M-Bus Client Protocol Binding
+# M-Bus Client Protocol Binding of node-wot
 
-W3C Web of Things (WoT) Protocol Binding for Meter Bus TCP. This package uses [node-mbus](https://www.npmjs.com/package/node-mbus) as a low level client for M-Bus TCP. This implementation only supports reading data.
+## Overview
+
+W3C Web of Things (WoT) Protocol Binding for [Meter Bus](https://en.wikipedia.org/wiki/Meter-Bus) TCP.
+This package uses [node-mbus](https://www.npmjs.com/package/node-mbus) as a low level client for M-Bus TCP.
+This implementation only supports reading data (for WoT Consumer applications).
 
 ## Protocol specifier
 
@@ -8,13 +12,15 @@ The protocol prefix handled by this binding is `mbus+tcp:`. This is currently a 
 
 ## Disclaimer
 
-This binding is currently experimental. Some errors might occur with the use of this binding. The code was tested in a specific situation which might not correspond to your own using.
+This binding is currently experimental. Some errors might occur with the use of this binding.
+The code was tested in a specific situation which might not correspond to your own using.
 
 ## Getting Started
 
 ### Run the Example App
 
-The Binding example in the `./examples` directory provides a TD (`mbus-thing.json`) and an app script (`mbus-example.js`) . To execute the script use the pre-configure servient inside `./examples/servients` folder, as following:
+The Binding example in the `./examples` directory provides a TD (`mbus-thing.json`) and an app script (`mbus-example.js`).
+To execute the script use the pre-configure servient inside `./examples/servients` folder, as following:
 
 ```bash
 # first init the node package
@@ -83,7 +89,7 @@ Here's an example of a payload from a request on `offset=0` :
 
 The protocol does not support security.
 
-# Implementation notes
+## Implementation notes
 
 This implementation handles multiple requests to the same slave by combining them if possible. In the following, the terms **request** and **transaction** are used as follows to describe this:
 
@@ -119,3 +125,7 @@ Reads the data with the id of 1 of the unit 2
 
 -   [ ] TEST
 -   [ ] (M-Bus Server Protocol Binding)
+
+## More Details
+
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-modbus/README.md
+++ b/packages/binding-modbus/README.md
@@ -1,16 +1,21 @@
-# Modbus Client Protocol Binding
+# Modbus Client Protocol Binding of node-wot
 
-W3C Web of Things (WoT) Protocol Binding for Modbus TCP [RFC](https://tools.ietf.org/html/draft-dube-modbus-applproto-00). This package uses [modbus-serial](https://www.npmjs.com/package/modbus-serial) as a low level client for Modbus TCP.
+## Overview
+
+W3C Web of Things (WoT) Protocol Binding for [Modbus](https://en.wikipedia.org/wiki/Modbus) TCP [RFC](https://tools.ietf.org/html/draft-dube-modbus-applproto-00).
+This package uses [modbus-serial](https://www.npmjs.com/package/modbus-serial) as a low level client for Modbus TCP.
+W3C WoT Binding Template for Modbus can be found [here](https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/index.html).
 
 ## Protocol specifier
 
-The protocol prefix handled by this binding is `modbus+tcp:`. This is currently a non-standard prefix.
+The protocol prefix handled by this binding is `modbus+tcp://`.
 
 ## Getting Started
 
 ### Run the Example App
 
-The Binding example in the `./examples` directory provides a TD (`modbus-thing.jsonld`) and an app script (`modbus-example.js`) . To execute the script use the pre-configure servient inside `./examples/servients` folder, as following:
+The Binding example in the `./examples` directory provides a TD (`modbus-thing.jsonld`) and an app script (`modbus-example.js`) .
+To execute the script use the pre-configure servient inside `./examples/servients` folder, as following:
 
 ```bash
 # first init the node package
@@ -25,7 +30,8 @@ cd ../../scripts
 node ../servients/modbus-cli/dist/modbus-cli.js modbus-example.js
 ```
 
-**Rember** to correctly initialize your dev environment as described inside the [repository readme](https://github.com/eclipse/thingweb.node-wot/blob/master/README.md), before to start the example application. In particular, the optional step `sudo npm run link` must be executed.
+**Remember** to correctly initialize your development environment as described inside the [repository readme](https://github.com/eclipse/thingweb.node-wot/blob/master/README.md),
+before starting the example application. In particular, the optional step `sudo npm run link` must be executed.
 
 ## New Form Fields for the Modbus Binding
 
@@ -216,3 +222,7 @@ Polls the 8th holding register of the unit 1 every second.
     -   Impose some limit to the overall number of registers. The MODBUS protocol has such a limit and devices may define even lower values
 -   [ ] When a connection times out, re-connection does not work (see `connectionTimeout` in modbus-client.ts)
 -   [x] When a Modbus device is not reachable, scripts using binding-modbus stop working - corresponding error handling is necessary
+
+## More Details
+
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-mqtt/README.md
+++ b/packages/binding-mqtt/README.md
@@ -1,5 +1,13 @@
 # Eclipse Thingweb node-wot MQTT Binding
 
+W3C Web of Things (WoT) Protocol Binding for [MQTT](https://en.wikipedia.org/wiki/MQTT).
+This package uses [mqtt](https://www.npmjs.com/package/mqtt) as a low level library for MQTT.
+W3C WoT Binding Template for MQTT can be found [here](https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html).
+
+## Protocol specifier
+
+The protocol prefix handled by this binding is `mqtt://` or `mqtts://`.
+
 ## Getting Started
 
 In the following examples it is shown how to use the MQTT binding of node-wot.
@@ -9,11 +17,13 @@ In the following examples it is shown how to use the MQTT binding of node-wot.
 -   `npm install @node-wot/core`
 -   `npm install @node-wot/binding-mqtt`
 
-### MQTT Client Example I
+### MQTT Thing Example I
 
-An MQTT client frequently publishes counter data on the topic /MQTT-Test/events/counterEvent to the MQTT broker running behind the address test.mosquitto.org:1883. In addition, the client subscribes the resetCounter topic as WoT action to reset the own counter.
+An MQTT Thing frequently publishes counter values (as an Event Affordance) to the topic `/MQTT-Test/events/counterEvent` of the MQTT broker running behind the address `test.mosquitto.org:1883`.
+In addition, the Thing subscribes to the `resetCounter` topic (via its action handler) as a WoT Action Affordance so that
+it can handle requests to reset the counter value.
 
-```
+```js
 Servient = require("@node-wot/core").Servient
 MqttBrokerServer = require("@node-wot/binding-mqtt").MqttBrokerServer
 
@@ -23,55 +33,60 @@ servient.addServer(new MqttBrokerServer("mqtt://test.mosquitto.org"));
 
 servient.start().then((WoT) => {
 
-	var counter  = 0;
+    var counter  = 0;
 
-	WoT.produce({
-		title: "MQTT-Test",
-		actions: {
-			resetCounter: {
-				description: "Reset counter"
-			}
-		},
-		events: {
-			counterEvent: {
-				description: "Get counter"
-			}
-		}
-	})
-	.then((thing) => {
+    WoT.produce({
+        title: "MQTT-Test",
+        id: "urn:dev:wot:mqtt:counter",
+        actions: {
+            resetCounter: {
+                description: "Reset counter"
+            }
+        },
+        events: {
+            counterEvent: {
+                description: "Counter Value"
+                data:{
+                    type:"integer"
+                }
+            }
+        }
+    })
+    .then((thing) => {
 
-		thing.setActionHandler("resetCounter", () => {
-			console.log("Resetting counter");
-			counter = 0;
-		});
+        thing.setActionHandler("resetCounter", () => {
+            console.log("Resetting counter");
+            counter = 0;
+        });
 
-		thing.expose().then(() => {
-			console.info(thing.title + " ready");
+        thing.expose().then(() => {
+            console.info(thing.title + " ready");
 
-			setInterval(() => {
-				++counter;
-				thing.emitEvent("counterEvent", counter);
-				console.info("New count", counter);
-			}, 1000);
-		});
-	})
-	.catch((e) => {
-		console.log(e)
-	});
+            setInterval(() => {
+                ++counter;
+                thing.emitEvent("counterEvent ", counter);
+                console.info("New count ", counter);
+            }, 1000);
+        });
+    })
+    .catch((e) => {
+        console.log(e)
+    });
 });
 ```
 
 #### Sample Thing Description for MQTT Clients
 
-The corresponding Thing Description of the previous example is shown here:
+The Thing Description corresponding to the previous example is shown below:
 
-```
+```js
 {
     "@context": "https://www.w3.org/2019/wot/td/v1",
     "title": "MQTT-Test",
     "id": "urn:dev:wot:mqtt:counter",
     "actions" : {
         "resetCounter": {
+            "description": "Reset counter"
             "forms": [
                 {"href": "mqtt://test.mosquitto.org:1883/MQTT-Test/actions/resetCounter"}
             ]
@@ -79,7 +94,10 @@ The corresponding Thing Description of the previous example is shown here:
     },
     "events": {
         "counterEvent": {
-            "type": "integer",
+            "description": "Counter Value",
+            "data": {
+                "type": "integer"
+            },
             "forms": [
                 {"href": "mqtt://test.mosquitto.org:1883/MQTT-Test/events/counterEvent"}
             ]
@@ -90,9 +108,9 @@ The corresponding Thing Description of the previous example is shown here:
 
 ### MQTT Client Example II
 
-This example takes the Thing Description of the previous example and subscribe to the counter event and reset the counter every 20s.
+This example takes the Thing Description of the previous example and subscribes to the `counterEvent` and resets the counter every 20s via the `resetCounter` action.
 
-```
+```js
 Servient = require("@node-wot/core").Servient
 MqttClientFactory = require("@node-wot/binding-mqtt").MqttClientFactory
 
@@ -116,7 +134,8 @@ let td =
         }
     },
     "events": {
-        "counter": {
+        "counterEvent": {
+            "description": "Counter Value",
             "data": {
                 "type": "integer"
             },
@@ -159,13 +178,16 @@ try {
 
 ### More Examples
 
-There are sample implementations provided in the [example/scripting folder](https://github.com/eclipse/thingweb.node-wot/tree/master/examples/scripts).
+There are example implementations provided in the [example/scripting folder](https://github.com/eclipse/thingweb.node-wot/tree/master/examples/scripts).
 
 Please setup node-wot as described at the [node-wot main page](https://github.com/eclipse/thingweb.node-wot#as-a-standalone-application).
 
--   example-mqtt-publish.js: Shows when node-wot act as a MQTT Client that publish data (latest counter value) to a broker. In the same time the client setup an action (reset counter) that can be initated by another MQTT client by sending a publication message to this action based topic. Please note to provide MQTT broker details (host, port, [username], [password], [clientId]) in the wot-servient.conf.json:
+-   example-mqtt-publish.js: Shows when node-wot acts as a MQTT Client that publishes data (latest counter value) to a broker.
+At the same time, another client can invoke an action, such as `resetCounter`, by sending a publication message to the topic of this action.
+This other client does not have to be node-wot, any MQTT client can interact with this Thing.
+For node-wot clients, make sure to provide MQTT broker details (`host`, `port`, `username`, `password`, `clientId`) in the wot-servient.conf.json:
 
-```
+```js
 {
     "mqtt" : {
         "host" : "mqtt://test.mosquitto.org",
@@ -186,4 +208,4 @@ Start the script by the command `wot-servient -c mqtt-subscribe.js` or `node ../
 
 ### More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-netconf/README.md
+++ b/packages/binding-netconf/README.md
@@ -2,6 +2,9 @@
 
 W3C Web of Things (WoT) Protocol Binding for NETCONF [RFC6241](https://tools.ietf.org/html/rfc6241)
 
+## Protocol specifier
+
+The protocol prefix handled by this binding is `netconf://`.
 ## Getting Started
 
 ### Optional: NETCONF Server Simulator
@@ -125,3 +128,7 @@ Please note that, in order to make this binding work, each href should always co
 -   [ ] Subscriptions implementation (EVENTS)
 -   [x] TEST
 -   [ ] (NETCONF Server Protocol Binding ?)
+
+## More Details
+
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/binding-opcua/README.md
+++ b/packages/binding-opcua/README.md
@@ -1,6 +1,10 @@
 # OPC UA Client Protocol Binding
 
-W3C Web of Things (WoT) Protocol Binding for OPC UA
+W3C Web of Things (WoT) Protocol Binding for [OPC UA](https://en.wikipedia.org/wiki/OPC_Unified_Architecture).
+
+## Protocol specifier
+
+The protocol prefix handled by this binding is `opc.tcp://`.
 
 ## Getting Started
 
@@ -76,3 +80,7 @@ A basic OPC UA server crawler and a basic OPC UA -> TD translator can be found [
 -   [ ] Subscriptions implementation (EVENTS) with Sub/Pub protocol
 -   [x] TEST
 -   [ ] (OPC UA Server Protocol Binding ?)
+
+## More Details
+
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/browser-bundle/README.md
+++ b/packages/browser-bundle/README.md
@@ -30,8 +30,9 @@ Install browser-bundle in your project by running
 ## Example and live demo
 
 An example of how to use node-wot as a browser-side library can be found under `https://github.com/eclipse/thingweb.node-wot/blob/master/examples/browser/index.html`.
-To run it live, open [`examples/browser/index.html`](http://plugfest.thingweb.io/webui/) in a modern browser, and consume the test Thing available under `http://plugfest.thingweb.io:8083/testthing` to interact with it.
+To run it live, open [`examples/browser/index.html`](http://plugfest.thingweb.io/webui/) in a modern browser,
+and consume the test Thing available under `http://plugfest.thingweb.io:8083/testthing` to interact with it.
 
-## More Information
+## More Details
 
-Visit the node-wot github project page here: https://github.com/eclipse/thingweb.node-wot
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,6 +112,6 @@ ADDRESS=http://hello.com
 
 See [node-wot examples using Node.js](https://github.com/eclipse/thingweb.node-wot/#no-time-for-explanations---show-me-a-running-example).
 
-### More Details
+## More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # Core of node-wot
 
-The `core` of node-wot is the entry point allowing to attach dedicated bindings such as:
+The core of node-wot is the entry point allowing to attach dedicated bindings such as:
 
 -   [HTTP](https://github.com/eclipse/thingweb.node-wot/blob/master/packages/binding-http)
 -   [CoAP](https://github.com/eclipse/thingweb.node-wot/blob/master/packages/binding-coap)
@@ -19,6 +19,6 @@ see binding examples such as
 -   https://github.com/eclipse/thingweb.node-wot/blob/master/packages/binding-http
 -   https://github.com/eclipse/thingweb.node-wot/blob/master/packages/binding-coap
 
-### More Details
+## More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>

--- a/packages/td-tools/README.md
+++ b/packages/td-tools/README.md
@@ -1,4 +1,4 @@
-# TD (ThingDescription) tools of node-wot
+# TD (Thing Description) tools of node-wot
 
 ## Getting Started
 
@@ -47,6 +47,6 @@ console.log(tdString2);
 console.log("****");
 ```
 
-### More Details
+## More Details
 
-see https://github.com/eclipse/thingweb.node-wot/
+See <https://github.com/eclipse/thingweb.node-wot/>


### PR DESCRIPTION
So I wanted to fix the language highlighting of the README of the MQTT package and in the end, I ended up going through all the packages. A few changes can be opinionated. What I have done in general:
- Make sure that code snippets have a language (having js after the triple ` )
- URI Scheme of each protocol is mentioned in the beginning
- Fix tabs to spaces in code snippets
- At the end of each readme has a clickable link that points to the github home page of node-wot (important since packages published to npm see the package readme and they are not aware of the entire project)
- Added Wikipedia links to protocols (most of them at least)
- Added Binding Template link to the beginning. Putting this in the beginning seems a bit weird, maybe.
- Fixed typos and English issues

Some notes:

- I think that each protocol should have a simple overview section in the beginning, a bit like [firestore](https://github.com/egekorkan/thingweb.node-wot/tree/master/packages/binding-firestore) has. 
- The examples in the readmes are old. While I was doing this, https://github.com/eclipse/thingweb.node-wot/pull/669 was still not merged so I did not do this yet.
- I think that each readme should contain a TD that can be consumed by the client of this protocol. Given that all protocols at least have the client-side, this sounds reasonable since TDs can be written by hand.

Signed-off-by: Ege Korkan <egekorkan@gmail.com>