### PR TITLE
Correctly configure built-ins in browserify

### DIFF
--- a/packages/browser-bundle/build.js
+++ b/packages/browser-bundle/build.js
@@ -11,13 +11,15 @@ const _stream_writable = require.resolve("readable-stream4/lib/_stream_writable"
 const fs = require("fs");
 
 const builder = browserify({
-    ...builtIns,
-    stream,
-    _stream_duplex,
-    _stream_passthrough,
-    _stream_readable,
-    _stream_transform,
-    _stream_writable,
+    builtins: {
+        ...builtIns,
+        stream,
+        _stream_duplex,
+        _stream_passthrough,
+        _stream_readable,
+        _stream_transform,
+        _stream_writable,
+    },
 });
 
 builder.add("./index.js");


### PR DESCRIPTION
Sorry, it seems that when I cleaned up the `built.js` script I wrongly assigned the list of builtins to the root configuration object of browserify. Silly mistake. Now everything should work correctly on the browsers. 

fixes https://github.com/eclipse/thingweb.node-wot/issues/785