### PR TITLE
Solve Eslint issues with circular definitions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,8 @@ module.exports = {
         ],
         "workspaces/no-relative-imports": "error",
         "@typescript-eslint/no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-use-before-define": ["error"],
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [
             "warn",

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -27,6 +27,10 @@ import { readFileSync } from "fs";
 import OAuthServer from "express-oauth-server";
 import bodyParser from "body-parser";
 
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 @suite("HTTP oauth client implementation")
 class HttpClientOAuthTest {
     private client: HttpClient;
@@ -152,8 +156,4 @@ class HttpClientOAuthTest {
         const body = await ProtocolHelpers.readStreamFully(resource.body);
         body.toString("ascii").should.eql("Ok!");
     }
-}
-
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -19,6 +19,8 @@ import { IntrospectionEndpoint, EndpointValidator } from "../src/oauth-token-val
 import Servient, { ExposedThing } from "@node-wot/core";
 import fetch from "node-fetch";
 
+class MockServient extends Servient {}
+
 should();
 @suite("OAuth server token validation tests")
 class OAuthServerTests {
@@ -128,5 +130,3 @@ class OAuthServerTests {
         response.status.should.be.equal(401);
     }
 }
-
-class MockServient extends Servient {}

--- a/packages/binding-mbus/src/mbus-connection.ts
+++ b/packages/binding-mbus/src/mbus-connection.ts
@@ -26,6 +26,30 @@ const configDefaults = {
 };
 
 /**
+ * MBusTransaction represents a raw M-Bus operation performed on a MBusConnection
+ */
+class MBusTransaction {
+    unitId: number;
+    base: number;
+    operations: Array<PropertyOperation>; // operations to be completed when this transaction completes
+    constructor(unitId: number, base: number) {
+        this.unitId = unitId;
+        this.base = base;
+        this.operations = new Array<PropertyOperation>();
+    }
+
+    /**
+     * Link PropertyOperation with this transaction, so that operations can be
+     * notified about the result of a transaction.
+     *
+     * @param op the PropertyOperation to link with this transaction
+     */
+    inform(op: PropertyOperation) {
+        this.operations.push(op);
+    }
+}
+
+/**
  * MBusConnection represents a client connected to a specific host and port
  */
 export class MBusConnection {
@@ -36,9 +60,7 @@ export class MBusConnection {
     connecting: boolean;
     connected: boolean;
     timer: NodeJS.Timer; // connection idle timer
-    // eslint-disable-next-line no-use-before-define
     currentTransaction: MBusTransaction; // transaction currently in progress or null
-    // eslint-disable-next-line no-use-before-define
     queue: Array<MBusTransaction>; // queue of further transactions
     config: {
         connectionTimeout?: number;
@@ -230,31 +252,6 @@ export class MBusConnection {
         });
         clearInterval(this.timer);
         this.timer = null;
-    }
-}
-
-/**
- * MBusTransaction represents a raw M-Bus operation performed on a MBusConnection
- */
-class MBusTransaction {
-    unitId: number;
-    base: number;
-    // eslint-disable-next-line no-use-before-define
-    operations: Array<PropertyOperation>; // operations to be completed when this transaction completes
-    constructor(unitId: number, base: number) {
-        this.unitId = unitId;
-        this.base = base;
-        this.operations = new Array<PropertyOperation>();
-    }
-
-    /**
-     * Link PropertyOperation with this transaction, so that operations can be
-     * notified about the result of a transaction.
-     *
-     * @param op the PropertyOperation to link with this transaction
-     */
-    inform(op: PropertyOperation) {
-        this.operations.push(op);
     }
 }
 

--- a/packages/binding-modbus/src/modbus-connection.ts
+++ b/packages/binding-modbus/src/modbus-connection.ts
@@ -135,9 +135,7 @@ export class ModbusConnection {
     connecting: boolean;
     connected: boolean;
     timer: NodeJS.Timer; // connection idle timer
-    // eslint-disable-next-line no-use-before-define
     currentTransaction: ModbusTransaction; // transaction currently in progress or null
-    // eslint-disable-next-line no-use-before-define
     queue: Array<ModbusTransaction>; // queue of further transactions
     config: {
         connectionTimeout?: number;

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -25,6 +25,35 @@ import { CoapServer, CoapClientFactory, CoapsClientFactory } from "@node-wot/bin
 import { MqttBrokerServer, MqttClientFactory } from "@node-wot/binding-mqtt";
 import { FileClientFactory } from "@node-wot/binding-file";
 
+// Helper function needed for `mergeConfigs` function
+function isObject(item: unknown) {
+    return item && typeof item === "object" && !Array.isArray(item);
+}
+
+/**
+ * Helper function merging default parameters into a custom config file.
+ *
+ * @param {object} target - an object containing default config parameters
+ * @param {object} source - an object containing custom config parameters
+ *
+ * @return {object} The new config file containing both custom and default parameters
+ */
+function mergeConfigs(target: any, source: any): any {
+    const output = Object.assign({}, target);
+    Object.keys(source).forEach((key) => {
+        if (!(key in target)) {
+            Object.assign(output, { [key]: source[key] });
+        } else {
+            if (isObject(target[key]) && isObject(source[key])) {
+                output[key] = mergeConfigs(target[key], source[key]);
+            } else {
+                Object.assign(output, { [key]: source[key] });
+            }
+        }
+    });
+    return output;
+}
+
 export default class DefaultServient extends Servient {
     private static readonly defaultConfig = {
         servient: {
@@ -266,33 +295,4 @@ export default class DefaultServient extends Servient {
             this.logLevel = "info";
         }
     }
-}
-
-/**
- * Helper function merging default parameters into a custom config file.
- *
- * @param {object} target - an object containing default config parameters
- * @param {object} source - an object containing custom config parameters
- *
- * @return {object} The new config file containing both custom and default parameters
- */
-function mergeConfigs(target: any, source: any): any {
-    const output = Object.assign({}, target);
-    Object.keys(source).forEach((key) => {
-        if (!(key in target)) {
-            Object.assign(output, { [key]: source[key] });
-        } else {
-            if (isObject(target[key]) && isObject(source[key])) {
-                output[key] = mergeConfigs(target[key], source[key]);
-            } else {
-                Object.assign(output, { [key]: source[key] });
-            }
-        }
-    });
-    return output;
-}
-
-// Helper function needed for `mergeConfigs` function
-function isObject(item: unknown) {
-    return item && typeof item === "object" && !Array.isArray(item);
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -251,7 +251,7 @@ Options:
   -ib, --inspect-brk[=[host:]port] activate inspector on host:port and break at start of user script
   -c,  --clientonly                do not start any servers
                                    (enables multiple instances without port conflicts)
-  -cp,  --compiler <module>        load module as a compiler 
+  -cp,  --compiler <module>        load module as a compiler
                                    (The module must export a create function which returns
                                     an object with a compile method)
   -f,  --configfile <file>         load configuration from specified file
@@ -307,8 +307,8 @@ wot-servient.conf.json fields:
   USERNAME        : string for providing a Basic Auth username
   PASSWORD        : string for providing a Basic Auth password
   ---------------------------------------------------------------------------
- 
-Environment variables must be provided in a .env file in the current working directory. 
+
+Environment variables must be provided in a .env file in the current working directory.
 
 Example:
 VAR1=Value1

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -20,6 +20,33 @@ import ExposedThing from "./exposed-thing";
 import ConsumedThing from "./consumed-thing";
 import Helpers from "./helpers";
 
+export class ThingDiscoveryImpl implements WoT.ThingDiscovery {
+    filter?: WoT.ThingFilter;
+    active: boolean;
+    done: boolean;
+    error?: Error;
+    constructor(filter?: WoT.ThingFilter) {
+        this.filter = filter || null;
+        this.active = false;
+        this.done = false;
+        this.error = new Error("not implemented");
+    }
+
+    start(): void {
+        this.active = true;
+    }
+
+    next(): Promise<WoT.ThingDescription> {
+        return new Promise<WoT.ThingDescription>((resolve, reject) => {
+            reject(this.error); // not implemented
+        });
+    }
+
+    stop(): void {
+        this.active = false;
+        this.done = false;
+    }
+}
 export default class WoTImpl {
     private srv: Servient;
     DiscoveryMethod: typeof WoT.DiscoveryMethod;
@@ -89,34 +116,6 @@ export enum DiscoveryMethod {
     "directory",
     /** for discovering Things in the device's network by using a supported multicast protocol  */
     "multicast",
-}
-
-export class ThingDiscoveryImpl implements WoT.ThingDiscovery {
-    filter?: WoT.ThingFilter;
-    active: boolean;
-    done: boolean;
-    error?: Error;
-    constructor(filter?: WoT.ThingFilter) {
-        this.filter = filter || null;
-        this.active = false;
-        this.done = false;
-        this.error = new Error("not implemented");
-    }
-
-    start(): void {
-        this.active = true;
-    }
-
-    next(): Promise<WoT.ThingDescription> {
-        return new Promise<WoT.ThingDescription>((resolve, reject) => {
-            reject(this.error); // not implemented
-        });
-    }
-
-    stop(): void {
-        this.active = false;
-        this.done = false;
-    }
 }
 
 /** Instantiation of the WoT.DataType declaration */

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -40,6 +40,91 @@ chaiUse(chaiAsPromised);
 
 // should must be called to augment all variables
 should();
+
+const myThingDesc = {
+    "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
+    "@type": ["Thing"],
+    id: "urn:dev:wot:test-thing",
+    title: "aThing",
+    security: [{ scheme: "nosec" }],
+    uriVariables: {
+        idTestGlobal: {
+            type: "string",
+            default: "test2",
+        },
+    },
+    properties: {
+        aProperty: {
+            type: "integer",
+            readOnly: false,
+            forms: [
+                {
+                    href: "testdata://host/athing/properties/aproperty{?idTest,idTestGlobal}",
+                    mediaType: "application/json",
+                },
+            ],
+            uriVariables: {
+                idTest: {
+                    type: "string",
+                },
+            },
+        },
+        aPropertyToObserve: {
+            type: "integer",
+            readOnly: false,
+            observable: true,
+            forms: [
+                {
+                    href: "testdata://host/athing/properties/apropertytoobserve",
+                    mediaType: "application/json",
+                    op: ["observeproperty", "unobserveproperty"],
+                },
+                {
+                    href: "testdata://host/athing/properties/apropertytoobserve1",
+                    contentType: "application/json",
+                    op: ["observeproperty"],
+                },
+                {
+                    href: "testdata://host/athing/properties/apropertytoobserve1",
+                    contentType: "application/json",
+                    op: ["unobserveproperty"],
+                },
+            ],
+        },
+    },
+    actions: {
+        anAction: {
+            input: { type: "integer" },
+            output: { type: "integer" },
+            forms: [{ href: "testdata://host/athing/actions/anaction", mediaType: "application/json" }],
+        },
+    },
+    events: {
+        anEvent: {
+            data: {
+                type: "string",
+            },
+            forms: [
+                {
+                    href: "testdata://host/athing/events/anevent",
+                    mediaType: "application/json",
+                    op: ["subscribeevent", "unsubscribeevent"],
+                },
+                {
+                    href: "testdata://host/athing/events/anevent",
+                    contentType: "application/json",
+                    op: ["subscribeevent"],
+                },
+                {
+                    href: "testdata://host/athing/events/anevent",
+                    contentType: "application/json",
+                    op: ["unsubscribeevent"],
+                },
+            ],
+        },
+    },
+};
+
 class TDClient implements ProtocolClient {
     public readResource(form: Form): Promise<Content> {
         // Note: this is not a "real" DataClient! Instead it just reports the same TD in any case
@@ -215,90 +300,6 @@ class TestProtocolClient implements ProtocolClient {
         return true;
     }
 }
-
-const myThingDesc = {
-    "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
-    "@type": ["Thing"],
-    id: "urn:dev:wot:test-thing",
-    title: "aThing",
-    security: [{ scheme: "nosec" }],
-    uriVariables: {
-        idTestGlobal: {
-            type: "string",
-            default: "test2",
-        },
-    },
-    properties: {
-        aProperty: {
-            type: "integer",
-            readOnly: false,
-            forms: [
-                {
-                    href: "testdata://host/athing/properties/aproperty{?idTest,idTestGlobal}",
-                    mediaType: "application/json",
-                },
-            ],
-            uriVariables: {
-                idTest: {
-                    type: "string",
-                },
-            },
-        },
-        aPropertyToObserve: {
-            type: "integer",
-            readOnly: false,
-            observable: true,
-            forms: [
-                {
-                    href: "testdata://host/athing/properties/apropertytoobserve",
-                    mediaType: "application/json",
-                    op: ["observeproperty", "unobserveproperty"],
-                },
-                {
-                    href: "testdata://host/athing/properties/apropertytoobserve1",
-                    contentType: "application/json",
-                    op: ["observeproperty"],
-                },
-                {
-                    href: "testdata://host/athing/properties/apropertytoobserve1",
-                    contentType: "application/json",
-                    op: ["unobserveproperty"],
-                },
-            ],
-        },
-    },
-    actions: {
-        anAction: {
-            input: { type: "integer" },
-            output: { type: "integer" },
-            forms: [{ href: "testdata://host/athing/actions/anaction", mediaType: "application/json" }],
-        },
-    },
-    events: {
-        anEvent: {
-            data: {
-                type: "string",
-            },
-            forms: [
-                {
-                    href: "testdata://host/athing/events/anevent",
-                    mediaType: "application/json",
-                    op: ["subscribeevent", "unsubscribeevent"],
-                },
-                {
-                    href: "testdata://host/athing/events/anevent",
-                    contentType: "application/json",
-                    op: ["subscribeevent"],
-                },
-                {
-                    href: "testdata://host/athing/events/anevent",
-                    contentType: "application/json",
-                    op: ["unsubscribeevent"],
-                },
-            ],
-        },
-    },
-};
 
 @suite("client flow of servient")
 class WoTClientTest {

--- a/packages/examples/src/scripts/counter-client.ts
+++ b/packages/examples/src/scripts/counter-client.ts
@@ -18,6 +18,17 @@ import { ThingDescription } from "wot-typescript-definitions";
 
 let WoTHelpers: Helpers;
 
+function getFormIndexForDecrementWithCoAP(thing: WoT.ConsumedThing): number {
+    const forms = thing.getThingDescription().actions.decrement.forms;
+    for (let i = 0; i < forms.length; i++) {
+        if (/^coaps?:\/\/.*/.test(forms[i].href)) {
+            return i;
+        }
+    }
+    // return formIndex: 0 if no CoAP target IRI found
+    return 0;
+}
+
 WoTHelpers.fetch("coap://localhost:5683/counter")
     .then(async (td) => {
         // using await for serial execution (note 'async' in then() of fetch())
@@ -54,14 +65,3 @@ WoTHelpers.fetch("coap://localhost:5683/counter")
     .catch((err) => {
         console.error("Fetch error:", err);
     });
-
-function getFormIndexForDecrementWithCoAP(thing: WoT.ConsumedThing): number {
-    const forms = thing.getThingDescription().actions.decrement.forms;
-    for (let i = 0; i < forms.length; i++) {
-        if (/^coaps?:\/\/.*/.test(forms[i].href)) {
-            return i;
-        }
-    }
-    // return formIndex: 0 if no CoAP target IRI found
-    return 0;
-}

--- a/packages/examples/src/scripts/smart-coffee-machine-client.ts
+++ b/packages/examples/src/scripts/smart-coffee-machine-client.ts
@@ -21,6 +21,14 @@ import { ThingDescription } from "wot-typescript-definitions";
 import { Helpers } from "@node-wot/core";
 let WoTHelpers: Helpers;
 
+// Print data and an accompanying message in a distinguishable way
+function log(msg: string, data: unknown) {
+    console.info("======================");
+    console.info(msg);
+    console.dir(data);
+    console.info("======================");
+}
+
 WoTHelpers.fetch("http://127.0.0.1:8080/smart-coffee-machine").then(async (td) => {
     try {
         const thing = await WoT.consume(td as ThingDescription);
@@ -88,11 +96,3 @@ WoTHelpers.fetch("http://127.0.0.1:8080/smart-coffee-machine").then(async (td) =
         console.error("Script error:", err);
     }
 });
-
-// Print data and an accompanying message in a distinguishable way
-function log(msg: string, data: unknown) {
-    console.info("======================");
-    console.info(msg);
-    console.dir(data);
-    console.info("======================");
-}

--- a/packages/examples/src/scripts/smart-coffee-machine.ts
+++ b/packages/examples/src/scripts/smart-coffee-machine.ts
@@ -23,6 +23,17 @@ let maintenanceNeeded: boolean;
 let schedules: unknown[];
 let servedCounter: number;
 
+function readFromSensor(sensorType: string): number {
+    // Actual implementation of reading data from a sensor can go here
+    // For the sake of example, let's just return a value
+    return 100;
+}
+
+function notify(subscribers: unknown, msg: string) {
+    // Actual implementation of notifying subscribers with a message can go here
+    console.log(msg);
+}
+
 WoT.produce({
     title: "Smart-Coffee-Machine",
     description: `A smart coffee machine with a range of capabilities.
@@ -409,14 +420,3 @@ Assumes one medium americano if not specified, but time and mode are mandatory f
     .catch((e) => {
         console.log(e);
     });
-
-function readFromSensor(sensorType: string): number {
-    // Actual implementation of reading data from a sensor can go here
-    // For the sake of example, let's just return a value
-    return 100;
-}
-
-function notify(subscribers: unknown, msg: string) {
-    // Actual implementation of notifying subscribers with a message can go here
-    console.log(msg);
-}

--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -20,6 +20,26 @@ import isAbsoluteUrl = require("is-absolute-url");
 import URLToolkit = require("url-toolkit");
 
 /** Parses a TD into a Thing object */
+
+function addDefaultLanguage(thing: Thing) {
+    // add @language : "en" if no @language set
+    if (Array.isArray(thing["@context"])) {
+        const arrayContext: Array<string | Record<string, unknown>> = thing["@context"];
+        let languageSet = false;
+        for (const arrayEntry of arrayContext) {
+            if (typeof arrayEntry === "object") {
+                if (arrayEntry["@language"] !== undefined) {
+                    languageSet = true;
+                }
+            }
+        }
+        if (!languageSet) {
+            arrayContext.push({
+                "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
+            });
+        }
+    }
+}
 export function parseTD(td: string, normalize?: boolean): Thing {
     console.debug("[td-tools/td-parser]", `parseTD() parsing\n\`\`\`\n${td}\n\`\`\``);
 
@@ -210,26 +230,6 @@ export function parseTD(td: string, normalize?: boolean): Thing {
     }
 
     return thing;
-}
-
-function addDefaultLanguage(thing: Thing) {
-    // add @language : "en" if no @language set
-    if (Array.isArray(thing["@context"])) {
-        const arrayContext: Array<string | Record<string, unknown>> = thing["@context"];
-        let languageSet = false;
-        for (const arrayEntry of arrayContext) {
-            if (typeof arrayEntry === "object") {
-                if (arrayEntry["@language"] !== undefined) {
-                    languageSet = true;
-                }
-            }
-        }
-        if (!languageSet) {
-            arrayContext.push({
-                "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
-            });
-        }
-    }
 }
 
 /** Serializes a Thing object into a TD */

--- a/packages/td-tools/src/thing-description.ts
+++ b/packages/td-tools/src/thing-description.ts
@@ -13,9 +13,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-// Ignored because of circular definitions
-/* eslint-disable no-use-before-define */
-
 // global W3C WoT Scripting API definitions
 import * as WoT from "wot-typescript-definitions";
 


### PR DESCRIPTION
This PR should resolve the first point of #534. The typescript-specific rule `@typescript-eslint/no-use-before-define` is added as an replacement for `no-use-before-define` which gets rid of some false positives. In the remaining cases, the issues are resolved by reordering definitions so that they are only used after they have been introduced.