### PR TITLE
fix: return the object as described in the TD

### DIFF
--- a/packages/core/src/codecs/json-codec.ts
+++ b/packages/core/src/codecs/json-codec.ts
@@ -51,7 +51,7 @@ export default class JsonCodec implements ContentCodec {
                 throw err;
             }
         }
-		
+
         return parsed;
     }
 

--- a/packages/core/src/codecs/json-codec.ts
+++ b/packages/core/src/codecs/json-codec.ts
@@ -51,15 +51,7 @@ export default class JsonCodec implements ContentCodec {
                 throw err;
             }
         }
-
-        // TODO validate using schema
-
-        // remove legacy wrapping and use RFC 7159
-        // TODO remove once dropped from all PlugFest implementation
-        if (parsed && parsed.value !== undefined) {
-            console.warn("[core/json-codec]", `JsonCodec removing { value: ... } wrapper`);
-            parsed = parsed.value;
-        }
+		
         return parsed;
     }
 

--- a/packages/core/src/codecs/netconf-codec.ts
+++ b/packages/core/src/codecs/netconf-codec.ts
@@ -42,14 +42,6 @@ export default class NetconfCodec implements ContentCodec {
             }
         }
 
-        // TODO validate using schema
-
-        // remove legacy wrapping and use RFC 7159
-        // TODO remove once dropped from all PlugFest implementation
-        if (parsed && parsed.value !== undefined) {
-            console.warn("[core/netconf-codec]", `NetconfCodec removing { value: ... } wrapper`);
-            parsed = parsed.value;
-        }
         return parsed;
     }
 


### PR DESCRIPTION
The json codec returned the value corresponding to the key "value" of the readed property, instead of the full json object as expected and described in the TD.





Signed-off-by: MartinMeyer1 <meyer.mart@outlook.com>