### PR TITLE
chore: let CI fail on linting error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,6 @@ jobs:
 
             - name: Lint
               run: npm run lint
-              continue-on-error: true
 
     version_consistency:
         name: Check version consistency of packages


### PR DESCRIPTION
As all eslint errors have now been fixed, we can actually let the CI fail if there should be any linting errors, asserting better code quality :)