### PR TITLE
fix(examples): fix oauth2 exposer example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14337,9 +14337,9 @@
             "dev": true
         },
         "node_modules/wot-thing-description-types": {
-            "version": "1.1.0-27-September-2021",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-27-September-2021.tgz",
-            "integrity": "sha512-DprWwVZKnEJSS5qNI0NHJSLYv6tmIkA3wSXjl9OskAXFMnQpxTwnlNT960f341XFDJF9pUBfi7nsD+7tnaFlvA=="
+            "version": "1.1.0-09-February-2022",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-February-2022.tgz",
+            "integrity": "sha512-XQ83iwPm5Y4i68VSu30k+ROHMgvSIdAAOx4BS+nOWwnW/v1oKsDAaeaIPiJu0ReLk7HvSd+ewaRgaL6aqCNnOQ=="
         },
         "node_modules/wot-thing-model-types": {
             "version": "1.1.0-3-February-2022",
@@ -15022,7 +15022,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             },
             "optionalDependencies": {
@@ -15068,7 +15068,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-thing-model-types": "^1.1.0-3-February-2022",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.22"
             }
@@ -15102,7 +15102,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             }
         },
@@ -15113,7 +15113,7 @@
             "dependencies": {
                 "is-absolute-url": "3.0.3",
                 "url-toolkit": "2.1.6",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             },
             "devDependencies": {
@@ -16067,7 +16067,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             }
         },
@@ -16106,7 +16106,7 @@
                 "uuid": "^7.0.3",
                 "vm2": "^3.9.6",
                 "web-streams-polyfill": "^3.0.1",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-thing-model-types": "^1.1.0-3-February-2022",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.22"
             }
@@ -16136,7 +16136,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             }
         },
@@ -16167,7 +16167,7 @@
                 "url-toolkit": "2.1.6",
                 "webpack": "^5.53.0",
                 "webpack-cli": "^4.8.0",
-                "wot-thing-description-types": "^1.1.0-26-July-2021a",
+                "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             }
         },
@@ -27178,9 +27178,9 @@
             "dev": true
         },
         "wot-thing-description-types": {
-            "version": "1.1.0-27-September-2021",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-27-September-2021.tgz",
-            "integrity": "sha512-DprWwVZKnEJSS5qNI0NHJSLYv6tmIkA3wSXjl9OskAXFMnQpxTwnlNT960f341XFDJF9pUBfi7nsD+7tnaFlvA=="
+            "version": "1.1.0-09-February-2022",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-February-2022.tgz",
+            "integrity": "sha512-XQ83iwPm5Y4i68VSu30k+ROHMgvSIdAAOx4BS+nOWwnW/v1oKsDAaeaIPiJu0ReLk7HvSd+ewaRgaL6aqCNnOQ=="
         },
         "wot-thing-model-types": {
             "version": "1.1.0-3-February-2022",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-26-July-2021a",
+        "wot-thing-description-types": "^1.1.0-09-February-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
     },
     "optionalDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-26-July-2021a",
+        "wot-thing-description-types": "^1.1.0-09-February-2022",
         "wot-thing-model-types": "^1.1.0-3-February-2022",
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.22"
     },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -23,7 +23,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-26-July-2021a",
+        "wot-thing-description-types": "^1.1.0-09-February-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
     },
     "dependencies": {

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -35,7 +35,6 @@ const td = {
     },
 };
 try {
-    // @ts-ignore see https://github.com/w3c/wot-thing-description/issues/1162
     WoT.produce(td).then((thing) => {
         thing.setActionHandler("sayOk", async () => "Ok!");
         thing.expose();

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "is-absolute-url": "3.0.3",
         "url-toolkit": "2.1.6",
-        "wot-thing-description-types": "^1.1.0-26-July-2021a",
+        "wot-thing-description-types": "^1.1.0-09-February-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
     },
     "scripts": {


### PR DESCRIPTION
This PR resolves another eslint issue by updating the `wot-thing-description-types` dependency and removing the `@ts-ignore` comment from the OAuth2 exposer example.