### PR TITLE
URL rewrite

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -567,7 +567,7 @@ export default class HttpServer implements ProtocolServer {
             const internalUrl = this.urlRewrite[entryUrl];
             if (internalUrl) {
                 pathname = internalUrl;
-                console.debug("[binding-http]", `URL "${entryUrl}" has been rewritten to "${pathname}"`);
+                debug("[binding-http]", `URL "${entryUrl}" has been rewritten to "${pathname}"`);
             }
         }
 

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -561,10 +561,21 @@ export default class HttpServer implements ProtocolServer {
             }
         }
 
+        // url-rewrite feature in use ?
+        let pathname = requestUri.pathname;
+        if (this.urlRewrite) {
+            const entryUrl = pathname;
+            const internalUrl = this.urlRewrite[entryUrl];
+            if (internalUrl) {
+                pathname = internalUrl;
+                console.debug("[binding-http]", `URL "${entryUrl}" has been rewritten to "${pathname}"`);
+            }
+        }
+
         // route request
         let segments: string[];
         try {
-            segments = decodeURI(requestUri.pathname).split("/");
+            segments = decodeURI(pathname).split("/");
         } catch (ex) {
             // catch URIError, see https://github.com/eclipse/thingweb.node-wot/issues/389
             console.warn(
@@ -606,15 +617,6 @@ export default class HttpServer implements ProtocolServer {
             // resource found and response sent
             return;
         } else {
-            // url-rewrite feature in use ?
-            if (this.urlRewrite) {
-                const entryUrl = segments.slice(1, segments.length).join("/");
-                const internalUrl = this.urlRewrite[entryUrl];
-                if (internalUrl) {
-                    segments = decodeURI(internalUrl).split("/");
-                }
-            }
-
             // path -> select Thing
             const thing: ExposedThing = this.things.get(segments[1]);
             if (thing) {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -58,6 +58,7 @@ export default class HttpServer implements ProtocolServer {
     private readonly port: number = 8080;
     private readonly address: string = undefined;
     private readonly baseUri: string = undefined;
+    private readonly urlRewrite: Record<string, string> = undefined;
     private readonly httpSecurityScheme: string = "NoSec"; // HTTP header compatible string
     private readonly validOAuthClients: RegExp = /.*/g;
     private readonly server: http.Server | https.Server = null;
@@ -93,6 +94,9 @@ export default class HttpServer implements ProtocolServer {
         }
         if (config.baseUri !== undefined) {
             this.baseUri = config.baseUri;
+        }
+        if (config.urlRewrite !== undefined) {
+            this.urlRewrite = config.urlRewrite;
         }
 
         // TLS
@@ -602,6 +606,15 @@ export default class HttpServer implements ProtocolServer {
             // resource found and response sent
             return;
         } else {
+            // url-rewrite feature in use ?
+            if (this.urlRewrite) {
+                const entryUrl = segments.slice(1, segments.length).join("/");
+                const internalUrl = this.urlRewrite[entryUrl];
+                if (internalUrl) {
+                    segments = decodeURI(internalUrl).split("/");
+                }
+            }
+
             // path -> select Thing
             const thing: ExposedThing = this.things.get(segments[1]);
             if (thing) {

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -37,6 +37,7 @@ export interface HttpConfig {
     port?: number;
     address?: string;
     baseUri?: string;
+    urlRewrite?: Record<string, string>;
     proxy?: HttpProxyConfig;
     allowSelfSigned?: boolean;
     serverKey?: string;

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -510,4 +510,43 @@ class HttpServerTest {
 
         return httpServer.stop();
     }
+
+    @test async "should allow url rewrite"() {
+        const httpServer = new HttpServer({ port: 0, urlRewrite: { "/myroot/foo": "/test/properties/test" } });
+
+        await httpServer.start(null);
+
+        const testThing = new ExposedThing(null, {
+            title: "Test",
+            properties: {
+                test: {
+                    type: "object",
+                },
+            },
+        });
+        let test = {};
+        testThing.setPropertyReadHandler("test", (_) => Promise.resolve(test));
+        testThing.setPropertyWriteHandler("test", async (value) => {
+            test = await value.value();
+        });
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        testThing.properties.test.forms = [];
+        await httpServer.expose(testThing);
+
+        const uriWithoutThing = `http://localhost:${httpServer.getPort()}/`;
+        let resp;
+
+        resp = await (await fetch(uriWithoutThing + "test/properties/test")).text();
+        expect(resp).to.equal("{}");
+
+        resp = await (await fetch(uriWithoutThing + "myroot/foo")).text();
+        expect(resp).to.equal("{}");
+
+        resp = await (await fetch(uriWithoutThing + "my-entry/does-not-exist")).text();
+        expect(resp).to.not.equal("{}"); // i.e., returns 'Not Found'
+
+        return httpServer.stop();
+    }
 }

--- a/packages/examples/src/bindings/http/example-server.ts
+++ b/packages/examples/src/bindings/http/example-server.ts
@@ -21,6 +21,10 @@ const servient = new Servient();
 servient.addServer(
     new HttpServer({
         port: 8081, // (default 8080)
+        urlRewrite: {
+            "/myroot/foo/cnt": "/mycounter/properties/count",
+            "/mysecondURL/for/the/same/resource": "/mycounter/properties/count",
+        },
     })
 );
 


### PR DESCRIPTION
This is a proof of concept to introduce URL rewrite capabilities in node-wot (i.e., using a desired URL for a given resource);

urlRewrite takes precedence and rewrites any possible "input" URL.
I tried to keep the changes as minimal as possible.

Moreover, I modified an example to show how this might look like in practice. You can run and play with it of course.

Questions/Downsides:
* One needs to know the *internals* of node-wot to know to which URL to point to.
  (e.g,. `"/myroot/foo/cnt"`  -->  `"/mycounter/properties/count"`)
* The ThingDescription itself contains the actual URL. Do we need to update the TD as well? What if multiple URLs point to the same resource?
* We do not differ between GET/PUT/POST request. Do we need to do so?

TODOs
* update [wot-servient-schema.conf.json](https://github.com/eclipse/thingweb.node-wot/blob/master/packages/cli/src/wot-servient-schema.conf.json)
* update CLI ([1](https://github.com/eclipse/thingweb.node-wot/blob/master/packages/cli/src/cli.ts#L61), ...)

Feedback is welcome!

fixes https://github.com/eclipse/thingweb.node-wot/issues/795