### PR TITLE
Update npm wot thing description types 2022 07 13

### DIFF
--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -63,7 +63,7 @@
         "query-string": "^7.1.1",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",
-        "wot-thing-description-types": "^1.1.0-06-July-2022"
+        "wot-thing-description-types": "^1.1.0-13-July-2022"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -931,22 +931,7 @@ export default class HttpServer implements ProtocolServer {
         // TODO can we reset "title" to another name given that title is used in URI creation?
 
         // set @language in @context
-        if (thing["@context"] && Array.isArray(thing["@context"])) {
-            const arrayContext: Extract<ThingDescription["@context"], [] | Array<unknown>> = thing["@context"];
-            // delete previous @language entry
-            for (const arrayEntry of arrayContext) {
-                if (typeof arrayEntry === "object") {
-                    if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
-                        delete arrayContext[arrayContext.indexOf(arrayEntry as never)];
-                        break;
-                    }
-                }
-            }
-            // set preferred language
-            (arrayContext as unknown[]).push({
-                "@language": prefLang,
-            });
-        }
+        TD.setContextLanguage(thing, prefLang, true);
 
         // use new language title
         if (thing.titles) {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -930,24 +930,22 @@ export default class HttpServer implements ProtocolServer {
     private resetMultiLangThing(thing: ThingDescription, prefLang: string) {
         // TODO can we reset "title" to another name given that title is used in URI creation?
 
-        // update/set @language in @context
+        // set @language in @context
         if (thing["@context"] && Array.isArray(thing["@context"])) {
             const arrayContext: Extract<ThingDescription["@context"], [] | Array<unknown>> = thing["@context"];
-            let languageSet = false;
+            // delete previous @language entry
             for (const arrayEntry of arrayContext) {
-                if (arrayEntry instanceof Object) {
-                    if (arrayEntry["@language"] !== undefined) {
-                        arrayEntry["@language"] = prefLang;
-                        languageSet = true;
+                if (typeof arrayEntry === "object") {
+                    if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
+                        delete arrayContext[arrayContext.indexOf(arrayEntry as never)];
+                        break;
                     }
                 }
             }
-
-            if (!languageSet) {
-                (arrayContext as unknown[]).push({
-                    "@language": prefLang,
-                });
-            }
+            // set preferred language
+            (arrayContext as unknown[]).push({
+                "@language": prefLang,
+            });
         }
 
         // use new language title

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -40,7 +40,7 @@
         "aedes": "^0.46.2",
         "mqtt": "^4.2.8",
         "rxjs": "5.5.11",
-        "wot-thing-description-types": "^1.1.0-06-July-2022"
+        "wot-thing-description-types": "^1.1.0-13-July-2022"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-06-July-2022",
+        "wot-thing-description-types": "^1.1.0-13-July-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "optionalDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-06-July-2022",
+        "wot-thing-description-types": "^1.1.0-13-July-2022",
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.23"
     },
     "dependencies": {

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -135,13 +135,13 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
             let languageSet = false;
             for (const arrayEntry of arrayContext) {
                 if (typeof arrayEntry === "object") {
-                    if (arrayEntry["@language"] !== undefined) {
+                    if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
                         languageSet = true;
                     }
                 }
             }
             if (!languageSet) {
-                (arrayContext as Exclude<typeof arrayContext, []>).push({
+                (arrayContext as unknown[]).push({
                     "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
                 });
             }

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -123,29 +123,8 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
                 }
             }
         } */
-        // set default language
-        this.addDefaultLanguage(this);
-    }
-
-    // Note: copy from td-parser.ts
-    addDefaultLanguage(thing: ExposedThing): void {
-        // add @language : "en" if no @language set
-        if (Array.isArray(thing["@context"])) {
-            const arrayContext: TDT.ThingContext = thing["@context"];
-            let languageSet = false;
-            for (const arrayEntry of arrayContext) {
-                if (typeof arrayEntry === "object") {
-                    if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
-                        languageSet = true;
-                    }
-                }
-            }
-            if (!languageSet) {
-                (arrayContext as unknown[]).push({
-                    "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
-                });
-            }
-        }
+        // set @language to "en" if no @language available
+        TD.setContextLanguage(this, TD.DEFAULT_CONTEXT_LANGUAGE, false);
     }
 
     public getThingDescription(): WoT.ThingDescription {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -23,7 +23,7 @@
         "ts-node": "10.1.0",
         "typescript": "4.4.3",
         "typescript-standard": "^0.3.36",
-        "wot-thing-description-types": "^1.1.0-06-July-2022",
+        "wot-thing-description-types": "^1.1.0-13-July-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -44,7 +44,7 @@
         "is-absolute-url": "3.0.3",
         "json-placeholder-replacer": "^1.0.35",
         "url-toolkit": "2.1.6",
-        "wot-thing-description-types": "^1.1.0-06-July-2022",
+        "wot-thing-description-types": "^1.1.0-13-July-2022",
         "wot-thing-model-types": "^1.1.0-06-July-2022",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },

--- a/packages/td-tools/src/td-helpers.ts
+++ b/packages/td-tools/src/td-helpers.ts
@@ -37,3 +37,27 @@ export function findPort(td: ThingDescription): number {
     const returnString: string = base.substring(columnLoc + 1, divLoc);
     return parseInt(returnString);
 }
+
+export function setContextLanguage(thing: ThingDescription, language: string, forceOverride: boolean): void {
+    // forceOverride == false -> set @language if no @language set
+    // forceOverride == true  -> set/override @language in any case
+    if (Array.isArray(thing["@context"])) {
+        const arrayContext = thing["@context"];
+        let languageSet = false;
+        for (const arrayEntry of arrayContext) {
+            if (typeof arrayEntry === "object") {
+                if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
+                    if (forceOverride) {
+                        (arrayEntry as Record<string, unknown>)["@language"] = language;
+                    }
+                    languageSet = true;
+                }
+            }
+        }
+        if (!languageSet) {
+            (arrayContext as unknown[]).push({
+                "@language": language,
+            });
+        }
+    }
+}

--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -15,32 +15,13 @@
 
 import Thing from "./thing-description";
 import * as TD from "./thing-description";
+import * as TDHelpers from "./td-helpers";
 
 import isAbsoluteUrl = require("is-absolute-url");
 import URLToolkit = require("url-toolkit");
 import { ThingContext } from "wot-thing-description-types";
 
 /** Parses a TD into a Thing object */
-
-function addDefaultLanguage(thing: Thing) {
-    // add @language : "en" if no @language set
-    if (Array.isArray(thing["@context"])) {
-        const arrayContext: ThingContext = thing["@context"];
-        let languageSet = false;
-        for (const arrayEntry of arrayContext) {
-            if (typeof arrayEntry === "object") {
-                if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
-                    languageSet = true;
-                }
-            }
-        }
-        if (!languageSet) {
-            (arrayContext as unknown[]).push({
-                "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
-            });
-        }
-    }
-}
 export function parseTD(td: string, normalize?: boolean): Thing {
     console.debug("[td-tools/td-parser]", `parseTD() parsing\n\`\`\`\n${td}\n\`\`\``);
 
@@ -95,8 +76,8 @@ export function parseTD(td: string, normalize?: boolean): Thing {
         // insert default contexts as first entries
         thing["@context"] = [TD.DEFAULT_CONTEXT_V1, TD.DEFAULT_CONTEXT_V11, semContext];
     }
-    // add @language : "en" if no @language set
-    addDefaultLanguage(thing);
+    // set @language to "en" if no @language available
+    TDHelpers.setContextLanguage(thing, TD.DEFAULT_CONTEXT_LANGUAGE, false);
 
     if (thing["@type"] === undefined) {
         thing["@type"] = TD.DEFAULT_THING_TYPE;

--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -25,17 +25,17 @@ import { ThingContext } from "wot-thing-description-types";
 function addDefaultLanguage(thing: Thing) {
     // add @language : "en" if no @language set
     if (Array.isArray(thing["@context"])) {
-        const arrayContext: Array<string | Record<string, unknown>> = thing["@context"];
+        const arrayContext: ThingContext = thing["@context"];
         let languageSet = false;
         for (const arrayEntry of arrayContext) {
             if (typeof arrayEntry === "object") {
-                if (arrayEntry["@language"] !== undefined) {
+                if ((arrayEntry as Record<string, unknown>)["@language"] !== undefined) {
                     languageSet = true;
                 }
             }
         }
         if (!languageSet) {
-            arrayContext.push({
+            (arrayContext as unknown[]).push({
                 "@language": TD.DEFAULT_CONTEXT_LANGUAGE,
             });
         }

--- a/packages/td-tools/test/TDParseTest.ts
+++ b/packages/td-tools/test/TDParseTest.ts
@@ -27,6 +27,7 @@ import Thing, {
     DEFAULT_CONTEXT_LANGUAGE,
 } from "../src/thing-description";
 import * as TDParser from "../src/td-parser";
+import * as TDHelpers from "../src/td-helpers";
 // should must be called to augment all variables
 should();
 
@@ -384,6 +385,26 @@ class TDParserTest {
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
         expect(thing["@context"][1]).to.have.property("iot").that.equals("http://example.org/iot");
         expect(thing["@context"][2]).to.have.property("@language").that.equals("de");
+        expect(thing).to.have.property("@type").that.equals(DEFAULT_THING_TYPE);
+    }
+
+    @test "should ovverride existing @language in context"() {
+        const testTD = `{ "title": "NoContext",
+      "@context": ["https://www.w3.org/2019/wot/td/v1", {
+          "iot": "http://example.org/iot"
+        },
+        { "@language" : "de" }
+      ]
+    }`;
+        const thing: Thing = TDParser.parseTD(testTD);
+        TDHelpers.setContextLanguage(thing, "en", true);
+
+        console.dir(thing);
+
+        expect(thing).to.have.property("@context").that.has.length(3);
+        expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
+        expect(thing["@context"][1]).to.have.property("iot").that.equals("http://example.org/iot");
+        expect(thing["@context"][2]).to.have.property("@language").that.equals("en");
         expect(thing).to.have.property("@type").that.equals(DEFAULT_THING_TYPE);
     }
 


### PR DESCRIPTION
Note: I am sometimes **VERY** surprised how _unrelated_ changes (see https://github.com/w3c/wot-scripting-api/commit/8c73b707462b494787d2d261e8f09b7d70dadcfc) break the types (`@context/@language`) used in node-wot.

Does anyone know why? Kind of frustrating.