### PR TITLE
style(binding-netconf): address linting issues

### DIFF
--- a/packages/binding-netconf/src/netconf.ts
+++ b/packages/binding-netconf/src/netconf.ts
@@ -19,7 +19,20 @@ export { default as NetconfClientFactory } from "./netconf-client-factory";
 export * from "./netconf";
 export * from "./netconf-client-factory";
 export class NetconfForm extends Form {
-    public "nc:NSs"?: any;
+    public "nc:NSs"?: Record<string, string>;
     public "nc:method"?: string;
     public "nc:target"?: string;
+}
+
+export type RpcMethod = "GET-CONFIG" | "EDIT-CONFIG" | "COMMIT" | "RPC";
+
+export interface NetConfCredentials {
+    username: string;
+    password?: string;
+
+    privateKey?: string;
+}
+
+export function isRpcMethod(method: string): method is RpcMethod {
+    return ["GET-CONFIG", "EDIT-CONFIG", "COMMIT", "RPC"].includes(method);
 }

--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -155,18 +155,18 @@ describe("outer describe", function () {
         };
 
         let objRequest = xpath2json.xpath2json(xpathQuery, NSs);
-        let validObject: any = {
+        const validObject1 = {
             "ietf-interfaces:interfaces": { interface: { name: "interface100" } },
         };
-        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject));
+        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject1));
 
         const payload = { value: "modem" };
         xpathQuery = xpath2json.addLeaves(xpathQuery, payload);
         objRequest = xpath2json.xpath2json(xpathQuery, NSs);
-        validObject = {
+        const validObject2 = {
             "ietf-interfaces:interfaces": { interface: { name: "interface100", value: "modem" } },
         };
-        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject));
+        expect(JSON.stringify(objRequest)).to.equal(JSON.stringify(validObject2));
     });
 
     it("should properly convert JSON to XPATH", async function () {


### PR DESCRIPTION
This PR applies some refactorings to the netconf binding, resolving a number of eslint warnings. There are now six warnings remaining in the `netconf-codec.ts` and the `xpath2json.ts` files which seem to require more substantial changes/type checking to be fixed. These should probably be dealt with in a follow-up PR.