### PR TITLE
Refactor event handling in exposed thing

### DIFF
--- a/packages/core/src/protocol-listener-registry.ts
+++ b/packages/core/src/protocol-listener-registry.ts
@@ -83,7 +83,7 @@ export default class ProtocolListenerRegistry {
                 // formIndex satisfied
                 return;
             }
-            // we couldn't found any listener for formIndex, defaulting to notify all forms
+            // we couldn't find any listener for formIndex, defaulting to notify all forms
         }
 
         for (const [index, value] of formMap) {

--- a/packages/core/src/protocol-listener-registry.ts
+++ b/packages/core/src/protocol-listener-registry.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { DataSchema, InteractionInput } from "wot-typescript-definitions";
+import { ContentListener } from "./protocol-interfaces";
+import { ThingInteraction } from "@node-wot/td-tools";
+import contentSerdes from "./content-serdes";
+
+export default class ProtocolListenerRegistry {
+    private static EMPTY_MAP = new Map();
+    private listeners: Map<ThingInteraction, Map<number, ContentListener[]>> = new Map();
+    register(affordance: ThingInteraction, formIndex: number, listener: ContentListener): void {
+        if (!affordance.forms[formIndex]) {
+            throw new Error(
+                "Can't register the listener for affordance with formIndex. The affordance does not contain the form"
+            );
+        }
+
+        let formMap = this.listeners.get(affordance);
+
+        if (!formMap) {
+            formMap = new Map();
+            this.listeners.set(affordance, formMap);
+        }
+
+        let listeners = formMap.get(formIndex);
+
+        if (!listeners) {
+            listeners = [];
+            formMap.set(formIndex, listeners);
+        }
+        listeners.push(listener);
+    }
+
+    unregister(affordance: ThingInteraction, formIndex: number, listener: ContentListener): void {
+        const formMap = this.listeners.get(affordance);
+
+        if (!formMap) {
+            throw new Error("Not found");
+        }
+
+        const listeners = formMap.get(formIndex);
+
+        if (!listeners) {
+            throw new Error("Form not found");
+        }
+
+        const index = listeners.indexOf(listener);
+
+        if (index < 0) {
+            throw new Error("Form not found");
+        }
+
+        listeners.splice(index, 1);
+    }
+
+    unregisterAll(): void {
+        this.listeners.clear();
+    }
+
+    notify(affordance: ThingInteraction, data: InteractionInput, schema?: DataSchema, formIndex?: number): void {
+        const formMap =
+            this.listeners.get(affordance) ?? (ProtocolListenerRegistry.EMPTY_MAP as Map<number, ContentListener[]>);
+
+        if (formIndex !== undefined) {
+            const listeners = formMap.get(formIndex);
+            if (listeners) {
+                const contentType = affordance.forms[formIndex].contentType;
+                const content = contentSerdes.valueToContent(data, schema, contentType);
+
+                listeners.forEach((listener) => listener(content));
+                // formIndex satisfied
+                return;
+            }
+            // we couldn't found any listener for formIndex, defaulting to notify all forms
+        }
+
+        for (const [index, value] of formMap) {
+            const contentType = affordance.forms[index].contentType;
+            const content = contentSerdes.valueToContent(data, schema, contentType);
+            value.forEach((listener) => listener(content));
+        }
+    }
+}

--- a/packages/core/test/ProtocolListnerRegistryTest.ts
+++ b/packages/core/test/ProtocolListnerRegistryTest.ts
@@ -1,0 +1,188 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { ThingInteraction } from "@node-wot/td-tools";
+import { suite, test } from "@testdeck/mocha";
+import { expect, should, spy, use as chaiUse } from "chai";
+import spies from "chai-spies";
+import ProtocolListenerRegistry from "../src/protocol-listener-registry";
+
+chaiUse(spies);
+should();
+
+@suite("Protocol Listener Registry test")
+class ProtocolListnerRegistryTest {
+    static emptyTestAffordance: ThingInteraction = {
+        forms: [{ href: "" }, { href: "" }],
+    };
+
+    @test "should throw when the form does not exist"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+
+        expect(function () {
+            registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 2, spyListener);
+        }).to.throw();
+    }
+
+    @test "should notify a subscriber"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0);
+
+        spyListener.should.have.been.called();
+    }
+
+    @test "should notify exactly one subscriber even with the same affordance structure"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        const spyListener2 = spy(() => {
+            /** */
+        });
+
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.register(
+            {
+                forms: [{ href: "" }],
+            },
+            0,
+            spyListener2
+        );
+
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0);
+
+        spyListener.should.have.been.called();
+        spyListener2.should.not.have.been.called();
+    }
+
+    @test "should notify exactly one subscriber with formIndex"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        const spyListener2 = spy(() => {
+            /** */
+        });
+
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 1, spyListener2);
+
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0, undefined, 0);
+
+        spyListener.should.have.been.called();
+        spyListener2.should.not.have.been.called();
+    }
+
+    @test "should notify all subscribers"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        const spyListener2 = spy(() => {
+            /** */
+        });
+
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 1, spyListener2);
+
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0);
+
+        spyListener.should.have.been.called();
+        spyListener2.should.have.been.called();
+    }
+
+    @test "should notify all subscribers when formIndex is not found"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        const spyListener2 = spy(() => {
+            /** */
+        });
+
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 1, spyListener2);
+
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0, undefined, 2);
+
+        spyListener.should.have.been.called();
+        spyListener2.should.have.been.called();
+    }
+
+    @test "should unregister a subscriber"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+
+        registry.unregister(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+        registry.notify(ProtocolListnerRegistryTest.emptyTestAffordance, 0);
+
+        spyListener.should.not.have.been.called();
+    }
+
+    @test "should throw when unregister a unknown affordance"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+
+        expect(function () {
+            registry.unregister(
+                {
+                    forms: [{ href: "" }],
+                },
+                0,
+                spyListener
+            );
+        }).to.throw();
+    }
+
+    @test "should throw when unregister a unknown index"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+
+        expect(function () {
+            registry.unregister(ProtocolListnerRegistryTest.emptyTestAffordance, 1, spyListener);
+        }).to.throw();
+    }
+
+    @test "should throw when unregister a unknown listener"() {
+        const registry = new ProtocolListenerRegistry();
+        const spyListener = spy(() => {
+            /** */
+        });
+        registry.register(ProtocolListnerRegistryTest.emptyTestAffordance, 0, spyListener);
+
+        expect(function () {
+            registry.unregister(ProtocolListnerRegistryTest.emptyTestAffordance, 0, () => {
+                /** */
+            });
+        }).to.throw();
+    }
+}


### PR DESCRIPTION
This PR improves the code structure by delegating the process to notify protocol bindings to a dedicated class: `ProtocolListenerRegistry`. This simplifies the code inside `ExposedThing` and makes it more readable. The PR also comes with additional tests to improve the code coverage. 

Side effects:
- It also refactors the `ExposedThing.destroy` method to use async and await. 
- Fixes #778