### PR TITLE
chore: update coap to version 1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4737,9 +4737,9 @@
             }
         },
         "node_modules/coap": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.8.tgz",
-            "integrity": "sha512-hG4KL7Js3435/zO1HlprkHqCyBTIsYkwgEA1lY5fsp8UX7VpkSe77JpWNWz4KUHXGeyo2GuLAe9+I+NxnhuOdA==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.11.tgz",
+            "integrity": "sha512-38BP98kiOzpv45aX1YmjR1OskPnHRQ3V/w43Ogp05sUGShhxVPBwmfjDRPHrpP8WnJbhwAdrj9WghaQ4ZxpHOQ==",
             "dependencies": {
                 "@types/bl": "^5.0.2",
                 "@types/lru-cache": "^5.1.1",
@@ -19027,7 +19027,7 @@
                 "@node-wot/core": "0.8.1",
                 "@node-wot/td-tools": "0.8.1",
                 "@types/node": "16.4.13",
-                "coap": "^1.0.8",
+                "coap": "^1.0.11",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -25002,9 +25002,9 @@
             "dev": true
         },
         "coap": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.8.tgz",
-            "integrity": "sha512-hG4KL7Js3435/zO1HlprkHqCyBTIsYkwgEA1lY5fsp8UX7VpkSe77JpWNWz4KUHXGeyo2GuLAe9+I+NxnhuOdA==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.11.tgz",
+            "integrity": "sha512-38BP98kiOzpv45aX1YmjR1OskPnHRQ3V/w43Ogp05sUGShhxVPBwmfjDRPHrpP8WnJbhwAdrj9WghaQ4ZxpHOQ==",
             "requires": {
                 "@types/bl": "^5.0.2",
                 "@types/lru-cache": "^5.1.1",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -37,7 +37,7 @@
         "@node-wot/core": "0.8.1",
         "@node-wot/td-tools": "0.8.1",
         "@types/node": "16.4.13",
-        "coap": "^1.0.8",
+        "coap": "^1.0.11",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",


### PR DESCRIPTION
This PR updates node-coap, incorporating a number of small fixes regarding the observe function, which were responsible for some hanging behavior. These issues should now be resolved for good :)