### PR TITLE
feat(binding-coap)!: use new binding-template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -850,15 +850,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/bl": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-            "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/readable-stream": "*"
-            }
-        },
         "node_modules/@types/bluebird": {
             "version": "3.5.38",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
@@ -3154,13 +3145,13 @@
             }
         },
         "node_modules/coap": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.2.2.tgz",
-            "integrity": "sha512-w6+oaO6+I6bzH7WN/XR5txvSq+/b92qws980ssw4Zv3ZgNIv/2Jq+y8v5BNvYzj7QtuUcuytOOZMSrxTk2GzYA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.3.0.tgz",
+            "integrity": "sha512-vRi1x4z0iCfez3fy9JCiH3Kwkt0wPmRZxeRfr9lQeWTrBSevkKZ458N3ZrwieD9vulcVODJr4SQP4cigIO150A==",
             "dependencies": {
-                "@types/bl": "~5.0.2",
                 "@types/lru-cache": "^5.1.1",
-                "bl": "^5.0.0",
+                "@types/readable-stream": "^2.3.15",
+                "bl": "^6.0.0",
                 "capitalize": "^2.0.4",
                 "coap-packet": "^1.1.1",
                 "debug": "^4.3.4",
@@ -3181,26 +3172,13 @@
             }
         },
         "node_modules/coap/node_modules/bl": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-            "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.0.tgz",
+            "integrity": "sha512-Ik9BVIMdcWzSOCpzDv2XpQ4rJ4oZBuk3ck6MgiOv0EopdgtohN2uSCrrLlkH1Jf0KnpZZMBA3D0bUMbCdj/jgA==",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/coap/node_modules/bl/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
+                "readable-stream": "^4.2.0"
             }
         },
         "node_modules/coap/node_modules/buffer": {
@@ -12548,7 +12526,7 @@
                 "@node-wot/core": "0.8.4",
                 "@node-wot/td-tools": "0.8.4",
                 "@types/node": "16.4.13",
-                "coap": "^1.2.2",
+                "coap": "^1.3.0",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -14248,15 +14226,6 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
-            }
-        },
-        "@types/bl": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-            "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-            "requires": {
-                "@types/node": "*",
-                "@types/readable-stream": "*"
             }
         },
         "@types/bluebird": {
@@ -16153,13 +16122,13 @@
             "dev": true
         },
         "coap": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.2.2.tgz",
-            "integrity": "sha512-w6+oaO6+I6bzH7WN/XR5txvSq+/b92qws980ssw4Zv3ZgNIv/2Jq+y8v5BNvYzj7QtuUcuytOOZMSrxTk2GzYA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.3.0.tgz",
+            "integrity": "sha512-vRi1x4z0iCfez3fy9JCiH3Kwkt0wPmRZxeRfr9lQeWTrBSevkKZ458N3ZrwieD9vulcVODJr4SQP4cigIO150A==",
             "requires": {
-                "@types/bl": "~5.0.2",
                 "@types/lru-cache": "^5.1.1",
-                "bl": "^5.0.0",
+                "@types/readable-stream": "^2.3.15",
+                "bl": "^6.0.0",
                 "capitalize": "^2.0.4",
                 "coap-packet": "^1.1.1",
                 "debug": "^4.3.4",
@@ -16169,25 +16138,13 @@
             },
             "dependencies": {
                 "bl": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-                    "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.0.tgz",
+                    "integrity": "sha512-Ik9BVIMdcWzSOCpzDv2XpQ4rJ4oZBuk3ck6MgiOv0EopdgtohN2uSCrrLlkH1Jf0KnpZZMBA3D0bUMbCdj/jgA==",
                     "requires": {
                         "buffer": "^6.0.3",
                         "inherits": "^2.0.4",
-                        "readable-stream": "^3.4.0"
-                    },
-                    "dependencies": {
-                        "readable-stream": {
-                            "version": "3.6.0",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                            "requires": {
-                                "inherits": "^2.0.3",
-                                "string_decoder": "^1.1.1",
-                                "util-deprecate": "^1.0.1"
-                            }
-                        }
+                        "readable-stream": "^4.2.0"
                     }
                 },
                 "buffer": {

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -37,7 +37,7 @@
         "@node-wot/core": "0.8.4",
         "@node-wot/td-tools": "0.8.4",
         "@types/node": "16.4.13",
-        "coap": "^1.2.2",
+        "coap": "^1.3.0",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -14,8 +14,6 @@
  ********************************************************************************/
 
 import { Form } from "@node-wot/td-tools";
-import { OptionName } from "coap-packet";
-import { OptionValue } from "coap";
 
 export { default as CoapServer } from "./coap-server";
 export { default as CoapClientFactory } from "./coap-client-factory";
@@ -29,16 +27,29 @@ export * from "./coap-client";
 export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
-export class CoapOption {
-    public "cov:optionName": OptionName;
-    public "cov:optionValue": OptionValue;
-}
-
 export type CoapMethodName = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
 
+export type BlockSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024;
+
+export type BlockSizeOptionValue = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface BlockWiseTransferParameters {
+    "cov:block2SZX"?: BlockSize;
+    "cov:block1SZX"?: BlockSize;
+}
+
 export class CoapForm extends Form {
-    public "cov:methodName"?: CoapMethodName;
-    public "cov:options"?: Array<CoapOption> | CoapOption;
+    public "cov:method"?: CoapMethodName;
+
+    public "cov:hopLimit"?: number;
+
+    public "cov:blockwise"?: BlockWiseTransferParameters;
+
+    public "cov:qblockwise"?: BlockWiseTransferParameters;
+
+    public "cov:contentFormat"?: number;
+
+    public "cov:accept"?: number;
 }
 
 /**
@@ -63,4 +74,36 @@ export function isValidCoapMethod(methodName: CoapMethodName): methodName is Coa
  */
 export function isSupportedCoapMethod(methodName: CoapMethodName): methodName is CoapMethodName {
     return ["GET", "POST", "PUT", "DELETE"].includes(methodName);
+}
+
+/**
+ * Encodes block size values for blockwise transfer to CoAP-specific values.
+ *
+ * Maps the values 16, 32, 64, 128, 256, 512, and 1024 to 0, 1, 2, 3, 4, 5, and 6,
+ * respectively.
+ *
+ * Throws an `Error` if an invalid value `blockSize` is passed.
+ *
+ * @param blockSize The original block size value.
+ * @returns A mapped block size value usable by CoAP.
+ */
+export function blockSizeToOptionValue(blockSize: BlockSize): BlockSizeOptionValue {
+    switch (blockSize) {
+        case 16:
+            return 0;
+        case 32:
+            return 1;
+        case 64:
+            return 2;
+        case 128:
+            return 3;
+        case 256:
+            return 4;
+        case 512:
+            return 5;
+        case 1024:
+            return 6;
+        default:
+            throw Error(`Expected one of 16, 32, 64, 128, 256, 512, or 1024 as blockSize value, got ${blockSize}.`);
+    }
 }

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -211,8 +211,8 @@ export default class CoapsClient implements ProtocolClient {
 
         let method;
 
-        if (form["cov:methodName"] != null) {
-            const formMethodName = form["cov:methodName"];
+        if (form["cov:method"] != null) {
+            const formMethodName = form["cov:method"];
             debug(`CoapClient got Form "methodName" ${formMethodName}`);
             method = this.determineRequestMethod(formMethodName, defaultMethod);
         } else {

--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -67,7 +67,7 @@ class CoapClientTest {
         // read with POST instead of GET
         await client.readResource({
             href: "coap://localhost:56833/",
-            "coap:methodCode": 2 // POST
+            "cov:method": "POST"
         });
         expect(testThing.expect).to.equal("POST");
         testVector.expect = "UNSET";
@@ -75,7 +75,7 @@ class CoapClientTest {
         // write with POST instead of PUT
         representation = await client.writeResource({
             href: "coap://localhost:56833/",
-            "coap:methodCode": 2 // POST
+            "cov:method": "POST"
         }, { contentType: ContentSerdes.DEFAULT, body: Buffer.from("test") });
         expect(testVector.expect).to.equal("POST");
         testVector.expect = "UNSET";
@@ -83,7 +83,7 @@ class CoapClientTest {
         // invoke with PUT instead of POST
         representation = await client.invokeResource({
             href: "coap://localhost:56833/",
-            "coap:methodCode": 3 // PUT
+            "cov:method": "PUT"
         }, { contentType: ContentSerdes.DEFAULT, body: Buffer.from("test") });
         expect(testVector.expect).to.equal("PUT");
         testVector.expect = "UNSET";
@@ -91,7 +91,7 @@ class CoapClientTest {
         // invoke with DELETE instead of POST
         representation = await client.invokeResource({
             href: "coap://localhost:56833/",
-            "coap:methodCode": 4 // DELETE
+            "cov:method": "DELETE"
         }, { contentType: ContentSerdes.DEFAULT, body: Buffer.from("test") });
         expect(testVector.expect).to.equal("DELETE");
         testVector.expect = "UNSET";
@@ -117,7 +117,7 @@ class CoapClientTest {
         const coapClient = new CoapClient(coapServer);
         const form: CoapForm = {
             href: `coap://127.0.0.1:${port2}`,
-            "cov:methodName": "GET",
+            "cov:method": "GET",
         };
         const subscription = await coapClient.subscribeResource(form, (value) => {
             /**  */

--- a/packages/binding-coap/test/coap-types-test.ts
+++ b/packages/binding-coap/test/coap-types-test.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+/**
+ * Protocol test suite for CoAP binding definitions
+ */
+
+import { suite, test } from "@testdeck/mocha";
+import { expect } from "chai";
+import { blockSizeToOptionValue } from "../src/coap";
+
+@suite("CoAP Binding Definitions")
+class CoapDefinitionsTest {
+    @test "should map raw blocksizes to the correct option value"() {
+        expect(blockSizeToOptionValue(16)).to.eq(0);
+        expect(blockSizeToOptionValue(32)).to.eq(1);
+        expect(blockSizeToOptionValue(64)).to.eq(2);
+        expect(blockSizeToOptionValue(128)).to.eq(3);
+        expect(blockSizeToOptionValue(256)).to.eq(4);
+        expect(blockSizeToOptionValue(512)).to.eq(5);
+        expect(blockSizeToOptionValue(1024)).to.eq(6);
+    }
+}


### PR DESCRIPTION
This PR implements a first version of the [CoAP Binding-Template](https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html) in the `binding-coap` package. While all current vocabulary terms are included, not all of them are handled yet (especially the qblockwise and hop-limit parameters).

Due to the changed prefix and a new vocabulary term for the methods, this PR should actually constitute a breaking change. Therefore, it might be included in the 0.9.0 release?