### PR TITLE
Move vm from core to cli package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -617,8 +617,9 @@
         },
         "node_modules/@testdeck/mocha": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@testdeck/mocha/-/mocha-0.1.2.tgz",
+            "integrity": "sha512-yn3OkFUlO9EkdBkDV08bPV0r26U2FC/8KvU9FdiS0ligOsjB5Ry4sp3eUQJAFxjrGJBpih0t7rZ/GzdsgCv/EQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "@testdeck/core": "^0.1.2"
             },
@@ -1392,7 +1393,8 @@
         },
         "node_modules/acorn-walk": {
             "version": "8.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2802,9 +2804,15 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.2",
-            "dev": true,
-            "license": "MIT",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -3015,21 +3023,6 @@
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/coap/node_modules/debug": {
-            "version": "4.3.3",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/code-point-at": {
@@ -3333,8 +3326,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.2",
-            "license": "MIT",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -5014,6 +5008,19 @@
             "version": "1.0.0",
             "license": "ISC"
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "license": "MIT"
@@ -5123,8 +5130,9 @@
             "license": "MIT"
         },
         "node_modules/glob": {
-            "version": "7.1.7",
-            "license": "ISC",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6739,31 +6747,32 @@
             "license": "MIT"
         },
         "node_modules/mocha": {
-            "version": "9.1.2",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -6823,6 +6832,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+            "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -7164,9 +7185,10 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.1.25",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -7980,31 +8002,6 @@
             },
             "bin": {
                 "pki": "bin/crypto_create_CA.js"
-            }
-        },
-        "node_modules/node-opcua-pki/node_modules/chokidar": {
-            "version": "3.5.3",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/node-opcua-pki/node_modules/is-fullwidth-code-point": {
@@ -11644,8 +11641,9 @@
             "license": "MIT"
         },
         "node_modules/vm2": {
-            "version": "3.9.7",
-            "license": "MIT",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
+            "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
             "dependencies": {
                 "acorn": "^8.7.0",
                 "acorn-walk": "^8.2.0"
@@ -11659,7 +11657,8 @@
         },
         "node_modules/vm2/node_modules/acorn": {
             "version": "8.7.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -11947,9 +11946,10 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.1.5",
-            "dev": true,
-            "license": "Apache-2.0"
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+            "dev": true
         },
         "node_modules/wot-thing-description-types": {
             "version": "1.1.0-27-September-2021",
@@ -12561,12 +12561,15 @@
                 "@node-wot/binding-mqtt": "0.8.0",
                 "@node-wot/binding-websockets": "0.8.0",
                 "@node-wot/core": "0.8.0",
-                "dotenv": "^8.6.0"
+                "@node-wot/td-tools": "^0.8.0",
+                "dotenv": "^8.6.0",
+                "vm2": "^3.9.9"
             },
             "bin": {
                 "wot-servient": "bin/index.js"
             },
             "devDependencies": {
+                "@testdeck/mocha": "^0.1.2",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
@@ -12577,6 +12580,7 @@
                 "eslint-plugin-node": "^11.1.0",
                 "eslint-plugin-promise": "^5.1.0",
                 "eslint-plugin-unused-imports": "^1.1.4",
+                "mocha": "^9.2.2",
                 "prettier": "^2.3.2",
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
@@ -12599,7 +12603,6 @@
                 "rxjs": "5.5.11",
                 "uritemplate": "0.3.4",
                 "uuid": "^7.0.3",
-                "vm2": "^3.9.6",
                 "web-streams-polyfill": "^3.0.1"
             },
             "devDependencies": {
@@ -13221,6 +13224,8 @@
                 "@node-wot/binding-mqtt": "0.8.0",
                 "@node-wot/binding-websockets": "0.8.0",
                 "@node-wot/core": "0.8.0",
+                "@node-wot/td-tools": "^0.8.0",
+                "@testdeck/mocha": "^0.1.2",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
@@ -13232,10 +13237,12 @@
                 "eslint-plugin-node": "^11.1.0",
                 "eslint-plugin-promise": "^5.1.0",
                 "eslint-plugin-unused-imports": "^1.1.4",
+                "mocha": "^9.1.1",
                 "prettier": "^2.3.2",
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
+                "vm2": "^3.9.9",
                 "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
             }
@@ -13273,7 +13280,6 @@
                 "typescript-standard": "^0.3.36",
                 "uritemplate": "0.3.4",
                 "uuid": "^7.0.3",
-                "vm2": "^3.9.6",
                 "web-streams-polyfill": "^3.0.1",
                 "wot-thing-description-types": "^1.1.0-09-February-2022",
                 "wot-typescript-definitions": "^0.8.0-SNAPSHOT.22"
@@ -13471,6 +13477,8 @@
         },
         "@testdeck/mocha": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@testdeck/mocha/-/mocha-0.1.2.tgz",
+            "integrity": "sha512-yn3OkFUlO9EkdBkDV08bPV0r26U2FC/8KvU9FdiS0ligOsjB5Ry4sp3eUQJAFxjrGJBpih0t7rZ/GzdsgCv/EQ==",
             "dev": true,
             "requires": {
                 "@testdeck/core": "^0.1.2"
@@ -14041,7 +14049,9 @@
             }
         },
         "acorn-walk": {
-            "version": "8.2.0"
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         },
         "aedes": {
             "version": "0.46.2",
@@ -15035,8 +15045,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.2",
-            "dev": true,
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -15174,12 +15185,6 @@
                     "requires": {
                         "base64-js": "^1.3.1",
                         "ieee754": "^1.2.1"
-                    }
-                },
-                "debug": {
-                    "version": "4.3.3",
-                    "requires": {
-                        "ms": "2.1.2"
                     }
                 }
             }
@@ -15419,7 +15424,9 @@
             }
         },
         "debug": {
-            "version": "4.3.2",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
             "requires": {
                 "ms": "2.1.2"
             }
@@ -16592,6 +16599,12 @@
         "fs.realpath": {
             "version": "1.0.0"
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1"
         },
@@ -16666,7 +16679,9 @@
             "version": "0.0.0"
         },
         "glob": {
-            "version": "7.1.7",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -17672,30 +17687,32 @@
             "version": "0.5.3"
         },
         "mocha": {
-            "version": "9.1.2",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -17725,6 +17742,15 @@
                     "dev": true,
                     "requires": {
                         "p-locate": "^5.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+                    "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "ms": {
@@ -17968,7 +17994,9 @@
             }
         },
         "nanoid": {
-            "version": "3.1.25",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true
         },
         "napi-build-utils": {
@@ -18666,19 +18694,6 @@
                 "yauzl": "^2.10.0"
             },
             "dependencies": {
-                "chokidar": {
-                    "version": "3.5.3",
-                    "requires": {
-                        "anymatch": "~3.1.2",
-                        "braces": "~3.0.2",
-                        "fsevents": "~2.3.2",
-                        "glob-parent": "~5.1.2",
-                        "is-binary-path": "~2.1.0",
-                        "is-glob": "~4.0.1",
-                        "normalize-path": "~3.0.0",
-                        "readdirp": "~3.6.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0"
                 },
@@ -21248,14 +21263,18 @@
             "dev": true
         },
         "vm2": {
-            "version": "3.9.7",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
+            "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
             "requires": {
                 "acorn": "^8.7.0",
                 "acorn-walk": "^8.2.0"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "8.7.0"
+                    "version": "8.7.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
                 }
             }
         },
@@ -21429,7 +21448,9 @@
             "dev": true
         },
         "workerpool": {
-            "version": "6.1.5",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "wot-thing-description-types": {

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -22,7 +22,7 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
     },
     "scripts": {
-        "build": "browserify -r vm:vm2 index.js --external coffee-script -o dist/wot-bundle.min.js",
+        "build": "browserify index.js -o dist/wot-bundle.min.js",
         "format": "prettier --write index.js \"**/*.json\""
     },
     "bugs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
         "wot-servient": "bin/index.js"
     },
     "devDependencies": {
+        "@testdeck/mocha": "^0.1.2",
         "@types/node": "16.4.13",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
@@ -27,6 +28,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-unused-imports": "^1.1.4",
+        "mocha": "^9.2.2",
         "prettier": "^2.3.2",
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
@@ -44,7 +46,9 @@
         "@node-wot/binding-mqtt": "0.8.0",
         "@node-wot/binding-websockets": "0.8.0",
         "@node-wot/core": "0.8.0",
-        "dotenv": "^8.6.0"
+        "@node-wot/td-tools": "^0.8.0",
+        "dotenv": "^8.6.0",
+        "vm2": "^3.9.9"
     },
     "scripts": {
         "build": "tsc -b",
@@ -52,7 +56,8 @@
         "debug": "node -r ts-node/register --inspect-brk=9229 src/cli.ts",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
-        "format": "prettier --write \"src/**/*.ts\" \"**/*.json\""
+        "format": "prettier --write \"src/**/*.ts\" \"**/*.json\"",
+        "test": "mocha --require ts-node/register --extension ts"
     },
     "bugs": {
         "url": "https://github.com/eclipse/thingweb.node-wot/issues"

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -24,6 +24,8 @@ import { HttpServer, HttpClientFactory, HttpsClientFactory } from "@node-wot/bin
 import { CoapServer, CoapClientFactory, CoapsClientFactory } from "@node-wot/binding-coap";
 import { MqttBrokerServer, MqttClientFactory } from "@node-wot/binding-mqtt";
 import { FileClientFactory } from "@node-wot/binding-file";
+import { CompilerFunction, NodeVM } from "vm2";
+import { ThingModelHelpers } from "@node-wot/td-tools";
 
 // Helper function needed for `mergeConfigs` function
 function isObject(item: unknown) {
@@ -53,7 +55,11 @@ function mergeConfigs(target: any, source: any): any {
     });
     return output;
 }
-
+export interface ScriptOptions {
+    argv?: Array<string>;
+    compiler?: CompilerFunction;
+    env?: Record<string, string>;
+}
 export default class DefaultServient extends Servient {
     private static readonly defaultConfig = {
         servient: {
@@ -72,6 +78,8 @@ export default class DefaultServient extends Servient {
         },
     };
 
+    private uncaughtListeners: Array<(...args: unknown[]) => void> = [];
+    private runtime: typeof WoT | undefined;
     public readonly config: any;
     // current log level
     public logLevel: string;
@@ -152,6 +160,102 @@ export default class DefaultServient extends Servient {
     }
 
     /**
+     * Runs the script in a new sandbox
+     * @param {string} code - the script to run
+     * @param {string} filename - the filename of the script
+     */
+    public runScript(code: string, filename = "script"): unknown {
+        if (!this.runtime) {
+            throw new Error("WoT runtime not loaded; have you called start()?");
+        }
+        const helpers = new Helpers(this);
+        const context = {
+            WoT: this.runtime,
+            WoTHelpers: helpers,
+            ModelHelpers: new ThingModelHelpers(helpers),
+        };
+
+        const vm = new NodeVM({
+            sandbox: context,
+        });
+
+        const listener = (err: Error) => {
+            this.logScriptError(`Asynchronous script error '${filename}'`, err);
+            // TODO: clean up script resources
+            process.exit(1);
+        };
+        process.prependListener("uncaughtException", listener);
+        this.uncaughtListeners.push(listener);
+
+        try {
+            return vm.run(code, filename);
+        } catch (err) {
+            this.logScriptError(`Servient found error in privileged script '${filename}'`, err);
+            return undefined;
+        }
+    }
+
+    /**
+     * Runs the script in privileged context (dangerous). In practice, this means that the script can
+     * require system modules.
+     * @param {string} code - the script to run
+     * @param {string} filename - the filename of the script
+     * @param {object} options - pass cli variables or envs to the script
+     */
+    public runPrivilegedScript(code: string, filename = "script", options: ScriptOptions = {}): unknown {
+        if (!this.runtime) {
+            throw new Error("WoT runtime not loaded; have you called start()?");
+        }
+        const helpers = new Helpers(this);
+        const context = {
+            WoT: this.runtime,
+            WoTHelpers: helpers,
+            ModelHelpers: new ThingModelHelpers(helpers),
+        };
+
+        const vm = new NodeVM({
+            sandbox: context,
+            require: {
+                external: true,
+                builtin: ["*"],
+            },
+            argv: options.argv,
+            compiler: options.compiler,
+            env: options.env,
+        });
+
+        const listener = (err: Error) => {
+            this.logScriptError(`Asynchronous script error '${filename}'`, err);
+            // TODO: clean up script resources
+            process.exit(1);
+        };
+        process.prependListener("uncaughtException", listener);
+        this.uncaughtListeners.push(listener);
+
+        try {
+            return vm.run(code, filename);
+        } catch (err) {
+            this.logScriptError(`Servient found error in privileged script '${filename}'`, err);
+            return undefined;
+        }
+    }
+
+    private logScriptError(description: string, error: Error): void {
+        let message: string;
+        if (typeof error === "object" && error.stack) {
+            const match = error.stack.match(/evalmachine\.<anonymous>:([0-9]+:[0-9]+)/);
+            if (Array.isArray(match)) {
+                message = `and halted at line ${match[1]}\n    ${error}`;
+            } else {
+                message = `and halted with ${error.stack}`;
+            }
+        } else {
+            message = `that threw ${typeof error} instead of Error\n    ${error}`;
+        }
+        console.error("[core/servient]", `Servient caught ${description} ${message}`);
+    }
+
+    /**
      * start
      */
     public start(): Promise<typeof WoT> {
@@ -160,7 +264,7 @@ export default class DefaultServient extends Servient {
                 .start()
                 .then((myWoT) => {
                     console.info("[cli/default-servient]", "DefaultServient started");
-
+                    this.runtime = myWoT;
                     // TODO think about builder pattern that starts with produce() ends with expose(), which exposes/publishes the Thing
                     myWoT
                         .produce({
@@ -237,6 +341,14 @@ export default class DefaultServient extends Servient {
                         });
                 })
                 .catch((err) => reject(err));
+        });
+    }
+
+    public async shutdown(): Promise<void> {
+        await super.shutdown();
+
+        this.uncaughtListeners.forEach((listener) => {
+            process.removeListener("uncaughtException", listener);
         });
     }
 

--- a/packages/cli/test/RuntimeTest.ts
+++ b/packages/cli/test/RuntimeTest.ts
@@ -22,26 +22,30 @@
 
 import { suite, test } from "@testdeck/mocha";
 import { should, assert } from "chai";
+import DefaultServient from "../src/cli-default-servient";
 
-import Servient from "../src/servient";
 import fs from "fs";
 // should must be called to augment all variables
 should();
 
-@suite("the runtime of servient")
+@suite("Test suite for script runtime")
 class WoTRuntimeTest {
-    static servient: Servient;
+    static servient: DefaultServient;
 
     static WoT: typeof WoT;
 
     exit: (code?: number) => never;
 
-    static before() {
+    static async before() {
         // We need to disable this check for killing servient logs
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        /* eslint-disable @typescript-eslint/no-empty-function */
         console.error = () => {};
-        this.servient = new Servient();
-        console.log("before starting test suite");
+        console.debug = () => {};
+        console.warn = () => {};
+        console.info = () => {};
+        /* eslint-enable @typescript-eslint/no-empty-function */
+        this.servient = new DefaultServient(true);
+        await this.servient.start();
     }
 
     beforeEach() {
@@ -53,7 +57,6 @@ class WoTRuntimeTest {
     }
 
     static async after(): Promise<void> {
-        console.log("after finishing test suite");
         await this.servient.shutdown();
     }
 

--- a/packages/cli/test/tsconfig.json
+++ b/packages/cli/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".."
+    },
+    "include": ["*.ts", "**/*.ts", "../src/**/*.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
         "rxjs": "5.5.11",
         "uritemplate": "0.3.4",
         "uuid": "^7.0.3",
-        "vm2": "^3.9.6",
         "web-streams-polyfill": "^3.0.1"
     },
     "scripts": {


### PR DESCRIPTION
Being close to our big release I thought that it makes sense to improve node-wot architecture with this substantial refactor. This PR moves the VM dependence from `core` to `cli`. The direct consequence of this change is that now the `core` module is leaner and it has not node only dependencies. Moreover, we can better serve users that want to use node-wot as a simple library (embedded in their applications) cause in 99% of cases they don't need the scripting runtime support. 

Fix #377 