### PR TITLE
CLI: pass port as argument

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -288,6 +288,7 @@ Options:
   -f,   --configfile <file>         load configuration from specified file
   -h,   --help                      show this help
         --[protocol].port           specify the port to expose the server for a specific protocol
+                                    (examples: --http.port 8888, --coap.port 3333)
 
 wot-servient.conf.json syntax:
 {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -71,7 +71,7 @@ const overrideConfig = function (conf: any): Promise<unknown> {
         conf = conf ?? {};
 
         servientPorts.forEach((port, protocol) => {
-            if (port !== 0) {
+            if (port !== undefined) {
                 if (!(protocol in conf)) {
                     conf[protocol] = {};
                 }
@@ -247,7 +247,6 @@ for (let i = 0; i < argv.length; i++) {
         flagArgPort = true;
         const matches = argv[i].match(/^--(http|coap|mqtt)\.port$/i);
         currentProtocolPort = matches[1];
-        servientPorts.set(currentProtocolPort, 0);
         argv.splice(i, 1);
         i--;
     } else if (argv[i].match(/^(-i|-ib|--inspect(-brk)?(=([a-z]*|[\d .]*):?(\d*))?|\/i|\/ib)$/i)) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -350,10 +350,6 @@ VAR2=Value2`);
 }
 
 readConf(confFile)
-    .then(overrideConfig)
-    .then((conf) => {
-        return new DefaultServient(clientOnly, conf);
-    })
     .catch((err) => {
         if (err.code === "ENOENT" && !confFile) {
             console.warn("[cli]", `WoT-Servient using defaults as '${defaultFile}' does not exist`);


### PR DESCRIPTION
This PR introduces a new cmd line option to pass the port and override default configurations (or the config file). Furthermore, it improves a little bit the `cli.ts` style code. 

Fix #117