### PR TITLE
added tuya binding with security and codec management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3606,6 +3606,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -5288,6 +5296,14 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/finalhandler": {
@@ -10174,6 +10190,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/query-string": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+            "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+            "dependencies": {
+                "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -11077,6 +11110,14 @@
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
             "dev": true
         },
+        "node_modules/split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -11325,6 +11366,14 @@
             "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/string_decoder": {
@@ -11698,6 +11747,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+        },
+        "node_modules/timekeeper": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+            "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+            "dev": true
         },
         "node_modules/timers-browserify": {
             "version": "1.4.2",
@@ -13214,6 +13269,7 @@
                 "client-oauth2": "^4.2.5",
                 "eventsource": "^1.0.7",
                 "node-fetch": "^2.6.7",
+                "query-string": "^7.1.1",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5"
             },
@@ -13245,6 +13301,7 @@
                 "mocha": "^9.1.1",
                 "prettier": "^2.3.2",
                 "ssestream": "^1.1.0",
+                "timekeeper": "^2.2.0",
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
@@ -13966,7 +14023,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "^1.0.6",
+                "coap": "^1.0.8",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -14064,9 +14121,11 @@
                 "mocha": "^9.1.1",
                 "node-fetch": "^2.6.7",
                 "prettier": "^2.3.2",
+                "query-string": "*",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
                 "ssestream": "^1.1.0",
+                "timekeeper": "^2.2.0",
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
@@ -17137,6 +17196,11 @@
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true
         },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -18500,6 +18564,11 @@
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
+        },
+        "filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
         },
         "finalhandler": {
             "version": "1.1.2",
@@ -22517,6 +22586,17 @@
             "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
             "dev": true
         },
+        "query-string": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+            "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+            "requires": {
+                "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            }
+        },
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -23226,6 +23306,11 @@
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
             "dev": true
         },
+        "split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+        },
         "split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -23461,6 +23546,11 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
             "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+        },
+        "strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string_decoder": {
             "version": "1.3.0",
@@ -23751,6 +23841,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+        },
+        "timekeeper": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+            "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+            "dev": true
         },
         "timers-browserify": {
             "version": "1.4.2",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -42,6 +42,7 @@
         "mocha": "^9.1.1",
         "prettier": "^2.3.2",
         "ssestream": "^1.1.0",
+        "timekeeper": "^2.2.0",
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
@@ -56,6 +57,7 @@
         "client-oauth2": "^4.2.5",
         "eventsource": "^1.0.7",
         "node-fetch": "^2.6.7",
+        "query-string": "^7.1.1",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5"
     },

--- a/packages/binding-http/src/codecs/tuya-codec.ts
+++ b/packages/binding-http/src/codecs/tuya-codec.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { ContentCodec } from "@node-wot/core";
+import * as TD from "@node-wot/td-tools";
+import { DataSchemaValue } from "wot-typescript-definitions";
+
+export default class HttpTuyaCodec implements ContentCodec {
+    getMediaType(): string {
+        return "application/json+tuya";
+    }
+
+    bytesToValue(bytes: Buffer, schema: TD.DataSchema, parameters: { [key: string]: string }): DataSchemaValue {
+        const parsedBody = JSON.parse(bytes.toString());
+        if (!parsedBody.success) throw new Error(parsedBody.msg ? parsedBody.msg : JSON.stringify(parsedBody));
+        for (const key in parsedBody.result) {
+            if (parsedBody.result[key].code === schema["tuya:PropertyName"]) {
+                return parsedBody.result[key].value;
+            }
+        }
+        throw new Error("Property not found");
+    }
+
+    valueToBytes(value: unknown, schema: TD.DataSchema, parameters?: { [key: string]: string }): Buffer {
+        const obj = {
+            commands: [
+                {
+                    code: schema["tuya:PropertyName"],
+                    value: value,
+                },
+            ],
+        };
+        const body = JSON.stringify(obj);
+        return Buffer.from(body);
+    }
+}

--- a/packages/binding-http/src/http-client.ts
+++ b/packages/binding-http/src/http-client.ts
@@ -26,7 +26,7 @@ import * as TD from "@node-wot/td-tools";
 // for Security definition
 
 import { ProtocolClient, Content, ProtocolHelpers } from "@node-wot/core";
-import { HttpForm, HttpHeader, HttpConfig, HTTPMethodName } from "./http";
+import { HttpForm, HttpHeader, HttpConfig, HTTPMethodName, TuyaCustomBearerSecurityScheme } from "./http";
 import fetch, { Request, RequestInit, Response } from "node-fetch";
 import { Buffer } from "buffer";
 import OAuthManager, { OAuthClientConfiguration, OAuthResourceOwnerConfiguration } from "./oauth-manager";
@@ -39,6 +39,8 @@ import {
     BasicCredentialConfiguration,
     BearerCredentialConfiguration,
     BasicKeyCredentialConfiguration,
+    TuyaCustomBearer,
+    TuyaCustomBearerCredentialConfiguration,
 } from "./credential";
 import { LongPollingSubscription, SSESubscription, InternalSubscription } from "./subscription-protocols";
 import { Readable } from "stream";
@@ -272,6 +274,13 @@ export default class HttpClient implements ProtocolClient {
                     );
                 }
 
+                break;
+            }
+            case "TuyaCustomBearer": {
+                this.credential = new TuyaCustomBearer(
+                    credentials as TuyaCustomBearerCredentialConfiguration,
+                    security as TuyaCustomBearerSecurityScheme
+                );
                 break;
             }
             case "nosec":

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -52,6 +52,15 @@ export interface OAuth2ServerConfig extends TD.SecurityScheme {
     allowedClients?: string;
 }
 
+export interface TuyaCustomBearerSecurityScheme extends TD.SecurityScheme {
+    /**
+     * This scheme is necessary because of the Tuya binding.
+     * The Tuya Apis are implementing a custom security protocol that needs a custom handling
+     */
+    scheme: "TuyaCustomBearer";
+    baseUri: string;
+}
+
 export type HTTPMethodName = "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "HEAD";
 
 export class HttpHeader {


### PR DESCRIPTION
Hello everyone,
I've developed a "binding" (codec + credential class) that allows Node-Wot to interact with Tuya's smart things.  
The binding is only client-side and it needs a slightly custom TD in order to work: a custom field ("tuya:PropertyName") in the schema that corresponds to the name used by tuya Apis to identify the property and two different forms for reading and writing (with an Url formed this way: https://openapi.{tuyaRegion}.com/v1.0/iot-03/devices/{deviceID} as a base Uri + /status (read) + /commands (write)).
The credential class implements the custom security protocol used by tuya Apis, it is a bit complicated and it needs a lot of data: it uses a secret key to sign a header field composed of the public key from tuya, a token, the current time, the method an ashed body and the other headers. [Tuya documentation](https://developer.tuya.com/en/docs/cloud)
I hope this can help, 
Alessio
 