### PR TITLE
add minimum npm version as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ cs.addCodec(new MyCodec("application/myType"));
 All systems require:
 
 -   [NodeJS](https://nodejs.org/) version 12+
+-   [npm](https://www.npmjs.com/) version 7+
 
 #### Linux
 


### PR DESCRIPTION
I recently struggled over a problem with having an NPM v 6 on an older machine.
Unfortunately the error log wasn't very clear what was causing the issue.

Hence I suggest to add this note about minimum npm requirement also.