### PR TITLE
Fix browser example

### DIFF
--- a/examples/browser/counter.js
+++ b/examples/browser/counter.js
@@ -44,12 +44,12 @@ function showInteractions(thing) {
             dtItem.appendChild(link);
             document.getElementById("properties").appendChild(dtItem);
             document.getElementById("properties").appendChild(ddItem);
-
+            console.log("property: " + td.properties[property]);
             dtItem.onclick = (click) => {
                 thing
                     .readProperty(property)
-                    .then((res) => {
-                        ddItem.textContent = res;
+                    .then(async (res) => {
+                        ddItem.textContent = await res.value();
                     })
                     .catch((err) => window.alert("error: " + err));
             };
@@ -103,7 +103,7 @@ function showInteractions(thing) {
             document.getElementById("events").appendChild(item);
 
             eventSubscriptions[evnt] = false;
-
+            let subscription;
             checkbox.onclick = (click) => {
                 if (
                     document.getElementById(evnt).checked &&
@@ -113,12 +113,13 @@ function showInteractions(thing) {
                     console.log("Try subscribing for event: " + evnt);
                     eventSubscriptions[evnt] = true;
                     thing
-                        .subscribeEvent(evnt, function (data) {
-                            console.log("Data:" + data);
+                        .subscribeEvent(evnt, async function (data) {
+                            console.log("Data:" + (await data.value()));
                             updateProperties();
                         })
-                        .then(() => {
-                            // OK
+                        .then((sub) => {
+                            subscription = sub;
+                            console.log("Subscribed for event: " + evnt);
                         })
                         .catch((error) => {
                             window.alert("Event " + evnt + " error\nMessage: " + error);
@@ -126,14 +127,16 @@ function showInteractions(thing) {
                 } else if (!document.getElementById(evnt).checked && eventSubscriptions[evnt]) {
                     console.log("Try to unsubscribing for event: " + evnt);
                     eventSubscriptions[evnt] = false;
-                    thing
-                        .unsubscribeEvent(evnt)
-                        .then(() => {
-                            // OK
-                        })
-                        .catch((error) => {
-                            window.alert("Event " + evnt + " error\nMessage: " + error);
-                        });
+                    if (subscription) {
+                        subscription
+                            .stop()
+                            .then(() => {
+                                console.log("Unsubscribed for event: " + evnt);
+                            })
+                            .catch((error) => {
+                                window.alert("Event " + evnt + " error\nMessage: " + error);
+                            });
+                    }
                 }
             };
         }

--- a/examples/browser/counter.js
+++ b/examples/browser/counter.js
@@ -44,7 +44,6 @@ function showInteractions(thing) {
             dtItem.appendChild(link);
             document.getElementById("properties").appendChild(dtItem);
             document.getElementById("properties").appendChild(ddItem);
-            console.log("property: " + td.properties[property]);
             dtItem.onclick = (click) => {
                 thing
                     .readProperty(property)

--- a/examples/scripts/counter.js
+++ b/examples/scripts/counter.js
@@ -121,6 +121,7 @@ WoT.produce({
     events: {
         change: {
             description: "change event",
+            data: { type: "integer" },
             descriptions: {
                 en: "change event",
                 de: "Änderungsnachricht",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "./packages/core",
                 "./packages/binding-!(firestore-browser-bundle|firestore)",
                 "./packages/cli",
-                "./packages/examples"
+                "./packages/examples",
+                "./packages/browser-bundle"
             ],
             "devDependencies": {
                 "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         }
     },
     "scripts": {
-        "build": "tsc -b",
+        "build": "tsc -b && npm run build -w packages/browser-bundle",
         "pretest": "npm run build",
         "start": "cd packages/cli && npm run start",
         "debug": "cd packages/cli && npm run debug",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "./packages/core",
         "./packages/binding-!(firestore-browser-bundle|firestore)",
         "./packages/cli",
-        "./packages/examples"
+        "./packages/examples",
+        "./packages/browser-bundle"
     ],
     "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -914,6 +914,10 @@ export default class HttpServer implements ProtocolServer {
                                 res.setTimeout(60 * 60 * 1000, () =>
                                     thing.handleUnsubscribeEvent(segments[3], listener, options)
                                 );
+                            } else if (req.method === "HEAD") {
+                                // HEAD support for long polling subscription
+                                res.writeHead(202);
+                                res.end();
                             } else {
                                 respondUnallowedMethod(res, "GET");
                             }

--- a/packages/binding-http/src/oauth-manager.ts
+++ b/packages/binding-http/src/oauth-manager.ts
@@ -16,7 +16,6 @@
 import { OAuth2SecurityScheme } from "@node-wot/td-tools";
 import ClientOAuth2 from "client-oauth2";
 import { request, RequestOptions } from "https";
-import { URL } from "url";
 import { OAuthCredential } from "./credential";
 
 function createRequestFunction(rejectUnauthorized: boolean) {

--- a/packages/binding-http/src/subscription-protocols.ts
+++ b/packages/binding-http/src/subscription-protocols.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { HttpClient, HttpForm } from "./http";
 import EventSource from "eventsource";
-import { Content } from "@node-wot/core";
+import { Content, ProtocolHelpers } from "@node-wot/core";
 import { Readable } from "stream";
 export interface InternalSubscription {
     open(next: (value: Content) => void, error?: (error: Error) => void, complete?: () => void): Promise<void>;
@@ -72,7 +72,10 @@ export class LongPollingSubscription implements InternalSubscription {
                     );
 
                     if (!this.closed) {
-                        next({ type: result.headers.get("content-type"), body: result.body });
+                        // in browsers node-fetch uses the native fetch, which returns a ReadableStream
+                        // not complaint with node. Therefore we have to force the conversion here.
+                        const body = ProtocolHelpers.toNodeStream(result.body as Readable);
+                        next({ type: result.headers.get("content-type"), body });
                         polling(false);
                     }
 

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -22,7 +22,7 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.21"
     },
     "scripts": {
-        "build": "browserify -r vm:vm2 index.js --plugin tinyify --external coffee-script -o dist/wot-bundle.min.js",
+        "build": "browserify -r vm:vm2 index.js --external coffee-script -o dist/wot-bundle.min.js",
         "format": "prettier --write index.js \"**/*.json\""
     },
     "bugs": {

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -29,5 +29,10 @@
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"
     },
     "homepage": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/browser-bundle#readme",
-    "keywords": []
+    "keywords": [],
+    "dependencies": {
+        "inherits": "^2.0.3",
+        "resolve": "^1.1.7",
+        "events": "^2.1.0"
+    }
 }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -25,7 +25,6 @@
  * ```
  */
 
-import { URL } from "url";
 import * as os from "os";
 
 // imports for fetchTD

--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -225,23 +225,25 @@ export default class ProtocolHelpers {
         return result;
     }
 
-    public static toNodeStream(stream: ReadableStream | PolyfillStream | IManagedStream): Readable {
+    public static toNodeStream(stream: ReadableStream | PolyfillStream | IManagedStream | Readable): Readable {
         if (isManaged(stream)) {
             return stream.nodeStream;
         }
 
+        if (stream instanceof Readable) {
+            return stream;
+        }
+
+        const reader = stream.getReader();
         const result = new ManagedReadable({
             read: (size) => {
-                stream
-                    .getReader()
-                    .read()
-                    .then((data) => {
-                        result.push(data.value);
-                        if (data.done) {
-                            // signal end
-                            result.push(null);
-                        }
-                    });
+                reader.read().then((data) => {
+                    result.push(data.value);
+                    if (data.done) {
+                        // signal end
+                        result.push(null);
+                    }
+                });
             },
             destroy: (error, callback) => {
                 stream.cancel(error);


### PR DESCRIPTION
This PR introduces back the browser bundle among the supported packages. A couple of notes:
1. I discovered that `node-fetch` when used in browsers defaults to native `fetch` implementation this means the http client was sending `ReadableStreams` (instead of `Readable` from NodeJS) instance to the core. The core is expecting that every binding respect the contract of the `Content` interface which requires a NodeJS `Readable`. This PR changes `binding-http` to convert the stream before sending it the the `core`
2. `browserify` is using an old package for replacing nodejs `url` package. This creates issues when directly importing `url`. I discovered that using the global `URL` variable bypass `browserify` and it works well in browsers too. This PRs adds this workaround. Maybe #640 is another possible solution
3. I improved a little bit the example code and updated it
4. I fixed a bug when handling HTTP log polling requests from events. The servent was not handling head requests properly. 