### PR TITLE
Reorganising CLI Readme information

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,48 +203,7 @@ You can then start the applications with node by running `node server.js` and `n
 
 #### CLI Tool
 
-You can alternatively use node-wot via its command line interface (CLI). Please visit the [CLI tool's Readme]([url](https://github.com/eclipse/thingweb.node-wot/tree/master/packages/cli)) to find out more.
-
-You can alternatively install the node-wot CLI, either globally (`npm i @node-wot/cli -g`) or as
-a (dev) dependency (`npm i @node-wot/cli --save` or `npm i @node-wot/cli --save-dev`).
-
-Then, you don't need to specify any further node-wot dependencies and can implement your application
-(e.g., `main.js`) without explicitly requiring node-wot dependencies:
-
-```JavaScript
-// No need to require node-wot components
-// WoT runtime is provided as global object
-
-WoT.produce({/*.....*/})
-```
-
-If the CLI is globally installed, you don't need to set up a Node.js project.
-If you do so, anyway, you can specify the entry point as follows:
-
-```JavaScript
-"scripts":{
-   "start": "wot-servient main.js"
-}
-```
-
-There are several ways to start the application:
-
-a. Execute `npm start`.
-b. Execute `./node_modules/.bin/wot-servient main.js`.
-c. Execute `node ./node_modules/@node-wot/cli/dist/cli.js main.js`.
-d. If you have installed `@node-wot/cli` globally you can even start the application right
-away using this command `wot-servient main.js`. However, in the current implementation, the
-import of local dependencies is not supported in this case.
-
-wot-servient can execute multiple files at once, for example as follows:
-
-```
-wot-servient script1.js ./src/script2.js
-```
-
-Finally, to debug use the option `--inspect` or `--inspect-brk` if you want to hang until your debug client is connected. Then start [Chrome Dev Tools](chrome://inspect) or [vscode debugger](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_attaching-to-nodejs) or your preferred v8 inspector to debug your code.
-
-For further details check: `wot-servient --help`
+You can alternatively use node-wot via its command line interface (CLI). Please visit the [CLI tool's Readme](<[url](https://github.com/eclipse/thingweb.node-wot/tree/master/packages/cli)>) to find out more.
 
 ### As a standalone application
 
@@ -437,7 +396,9 @@ This library implements the WoT Scripting API:
 -   [Editors Draft](w3c.github.io/wot-scripting-api/) in [master](https://github.com/eclipse/thingweb.node-wot)
 -   [Working Draft](https://www.w3.org/TR/wot-scripting-api/) corresponding to node-wot [release versions](https://github.com/eclipse/thingweb.node-wot/releases)
 
-You can also see `examples/scripts` to have a feeling of how to script a Thing.
+Additionally, you can have a look at our [API Documentation](API.md).
+
+To learn by examples, see `examples/scripts` to have a feeling of how to script a Thing or a Consumer.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ You can then start the applications with node by running `node server.js` and `n
 
 #### CLI Tool
 
+You can alternatively use node-wot via its command line interface (CLI). Please visit the [CLI tool's Readme]([url](https://github.com/eclipse/thingweb.node-wot/tree/master/packages/cli)) to find out more.
+
 You can alternatively install the node-wot CLI, either globally (`npm i @node-wot/cli -g`) or as
 a (dev) dependency (`npm i @node-wot/cli --save` or `npm i @node-wot/cli --save-dev`).
 
@@ -226,6 +228,7 @@ If you do so, anyway, you can specify the entry point as follows:
 ```
 
 There are several ways to start the application:
+
 a. Execute `npm start`.
 b. Execute `./node_modules/.bin/wot-servient main.js`.
 c. Execute `node ./node_modules/@node-wot/cli/dist/cli.js main.js`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,50 @@
 
 ## Getting Started
 
-The following examples show how to use `wot-servient` based CLI.
+### Installation
+
+- `npm install @node-wot/cli`
+- You can alternatively install the node-wot CLI, either globally (`npm i @node-wot/cli -g`) or as
+a (dev) dependency (`npm i @node-wot/cli --save` or `npm i @node-wot/cli --save-dev`).
+
+### Usage
+
+With the CLI, you don't need to specify any further node-wot dependencies and can implement your application
+(e.g., `main.js`) without explicitly requiring node-wot dependencies:
+
+```JavaScript
+// No need to require node-wot components
+// WoT runtime is provided as global object
+
+WoT.produce({/*.....*/})
+```
+
+If the CLI is globally installed, you don't need to set up a Node.js project.
+If you do so, anyway, you can specify the entry point as follows:
+
+```JavaScript
+"scripts":{
+   "start": "wot-servient main.js"
+}
+```
+
+There are several ways to start the application:
+
+a. Execute `npm start`.
+b. Execute `./node_modules/.bin/wot-servient main.js`.
+c. Execute `node ./node_modules/@node-wot/cli/dist/cli.js main.js`.
+d. If you have installed `@node-wot/cli` globally you can even start the application right
+away using this command `wot-servient main.js`. However, in the current implementation, the
+import of local dependencies is not supported in this case.
+
+wot-servient can execute multiple files at once, for example as follows:
+
+```
+wot-servient script1.js ./src/script2.js
+```
+
+### Configuration
+
 The `-h` option explains the functionality and also how node-wot can be configured based on `wot-servient.conf.json`.
 
 -   `wot-servient -h` _or_
@@ -11,25 +54,25 @@ The `-h` option explains the functionality and also how node-wot can be configur
 The `-h` help options shows the following output:
 
 ```
-Usage: wot-servient [options] [SCRIPT]...
-       wot-servient
-       wot-servient examples/scripts/counter.js examples/scripts/example-event.js
-       wot-servient -c counter-client.js
-       wot-servient -f ~/mywot.conf.json examples/testthing/testthing.js
+Usage: wot-servient [options] [files...]
+
 
 Run a WoT Servient in the current directory.
-If no SCRIPT is given, all .js files in the current directory are loaded.
-If one or more SCRIPT is given, these files are loaded instead of the directory.
-If the file 'wot-servient.conf.json' exists, that configuration is applied.
+
+
+Arguments:
+  files                             script files to execute. If no script is given, all .js files in the current directory are
+                                    loaded. If one or more script is given, these files are loaded instead of the directory.
 
 Options:
-  -v,  --version                   display node-wot version
-  -i,  --inspect[=[host:]port]     activate inspector on host:port (default: 127.0.0.1:9229)
-  -ib, --inspect-brk[=[host:]port] activate inspector on host:port and break at start of user script
-  -c,  --client-only                do not start any servers
-                                   (enables multiple instances without port conflicts)
-  -f,  --config-file <file>         load configuration from specified file
-  -h,  --help                      show this help
+  -v, --version                     display node-wot version
+  -i, --inspect [host]:[port]       activate inspector on host:port (default: 127.0.0.1:9229)
+  -ib, --inspect-brk [host]:[port]  activate inspector on host:port (default: 127.0.0.1:9229)
+  -c, --client-only                 do not start any servers (enables multiple instances without port conflicts)
+  -cp, --compiler <module>          load module as a compiler
+  -f, --config-file <file>          load configuration from specified file (default: "wot-servient.conf.json")
+  -p, --config-params <param...>    override configuration paramters [key1:=value1 key2:=value2 ...] (e.g. http.port:=8080)
+  -h, --help                        show this help
 
 wot-servient.conf.json syntax:
 {
@@ -50,9 +93,6 @@ wot-servient.conf.json syntax:
         "clientId": BROKER-UNIQUEID,
         "protocolVersion": MQTT_VERSION
     },
-    "log": {
-        "level": LEVEL
-    },
     "credentials": {
         THING_ID1: {
             "token": TOKEN
@@ -64,11 +104,7 @@ wot-servient.conf.json syntax:
     }
 }
 
-
 wot-servient.conf.json fields:
-  ---------------------------------------------------------------------------
-  All entries in the config file structure are optional
-  ---------------------------------------------------------------------------
   CLIENTONLY      : boolean setting if no servers shall be started (default=false)
   STATIC          : string with hostname or IP literal for static address config
   RUNSCRIPT       : boolean to activate the 'runScript' Action (default=false)
@@ -78,9 +114,8 @@ wot-servient.conf.json fields:
                                 corresponding credential fields as defined below
   ALLOW           : boolean whether self-signed certificates should be allowed
   BROKER-URL      : URL to an MQTT broker that publisher and subscribers will use
-  BROKER-UNIQUEID : unique id set by mqtt client while connecting to broker
+  BROKER-UNIQUEID : unique id set by MQTT client while connecting to the broker
   MQTT_VERSION    : number indicating the MQTT protocol version to be used (3, 4, or 5)
-  LEVEL           : string or number setting the log level: { error: 0, warn: 1, info: 2, debug: 3 } (default info)
   THING_IDx       : string with TD "id" for which credentials should be configured
   TOKEN           : string for providing a Bearer token
   USERNAME        : string for providing a Basic Auth username
@@ -92,12 +127,9 @@ Environment variables must be provided in a .env file in the current working dir
 Example:
 VAR1=Value1
 VAR2=Value2
-
 ```
 
-### Prerequisites
-
-See instructions [how to build node-wot as a standalone application](https://github.com/eclipse/thingweb.node-wot/#as-a-standalone-application).
+Additionally, you can look at [the JSON Schema](https://github.com/eclipse/thingweb.node-wot/blob/master/packages/cli/src/wot-servient-schema.conf.json) to understand possible values for each field.
 
 ### Environment variables
 
@@ -108,6 +140,11 @@ PORT=4242
 ADDRESS=http://hello.com
 ```
 
+### Debugging
+
+To debug, use the option `--inspect` or `--inspect-brk` if you want to hang until your debug client is connected. Then start [Chrome Dev Tools](chrome://inspect) or [vscode debugger](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_attaching-to-nodejs) or your preferred v8 inspector to debug your code.
+
+For further details check: `wot-servient --help`
 ### Examples
 
 See [node-wot examples using Node.js](https://github.com/eclipse/thingweb.node-wot/#no-time-for-explanations---show-me-a-running-example).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,9 +4,9 @@
 
 ### Installation
 
-- `npm install @node-wot/cli`
-- You can alternatively install the node-wot CLI, either globally (`npm i @node-wot/cli -g`) or as
-a (dev) dependency (`npm i @node-wot/cli --save` or `npm i @node-wot/cli --save-dev`).
+-   `npm install @node-wot/cli`
+-   You can alternatively install the node-wot CLI, either globally (`npm i @node-wot/cli -g`) or as
+    a (dev) dependency (`npm i @node-wot/cli --save` or `npm i @node-wot/cli --save-dev`).
 
 ### Usage
 
@@ -145,6 +145,7 @@ ADDRESS=http://hello.com
 To debug, use the option `--inspect` or `--inspect-brk` if you want to hang until your debug client is connected. Then start [Chrome Dev Tools](chrome://inspect) or [vscode debugger](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_attaching-to-nodejs) or your preferred v8 inspector to debug your code.
 
 For further details check: `wot-servient --help`
+
 ### Examples
 
 See [node-wot examples using Node.js](https://github.com/eclipse/thingweb.node-wot/#no-time-for-explanations---show-me-a-running-example).


### PR DESCRIPTION
I am moving CLI readme to its own package's readme and thus tidying up the main one. 

I have started in the web editor but it is not easy to check for prettier etc.