### PR TITLE
chore: use cache in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
               run: npm run build
 
             - name: Test with coverage report
-              run: npm run coverage
+              run: npm run coverage:only
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,10 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Use Node.js ${{ matrix.os }} ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
+                  cache: "npm"
             - name: npm 7
               # npm workspaces requires npm v7 or higher
               run: npm i -g npm@7 --registry=https://registry.npmjs.org


### PR DESCRIPTION
This morning I read a Twitter thread from @mcollina, about caching node:_modules to speed up CI runs. Since our runs last already an eternity I think we can try this minor tweak. Let's see if it improves the situation. :) 