### PR TITLE
Strictly check for undefined in getClientFor

### DIFF
--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -477,7 +477,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         let form: TD.Form | undefined;
         let client: ProtocolClient;
 
-        if (options && options.formIndex) {
+        if (options?.formIndex !== undefined) {
             // pick provided formIndex (if possible)
             console.debug(
                 "[core/consumed-thing]",


### PR DESCRIPTION
Notice that I've tried to add a test for this change but the current test suite is at a very high abstraction level. At that level, the bug is negligible since if you provide 0 as formIndex the code will end up choosing the first form anyway. Unless the first form contains a form that has a client but in this case, the operation will fail anyway. 