### PR TITLE
Proposal for a new logging API

### DIFF
--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 
 import { ConsumedThing as IConsumedThing, InteractionInput, Subscription } from "wot-typescript-definitions";
-import { log, LogLevel } from "./logger";
+import { logDebug, logWarn } from "./logger";
 
 import * as TD from "@node-wot/td-tools";
 
@@ -30,7 +30,7 @@ import { InteractionOutput } from "./interaction-output";
 import { FormElementEvent, FormElementProperty } from "wot-thing-description-types";
 import { ThingInteraction } from "@node-wot/td-tools";
 
-const debugPrefix = "core/consumed-thing";
+const loggingPrefix = "core/consumed-thing";
 
 enum Affordance {
     PropertyAffordance,
@@ -145,7 +145,7 @@ class InternalPropertySubscription extends InternalSubscription {
         if (!form) {
             throw new Error(`ConsumedThing '${this.thing.title}' did not get suitable form`);
         }
-        log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.thing.title}' unobserving to ${form.href}`);
+        logDebug(loggingPrefix, `ConsumedThing '${this.thing.title}' unobserving to ${form.href}`);
         await client.unlinkResource(form);
         this.active = false;
     }
@@ -278,7 +278,7 @@ class InternalEventSubscription extends InternalSubscription {
         if (!form) {
             throw new Error(`ConsumedThing '${this.thing.title}' did not get suitable form`);
         }
-        log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.thing.title}' unsubscribing to ${form.href}`);
+        logDebug(loggingPrefix, `ConsumedThing '${this.thing.title}' unsubscribing to ${form.href}`);
         client.unlinkResource(form);
         this.active = false;
     }
@@ -352,7 +352,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
     public emitEvent(name: string, data: InteractionInput): void {
-        log(LogLevel.Warn, debugPrefix, "not implemented");
+        logWarn(loggingPrefix, "not implemented");
     }
 
     extendInteractions(): void {
@@ -421,9 +421,8 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     ensureClientSecurity(client: ProtocolClient, form: TD.Form): void {
         if (this.securityDefinitions) {
             const logStatement = () =>
-                log(
-                    LogLevel.Debug,
-                    debugPrefix,
+                logDebug(
+                    loggingPrefix,
                     `ConsumedThing '${this.title}' setting credentials for ${client} based on thing security`
                 );
 
@@ -462,18 +461,14 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
         if (options && options.formIndex) {
             // pick provided formIndex (if possible)
-            log(
-                LogLevel.Debug,
-                debugPrefix,
-                `ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`
-            );
+            logDebug(loggingPrefix, `ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`);
 
             if (options.formIndex >= 0 && options.formIndex < forms.length) {
                 form = forms[options.formIndex];
                 const scheme = Helpers.extractScheme(form.href);
 
                 if (this.getServient().hasClientFor(scheme)) {
-                    log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' got client for '${scheme}'`);
+                    logDebug(loggingPrefix, `ConsumedThing '${this.title}' got client for '${scheme}'`);
                     client = this.getServient().getClientFor(scheme);
 
                     if (!this.getClients().get(scheme)) {
@@ -493,16 +488,12 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
             if (cacheIdx !== -1) {
                 // from cache
-                log(
-                    LogLevel.Debug,
-                    debugPrefix,
-                    `ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`
-                );
+                logDebug(loggingPrefix, `ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
                 client = this.getClients().get(schemes[cacheIdx]);
                 form = this.findForm(forms, op, affordance, schemes, cacheIdx);
             } else {
                 // new client
-                log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
+                logDebug(loggingPrefix, `ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
                 const srvIdx = schemes.findIndex((scheme) => this.getServient().hasClientFor(scheme));
 
                 if (srvIdx === -1)
@@ -510,11 +501,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
                 client = this.getServient().getClientFor(schemes[srvIdx]);
 
-                log(
-                    LogLevel.Debug,
-                    debugPrefix,
-                    `ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`
-                );
+                logDebug(loggingPrefix, `ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`);
 
                 this.ensureClientSecurity(client, form);
                 this.getClients().set(schemes[srvIdx], client);
@@ -539,7 +526,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         if (!form) {
             throw new Error(`ConsumedThing '${this.title}' did not get suitable form`);
         }
-        log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' reading ${form.href}`);
+        logDebug(loggingPrefix, `ConsumedThing '${this.title}' reading ${form.href}`);
 
         // uriVariables ?
         form = this.handleUriVariables(tp, form, options);
@@ -605,7 +592,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         if (!form) {
             throw new Error(`ConsumedThing '${this.title}' did not get suitable form`);
         }
-        log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' writing ${form.href} with '${value}'`);
+        logDebug(loggingPrefix, `ConsumedThing '${this.title}' writing ${form.href} with '${value}'`);
 
         const content = ContentManager.valueToContent(value, tp, form.contentType);
 
@@ -647,9 +634,8 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         if (!form) {
             throw new Error(`ConsumedThing '${this.title}' did not get suitable form`);
         }
-        log(
-            LogLevel.Debug,
-            debugPrefix,
+        logDebug(
+            loggingPrefix,
             `ConsumedThing '${this.title}' invoking ${form.href}${
                 parameter !== undefined ? " with '" + parameter + "'" : ""
             }`
@@ -707,7 +693,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 `ConsumedThing '${this.title}' has already a function subscribed to ${name}. You can only observe once`
             );
         }
-        log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' observing to ${form.href}`);
+        logDebug(loggingPrefix, `ConsumedThing '${this.title}' observing to ${form.href}`);
 
         // uriVariables ?
         form = this.handleUriVariables(tp, form, options);
@@ -720,8 +706,8 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 try {
                     listener(new InteractionOutput(content, form, tp));
                 } catch (e) {
-                    log(LogLevel.Warn, debugPrefix, `Error while processing observe event for ${tp.title}`);
-                    log(LogLevel.Warn, debugPrefix, e.toString());
+                    logWarn(loggingPrefix, `Error while processing observe event for ${tp.title}`);
+                    logWarn(loggingPrefix, e.toString());
                 }
             },
             // error
@@ -764,7 +750,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 `ConsumedThing '${this.title}' has already a function subscribed to ${name}. You can only subscribe once`
             );
         }
-        log(LogLevel.Warn, debugPrefix, `ConsumedThing '${this.title}' subscribing to ${form.href}`);
+        logWarn(loggingPrefix, `ConsumedThing '${this.title}' subscribing to ${form.href}`);
 
         // uriVariables ?
         form = this.handleUriVariables(te, form, options);
@@ -776,8 +762,8 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 try {
                     listener(new InteractionOutput(content, form, te.data));
                 } catch (e) {
-                    log(LogLevel.Warn, debugPrefix, `Error while processing event for ${te.title}`);
-                    log(LogLevel.Warn, debugPrefix, e.toString());
+                    logWarn(loggingPrefix, `Error while processing event for ${te.title}`);
+                    logWarn(loggingPrefix, e.toString());
                 }
             },
             // error
@@ -807,7 +793,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
             const updForm = { ...form };
             updForm.href = updatedHref;
             form = updForm;
-            log(LogLevel.Debug, debugPrefix, `ConsumedThing '${this.title}' update form URI to ${form.href}`);
+            logDebug(loggingPrefix, `ConsumedThing '${this.title}' update form URI to ${form.href}`);
         }
 
         return form;

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -38,14 +38,6 @@ let globalLogLevel: LogLevel | null = null;
 
 const logLevelsByPrefix = new Map<string, LogLevel | null>();
 
-function updateLogLevel(logLevel: LogLevel, prefix?: string): void {
-    if (prefix == null) {
-        globalLogLevel = logLevel;
-    } else {
-        logLevelsByPrefix.set(prefix, logLevel);
-    }
-}
-
 /**
  * Sets a new log level either globally or, when defined, for a specific prefix.
  *
@@ -53,7 +45,11 @@ function updateLogLevel(logLevel: LogLevel, prefix?: string): void {
  * @param prefix The optional prefix for which the log level should be set.
  */
 export function setLogLevel(logLevel: LogLevel, prefix?: string): void {
-    updateLogLevel(logLevel, prefix);
+    if (prefix == null) {
+        globalLogLevel = logLevel;
+    } else {
+        logLevelsByPrefix.set(prefix, logLevel);
+    }
 }
 
 /**
@@ -92,14 +88,6 @@ let warnLogger: LoggerFunction = (message: string) => console.warn(message);
 
 let errorLogger: LoggerFunction = (message: string) => console.error(message);
 
-/**
- * Type signature of functions that can be used for formatting log messages.
- */
-export type LogMessageFormatter = (logLevel: LogLevel, prefix: string, message: string) => string;
-
-let messageFormatter: LogMessageFormatter = (loglevel: LogLevel, prefix: string, message: string) =>
-    `[${prefix}] ${message}`;
-
 export function setLogger(logLevel: LogLevel, loggerFunction: LoggerFunction): void {
     switch (logLevel) {
         case LogLevel.Info:
@@ -116,6 +104,14 @@ export function setLogger(logLevel: LogLevel, loggerFunction: LoggerFunction): v
             break;
     }
 }
+
+/**
+ * Type signature of functions that can be used for formatting log messages.
+ */
+export type LogMessageFormatter = (logLevel: LogLevel, prefix: string, message: string) => string;
+
+let messageFormatter: LogMessageFormatter = (loglevel: LogLevel, prefix: string, message: string) =>
+    `[${prefix}] ${message}`;
 
 /**
  * Overrides the default formatting function with a custom one.

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-export enum LogLevel {
+enum InternalLogLevel {
     Info,
     Debug,
     Warn,
@@ -21,47 +21,87 @@ export enum LogLevel {
     None,
 }
 
-let currentLogLevel: LogLevel = LogLevel.None;
+export enum LogLevel {
+    Info,
+    Debug,
+    Warn,
+    Error,
+}
+
+let currentLogLevel: InternalLogLevel = InternalLogLevel.None;
 
 export function setLogLevel(logLevel: LogLevel): void {
-    currentLogLevel = logLevel;
+    switch (logLevel) {
+        case LogLevel.Info:
+            currentLogLevel = InternalLogLevel.Info;
+            break;
+        case LogLevel.Debug:
+            currentLogLevel = InternalLogLevel.Debug;
+            break;
+        case LogLevel.Warn:
+            currentLogLevel = InternalLogLevel.Warn;
+            break;
+        case LogLevel.Error:
+            currentLogLevel = InternalLogLevel.Error;
+            break;
+    }
 }
 
-function logInfo(message: string) {
+export function disableLogging(): void {
+    currentLogLevel = InternalLogLevel.None;
+}
+
+function printInfo(message: string) {
     console.log(message);
 }
 
-function logDebug(message: string) {
+function printDebug(message: string) {
     console.log(message);
 }
 
-function logWarn(message: string) {
+function printWarn(message: string) {
     console.log(message);
 }
 
-function logError(message: string) {
+function printError(message: string) {
     console.log(message);
 }
 
-export function log(logLevel: LogLevel, prefix: string, message: string): void {
-    if (currentLogLevel > logLevel || logLevel === LogLevel.None) {
+function log(logLevel: InternalLogLevel, prefix: string, message: string): void {
+    if (currentLogLevel > logLevel || logLevel === InternalLogLevel.None) {
         return;
     }
 
     const logMessage = `[${prefix}] ${message}`;
 
     switch (logLevel) {
-        case LogLevel.Info:
-            logInfo(logMessage);
+        case InternalLogLevel.Info:
+            printInfo(logMessage);
             break;
-        case LogLevel.Debug:
-            logDebug(logMessage);
+        case InternalLogLevel.Debug:
+            printDebug(logMessage);
             break;
-        case LogLevel.Warn:
-            logWarn(logMessage);
+        case InternalLogLevel.Warn:
+            printWarn(logMessage);
             break;
-        case LogLevel.Error:
-            logError(logMessage);
+        case InternalLogLevel.Error:
+            printError(logMessage);
             break;
     }
+}
+
+export function logInfo(prefix: string, message: string): void {
+    log(InternalLogLevel.Info, prefix, message);
+}
+
+export function logDebug(prefix: string, message: string): void {
+    log(InternalLogLevel.Debug, prefix, message);
+}
+
+export function logWarn(prefix: string, message: string): void {
+    log(InternalLogLevel.Warn, prefix, message);
+}
+
+export function logError(prefix: string, message: string): void {
+    log(InternalLogLevel.Error, prefix, message);
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+export enum LogLevel {
+    Info,
+    Debug,
+    Warn,
+    Error,
+    None,
+}
+
+let currentLogLevel: LogLevel = LogLevel.None;
+
+export function setLogLevel(logLevel: LogLevel): void {
+    currentLogLevel = logLevel;
+}
+
+function logInfo(message: string) {
+    console.log(message);
+}
+
+function logDebug(message: string) {
+    console.log(message);
+}
+
+function logWarn(message: string) {
+    console.log(message);
+}
+
+function logError(message: string) {
+    console.log(message);
+}
+
+export function log(logLevel: LogLevel, prefix: string, message: string): void {
+    if (currentLogLevel > logLevel || logLevel === LogLevel.None) {
+        return;
+    }
+
+    const logMessage = `[${prefix}] ${message}`;
+
+    switch (logLevel) {
+        case LogLevel.Info:
+            logInfo(logMessage);
+            break;
+        case LogLevel.Debug:
+            logDebug(logMessage);
+            break;
+        case LogLevel.Warn:
+            logWarn(logMessage);
+            break;
+        case LogLevel.Error:
+            logError(logMessage);
+            break;
+    }
+}

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -21,6 +21,20 @@ enum InternalLogLevel {
     None,
 }
 
+/**
+ * The four possible log levels, which have a strict hierachy, where
+ * `Info` is the lowest value and `Error` is the highest one.
+ *
+ * Calling a logging function will only result in a processed
+ * log message if the current log level or the log level defined
+ * for a prefix is at least as high as the log level associated with
+ * the logging function.
+ *
+ * For example, calling `logInfo` when the the current log level is set
+ * to `Debug` will result in no operation. Calling `logDebug` when the
+ * log level is set to `Info`, however, will result in a processed debug
+ * message.
+ */
 export enum LogLevel {
     Info,
     Debug,

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -157,8 +157,6 @@ function log(logLevel: LogLevel, prefix: string, message: string): void {
 /**
  * Creates a new log message with log level `Info`.
  *
- * The prefix will be wrapped in square brackets in the resulting log message.
- *
  * @param prefix The prefix used for the message.
  * @param message The actual content of the log message.
  */
@@ -168,8 +166,6 @@ export function logInfo(prefix: string, message: string): void {
 
 /**
  * Creates a new log message with log level `Debug`.
- *
- * The prefix will be wrapped in square brackets in the resulting log message.
  *
  * @param prefix The prefix used for the message.
  * @param message The actual content of the log message.
@@ -181,8 +177,6 @@ export function logDebug(prefix: string, message: string): void {
 /**
  * Creates a new log message with log level `Warn`.
  *
- * The prefix will be wrapped in square brackets in the resulting log message.
- *
  * @param prefix The prefix used for the message.
  * @param message The actual content of the log message.
  */
@@ -192,8 +186,6 @@ export function logWarn(prefix: string, message: string): void {
 
 /**
  * Creates a new log message with log level `Error`.
- *
- * The prefix will be wrapped in square brackets in the resulting log message.
  *
  * @param prefix The prefix used for the message.
  * @param message The actual content of the log message.

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -121,7 +121,7 @@ function printError(message: string) {
 function log(logLevel: InternalLogLevel, prefix: string, message: string): void {
     const logLevelToCheck = logLevelsByPrefix[prefix] ?? globalLogLevel;
 
-    if (logLevelToCheck > logLevel || logLevel === InternalLogLevel.None) {
+    if (logLevelToCheck > logLevel || logLevelToCheck === InternalLogLevel.None) {
         return;
     }
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -52,7 +52,7 @@ export function disableLogging(): void {
 }
 
 function printInfo(message: string) {
-    console.log(message);
+    console.info(message);
 }
 
 function printDebug(message: string) {
@@ -60,11 +60,11 @@ function printDebug(message: string) {
 }
 
 function printWarn(message: string) {
-    console.log(message);
+    console.warn(message);
 }
 
 function printError(message: string) {
-    console.log(message);
+    console.error(message);
 }
 
 function log(logLevel: InternalLogLevel, prefix: string, message: string): void {


### PR DESCRIPTION
As I mentioned in https://github.com/eclipse/thingweb.node-wot/issues/17#issuecomment-927098851, I see some potential for improvement of the current logging solution as a lot of debug messages are added to the console by default. There is of course the possibility to redefine the functions on the `console` object, but I don't think that this is the most elegant solution and also removes the capability of printing anything to the console at all.

In this PR, I therefore wanted to propose a different solution which uses a `LogLevel` enum and a `log` function which only prints the logging statement if the `LogLevel` is high enough (otherwise it gets ignored). The log level can be set globally using a `setLogLevel` function. I also introduced individual logging functions for each log level so that the actual logging provider could be replaced (for example, with functions from the `debug` package). For now, I only refactored the `ConsumedThing` class to demonstrate how the new API could look in practice.

I am looking forward to your feedback :)

