### PR TITLE
Use new logging functions in binding packages

### DIFF
--- a/packages/binding-coap/src/coap-client-factory.ts
+++ b/packages/binding-coap/src/coap-client-factory.ts
@@ -17,9 +17,11 @@
  * CoAP client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import CoapClient from "./coap-client";
 import CoapServer from "./coap-server";
+
+const { debug } = createLoggers("binding-coap", "coap-client-factory");
 
 export default class CoapClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "coap";
@@ -31,18 +33,18 @@ export default class CoapClientFactory implements ProtocolClientFactory {
     }
 
     public getClient(): ProtocolClient {
-        console.debug("[binding-coap]", `CoapClientFactory creating client for '${this.scheme}'`);
+        debug(`CoapClientFactory creating client for '${this.scheme}'`);
         return new CoapClient(this.server);
     }
 
     public init(): boolean {
-        // console.info(`CoapClientFactory for '${this.scheme}' initializing`);
+        // info(`CoapClientFactory for '${this.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`CoapClientFactory for '${this.scheme}' destroyed`);
+        // info(`CoapClientFactory for '${this.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-coap/src/coaps-client-factory.ts
+++ b/packages/binding-coap/src/coaps-client-factory.ts
@@ -17,25 +17,27 @@
  * CoAPS client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import CoapsClient from "./coaps-client";
+
+const { debug } = createLoggers("binding-coap", "coaps-client-factory");
 
 export default class CoapsClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "coaps";
 
     public getClient(): ProtocolClient {
-        console.debug("[binding-coap]", `CoapsClientFactory creating client for '${this.scheme}'`);
+        debug(`CoapsClientFactory creating client for '${this.scheme}'`);
         return new CoapsClient();
     }
 
     public init(): boolean {
-        // console.info(`CoapsClientFactory for '${this.scheme}' initializing`);
+        // info(`CoapsClientFactory for '${this.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`CoapsClientFactory for '${this.scheme}' destroyed`);
+        // info(`CoapsClientFactory for '${this.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-file/src/file-client-factory.ts
+++ b/packages/binding-file/src/file-client-factory.ts
@@ -16,14 +16,16 @@
 /**
  * File protocol binding
  */
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import FileClient from "./file-client";
+
+const { debug } = createLoggers("binding-file", "file-client-factory");
 
 export default class FileClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "file";
 
     public getClient(): ProtocolClient {
-        console.debug("[binding-file]", `FileClientFactory creating client for '${this.scheme}'`);
+        debug(`FileClientFactory creating client for '${this.scheme}'`);
         return new FileClient();
     }
 

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -17,10 +17,12 @@
  * File protocol binding
  */
 import { Form, SecurityScheme } from "@node-wot/td-tools";
-import { ProtocolClient, Content } from "@node-wot/core";
+import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Subscription } from "rxjs/Subscription";
 import fs = require("fs");
 import path = require("path");
+
+const { debug, warn } = createLoggers("binding-file", "file-client");
 
 export default class FileClient implements ProtocolClient {
     public toString(): string {
@@ -32,7 +34,7 @@ export default class FileClient implements ProtocolClient {
             const filepath = form.href.split("//");
             const resource = fs.createReadStream(filepath[1]);
             const extension = path.extname(filepath[1]);
-            console.debug("[binding-file]", `FileClient found '${extension}' extension`);
+            debug(`FileClient found '${extension}' extension`);
             let contentType;
             if (form.contentType) {
                 contentType = form.contentType;
@@ -53,7 +55,7 @@ export default class FileClient implements ProtocolClient {
                         contentType = "application/ld+json";
                         break;
                     default:
-                        console.warn("[binding-file]", `FileClient cannot determine media type of '${form.href}'`);
+                        warn(`FileClient cannot determine media type of '${form.href}'`);
                 }
             }
             resolve({ type: contentType, body: resource });

--- a/packages/binding-firestore/src/firestore-client-factory.ts
+++ b/packages/binding-firestore/src/firestore-client-factory.ts
@@ -17,10 +17,12 @@
  * WoT Firestore client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient, ContentSerdes } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, ContentSerdes, createLoggers } from "@node-wot/core";
 import { BindingFirestoreConfig } from "./firestore";
 import FirestoreClient from "./firestore-client";
 import FirestoreCodec from "./codecs/firestore-codec";
+
+const { warn } = createLoggers("binding-firestore", "firestore-client-factory");
 
 export default class FirestoreClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "firestore";
@@ -34,7 +36,7 @@ export default class FirestoreClientFactory implements ProtocolClientFactory {
     }
 
     public getClient(): ProtocolClient {
-        console.warn(`[binding-firestore] firebaseClientFactory creating client`);
+        warn(`Creating client`);
         if (this.firestoreClient === null) {
             this.firestoreClient = new FirestoreClient(this.config);
         }

--- a/packages/binding-firestore/src/firestore-client.ts
+++ b/packages/binding-firestore/src/firestore-client.ts
@@ -16,7 +16,7 @@
 /**
  * Firestore client
  */
-import { ProtocolClient, Content } from "@node-wot/core";
+import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { FirestoreForm, BindingFirestoreConfig } from "./firestore";
 import { v4 as uuidv4 } from "uuid";
 
@@ -33,6 +33,8 @@ import * as TD from "@node-wot/td-tools";
 import { Subscription } from "rxjs/Subscription";
 
 type Firestore = Firebase.firestore.Firestore;
+
+const { debug, error: logError } = createLoggers("binding-firestore", "firestore-client");
 
 export default class FirestoreClient implements ProtocolClient {
     private firestore: Firestore = null;
@@ -111,8 +113,8 @@ export default class FirestoreClient implements ProtocolClient {
                 this.firestoreObservers,
                 propertyReadResultTopic,
                 (err, content, resId) => {
-                    console.debug("[binding-firestore] return read property result");
-                    console.debug(`[binding-firestore] reqId ${reqId}, resId ${resId}`);
+                    debug("return read property result");
+                    debug(`reqId ${reqId}, resId ${resId}`);
                     if (reqId !== resId) {
                         // Ignored because reqId and resId do not match
                         return;
@@ -120,7 +122,7 @@ export default class FirestoreClient implements ProtocolClient {
                     unsubscribeToFirestore(this.firestoreObservers, propertyReadResultTopic);
                     clearTimeout(timeoutId);
                     if (err) {
-                        console.error("[binding-firestore] failed to get reading property result:", err);
+                        logError(`failed to get reading property result: ${err}`);
                         reject(err);
                     } else {
                         resolve(content);
@@ -170,8 +172,8 @@ export default class FirestoreClient implements ProtocolClient {
         let timeoutId: NodeJS.Timeout;
         const retContent: Content = await new Promise((resolve, reject) => {
             subscribeToFirestore(this.firestore, this.firestoreObservers, actionResultTopic, (err, content, resId) => {
-                console.debug("[binding-firestore] return action and unsubscribe");
-                console.debug(`[binding-firestore] reqId ${reqId}, resId ${resId}`);
+                debug("return action and unsubscribe");
+                debug(`reqId ${reqId}, resId ${resId}`);
                 if (reqId !== resId) {
                     // Ignored because reqId and resId do not match
                     return;
@@ -179,7 +181,7 @@ export default class FirestoreClient implements ProtocolClient {
                 unsubscribeToFirestore(this.firestoreObservers, actionResultTopic);
                 clearTimeout(timeoutId);
                 if (err) {
-                    console.error("[binding-firestore] failed to get action result:", err);
+                    logError(`failed to get action result: ${err}`);
                     reject(err);
                 } else {
                     resolve(content);
@@ -234,7 +236,7 @@ export default class FirestoreClient implements ProtocolClient {
                         pointerInfo.topic,
                         (err: Error, content) => {
                             if (err) {
-                                console.error("[binding-firestore] failed to subscribe resource: ", err);
+                                logError(`failed to subscribe resource: ${err}`);
                                 error(err);
                             } else {
                                 next(content);
@@ -248,7 +250,7 @@ export default class FirestoreClient implements ProtocolClient {
                     );
                 })
                 .catch((err) => {
-                    console.error("[binding-firestore] failed to init firestore: ", err);
+                    logError(`failed to init firestore: ${err}`);
                     error(err);
                 });
         });

--- a/packages/binding-firestore/test/firestore-client-basic-test.ts
+++ b/packages/binding-firestore/test/firestore-client-basic-test.ts
@@ -15,7 +15,7 @@
 import { suite, test } from "@testdeck/mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import Servient, { Helpers } from "@node-wot/core";
+import Servient, { Helpers, createLoggers } from "@node-wot/core";
 import FirestoreClientFactory from "../src/firestore-client-factory";
 import FirestoreCodec from "../src/codecs/firestore-codec";
 import firebase from "firebase/compat/app";
@@ -27,6 +27,7 @@ import { ThingDescription } from "wot-typescript-definitions";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const firestoreConfig = require("./firestore-config.json");
+const { error } = createLoggers("binding-firestore", "firestore-client-basic-test");
 
 // chai.should()
 chai.use(chaiAsPromised);
@@ -73,10 +74,10 @@ class FirestoreClientBasicTest {
                 const WoT = await servient.start();
                 thing = await WoT.consume(td as ThingDescription);
             } catch (err) {
-                console.error("Script error:", err);
+                error(`Script error: ${err}`);
             }
         } catch (err) {
-            console.error("Fetch error:", err);
+            error(`Fetch error: ${err}`);
         }
     }
 

--- a/packages/binding-firestore/test/test-thing.ts
+++ b/packages/binding-firestore/test/test-thing.ts
@@ -13,12 +13,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import Servient from "@node-wot/core";
+import { Servient, createLoggers } from "@node-wot/core";
 import FirestoreServer from "../src/firestore-server";
 import FirestoreCodec from "../src/codecs/firestore-codec";
 import firebase from "firebase/compat/app";
 
 import firestoreConfig from "./firestore-config.json";
+
+const { debug, info, error } = createLoggers("binding-firestore", "test-thing");
 
 export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
     // setup for emulator
@@ -40,7 +42,7 @@ export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
                     .createUserWithEmailAndPassword(firestoreConfig.user.email, firestoreConfig.user.password);
             } catch (e) {
                 // is not error
-                console.log("user ia already created err: ", e);
+                error(`user ia already created err: ${e}`);
             }
         }
         // create server
@@ -177,7 +179,7 @@ export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
         // expose the thing
         await thing.expose();
 
-        // console.log("Produced " + thing.getThingDescription().title);
+        debug(`Produced ${thing.getThingDescription().title}`);
 
         // set property handlers (using async-await)
         thing.setPropertyReadHandler("objectProperty", async () => {
@@ -207,67 +209,67 @@ export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
 
         // set action handlers
         thing.setActionHandler("actionWithoutArgsResponse", async (params) => {
-            console.log("actionWithoutArgsResponse", params);
+            debug(`actionWithoutArgsResponse ${params}`);
             return undefined;
         });
         thing.setActionHandler("actionNum", async (params) => {
             const v = await params.value();
-            console.log("actionNum", v);
+            debug(`actionNum ${v}`);
             return v;
         });
         thing.setActionHandler("actionString", async (params) => {
             const v = await params.value();
-            console.log("actionString", v);
+            debug(`actionString ${v}`);
             return v;
         });
         thing.setActionHandler("actionObject", async (params) => {
             const v = await params.value();
-            console.log("actionObject", v);
+            debug(`actionObject ${v}`);
             return v;
         });
         thing.setActionHandler("actionStringToObj", async (params) => {
             const v = await params.value();
-            console.log("actionStringToObj", v);
+            debug(`actionStringToObj ${v}`);
             return { test: v };
         });
         thing.setActionHandler("actionObjToNum", async (params) => {
             const v = await params.value();
-            console.log("actionObjToNum", v);
+            debug(`actionObjToNum ${v}`);
             return 1;
         });
         thing.setActionHandler("actionStringToObj", async (params) => {
             const v = await params.value();
-            console.log("actionStringToObj", v);
+            debug(`actionStringToObj ${v}`);
             return { test: v };
         });
         thing.setActionHandler("actionObjToNum", async (params) => {
             const v = await params.value();
-            console.log("actionObjToNum", v);
+            debug(`actionObjToNum ${v}`);
             return 1;
         });
         // actions for event
         thing.setActionHandler("actionEventInteger", async (params) => {
             const v = await params.value();
-            console.log("actionEventInteger", v);
+            debug(`actionEventInteger ${v}`);
             thing.emitEvent("eventInteger", v);
             return undefined;
         });
         thing.setActionHandler("actionEventString", async (params) => {
             const v = await params.value();
-            console.log("actionEventString", v);
+            debug(`actionEventString ${v}`);
             thing.emitEvent("eventString", v);
             return undefined;
         });
         thing.setActionHandler("actionEventObject", async (params) => {
             const v = await params.value();
-            console.log("actionEventObject", v);
+            debug(`actionEventObject ${v}`);
             thing.emitEvent("eventObject", v);
             return undefined;
         });
 
-        console.info(thing.getThingDescription().title + " ready");
+        info(`${thing.getThingDescription().title} ready`);
         return thing;
     } catch (err) {
-        console.log(err);
+        debug(err);
     }
 };

--- a/packages/binding-http/src/http-client-factory.ts
+++ b/packages/binding-http/src/http-client-factory.ts
@@ -17,10 +17,12 @@
  * HTTP client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import { HttpConfig } from "./http";
 import HttpClient from "./http-client";
 import OAuthManager from "./oauth-manager";
+
+const { debug, warn } = createLoggers("binding-http", "http-client-factory");
 
 export default class HttpClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "http";
@@ -34,25 +36,22 @@ export default class HttpClientFactory implements ProtocolClientFactory {
     public getClient(): ProtocolClient {
         // HTTP over HTTPS proxy requires HttpsClient
         if (this.config && this.config.proxy && this.config.proxy.href && this.config.proxy.href.startsWith("https:")) {
-            console.warn(
-                "[binding-http]",
-                `HttpClientFactory creating client for 'https' due to secure proxy configuration`
-            );
+            warn("HttpClientFactory creating client for 'https' due to secure proxy configuration");
             return new HttpClient(this.config, true, this.oAuthManager);
         } else {
-            console.debug("[binding-http]", `HttpClientFactory creating client for '${this.scheme}'`);
+            debug(`HttpClientFactory creating client for '${this.scheme}'`);
             return new HttpClient(this.config);
         }
     }
 
     public init(): boolean {
-        // console.info(`HttpClientFactory for '${HttpClientFactory.scheme}' initializing`);
+        // info(`HttpClientFactory for '${HttpClientFactory.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`HttpClientFactory for '${HttpClientFactory.scheme}' destroyed`);
+        // info(`HttpClientFactory for '${HttpClientFactory.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-http/src/https-client-factory.ts
+++ b/packages/binding-http/src/https-client-factory.ts
@@ -17,9 +17,11 @@
  * HTTPS client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import { HttpConfig } from "./http";
 import HttpClient from "./http-client";
+
+const { debug, warn } = createLoggers("binding-http", "https-client-factory");
 
 export default class HttpsClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "https";
@@ -32,24 +34,22 @@ export default class HttpsClientFactory implements ProtocolClientFactory {
     public getClient(): ProtocolClient {
         // HTTPS over HTTP proxy requires HttpClient
         if (this.config && this.config.proxy && this.config.proxy.href && this.config.proxy.href.startsWith("http:")) {
-            console.warn(
-                `"[binding-http]",HttpsClientFactory creating client for 'http' due to insecure proxy configuration`
-            );
+            warn("HttpsClientFactory creating client for 'http' due to insecure proxy configuration");
             return new HttpClient(this.config);
         } else {
-            console.debug("[binding-http]", `HttpsClientFactory creating client for '${this.scheme}'`);
+            debug(`HttpsClientFactory creating client for '${this.scheme}'`);
             return new HttpClient(this.config, true);
         }
     }
 
     public init(): boolean {
-        // console.info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' initializing`);
+        // info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' destroyed`);
+        // info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-http/test/http-client-test.ts
+++ b/packages/binding-http/test/http-client-test.ts
@@ -23,7 +23,7 @@ import chai, { expect, should } from "chai";
 import * as http from "http";
 import { AddressInfo } from "net";
 
-import { Content, ContentSerdes, ProtocolHelpers, ProtocolServer } from "@node-wot/core";
+import { Content, ContentSerdes, createLoggers, ProtocolHelpers, ProtocolServer } from "@node-wot/core";
 
 import { Readable } from "stream";
 
@@ -37,6 +37,8 @@ import SseStream from "ssestream";
 
 // Add spies
 import spies from "chai-spies";
+
+const { debug } = createLoggers("binding-http", "http-client-test");
 
 // should must be called to augment all variables
 should();
@@ -319,7 +321,7 @@ class HttpClientTest2 {
         const app = express();
         app.use(serveStatic(__dirname));
         app.get("/sse", function (req: express.Request, res: express.Response) {
-            console.log("new connection");
+            debug("new connection");
 
             const sseStream = new SseStream(req);
             sseStream.pipe(res);
@@ -330,7 +332,7 @@ class HttpClientTest2 {
             }, 300);
 
             res.on("close", () => {
-                console.log("lost connection");
+                debug("lost connection");
                 clearInterval(pusher);
                 sseStream.unpipe(res);
                 done();
@@ -338,9 +340,9 @@ class HttpClientTest2 {
         });
 
         const server = app.listen(port1, () => {
-            console.log(`server ready on http://localhost:${port1}`);
+            debug(`server ready on http://localhost:${port1}`);
         });
-        console.log("client created");
+        debug("client created");
         const client = new HttpClient();
 
         // Subscribe to a resource with sse

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -23,10 +23,12 @@ import * as chai from "chai";
 import fetch from "node-fetch";
 
 import HttpServer from "../src/http-server";
-import { Content, ExposedThing, Helpers, ProtocolHelpers } from "@node-wot/core";
+import { Content, createLoggers, ExposedThing, Helpers, ProtocolHelpers } from "@node-wot/core";
 import { DataSchemaValue, InteractionInput, InteractionOptions } from "wot-typescript-definitions";
 import chaiAsPromised from "chai-as-promised";
 import { Readable } from "stream";
+
+const { debug, error } = createLoggers("binding-http", "http-server-test");
 
 chai.use(chaiAsPromised);
 
@@ -140,7 +142,7 @@ class HttpServerTest {
         const uri = `http://localhost:${httpServer.getPort()}/test/`;
         let resp;
 
-        console.log("Testing", uri);
+        debug(`Testing ${uri}`);
 
         resp = await (await fetch(uri + "properties/test")).text();
         expect(resp).to.equal('"off"');
@@ -267,7 +269,7 @@ class HttpServerTest {
         const uri = `http://localhost:${httpServer.getPort()}/test/`;
         let resp;
 
-        console.log("Testing", uri);
+        debug(`Testing ${uri}`);
 
         resp = await (await fetch(uri + "properties/test")).text();
         expect(resp).to.equal("{}");
@@ -307,7 +309,7 @@ class HttpServerTest {
         try {
             await httpServer2.start(null); // should fail
         } catch (err) {
-            console.log("HttpServer failed correctly on EADDRINUSE");
+            error(`HttpServer failed correctly on EADDRINUSE. ${err}`);
             assert(true);
         }
 
@@ -358,7 +360,7 @@ class HttpServerTest {
     }
 
     @test async "should not accept an unsupported scheme"() {
-        console.log("START SHOULD");
+        debug("START SHOULD");
         const httpServer = new HttpServer({
             port: port2,
             serverKey: "./test/server.key",
@@ -455,7 +457,7 @@ class HttpServerTest {
         const expectedUrl = `${theBaseUri}/smart-coffee-machine/actions/makeDrink`;
 
         expect(body).to.include(expectedUrl);
-        console.log(`Found URL ${expectedUrl} in TD`);
+        debug(`Found URL ${expectedUrl} in TD`);
         await httpServer.stop();
     }
 

--- a/packages/binding-http/test/memory-model.ts
+++ b/packages/binding-http/test/memory-model.ts
@@ -13,7 +13,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+import { createDebugLogger } from "@node-wot/core";
 import { PasswordModel, ClientCredentialsModel, Callback, Token, Falsey, Client, User } from "oauth2-server";
+
+const debug = createDebugLogger("binding-http", "memory-model");
 
 /**
  * oAuth server logic. See https://oauth2-server.readthedocs.io/en/latest/model/overview.html
@@ -72,9 +75,9 @@ export default class InMemoryModel implements ClientCredentialsModel, PasswordMo
     }
 
     dump(): void {
-        console.log("clients", this.clients);
-        console.log("tokens", this.tokens);
-        console.log("users", this.users);
+        debug(`Clients: ${this.clients}`);
+        debug(`Tokens: ${this.tokens}`);
+        debug(`Users: ${this.users}`);
     }
 
     /*

--- a/packages/binding-mbus/src/mbus-client-factory.ts
+++ b/packages/binding-mbus/src/mbus-client-factory.ts
@@ -13,14 +13,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createInfoLogger } from "@node-wot/core";
 import MBusClient from "./mbus-client";
+
+const info = createInfoLogger("binding-mbus", "mbus-client-factory");
 
 export default class MBusClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "mbus+tcp";
 
     public getClient(): ProtocolClient {
-        console.info("[binding-mbus]", `MBusClientFactory creating client for '${this.scheme}'`);
+        info(`MBusClientFactory creating client for '${this.scheme}'`);
         return new MBusClient();
     }
 

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -18,11 +18,13 @@
  */
 import { MBusForm } from "./mbus";
 
-import { ProtocolClient, Content } from "@node-wot/core";
+import { ProtocolClient, Content, createDebugLogger } from "@node-wot/core";
 import { SecurityScheme } from "@node-wot/td-tools";
 import { MBusConnection, PropertyOperation } from "./mbus-connection";
 
 import { Subscription } from "rxjs/Subscription";
+
+const debug = createDebugLogger("binding-mbus", "mbus-client");
 
 const DEFAULT_PORT = 805;
 const DEFAULT_TIMEOUT = 1000;
@@ -97,14 +99,14 @@ export default class MBusClient implements ProtocolClient {
         let connection = this._connections.get(hostAndPort);
 
         if (!connection) {
-            console.debug("[binding-mbus]", "Creating new MbusConnection for ", hostAndPort);
+            debug(`Creating new MbusConnection for ${hostAndPort}`);
             this._connections.set(
                 hostAndPort,
                 new MBusConnection(host, port, { connectionTimeout: form["mbus:timeout"] || DEFAULT_TIMEOUT })
             );
             connection = this._connections.get(hostAndPort);
         } else {
-            console.debug("[binding-mbus]", "Reusing MbusConnection for ", hostAndPort);
+            debug(`Reusing MbusConnection for ${hostAndPort}`);
         }
         // create operation
         const operation = new PropertyOperation(form);

--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -12,14 +12,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createDebugLogger } from "@node-wot/core";
 import ModbusClient from "./modbus-client";
+
+const debug = createDebugLogger("binding-modbus", "modbus-client-factory");
 
 export default class ModbusClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "modbus+tcp";
 
     public getClient(): ProtocolClient {
-        console.log(`ModbusClientFactory creating client for '${this.scheme}'`);
+        debug(`Creating client for '${this.scheme}'`);
         return new ModbusClient();
     }
 

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -17,12 +17,14 @@
  */
 import { ModbusForm, ModbusFunction, ModbusEndianness } from "./modbus";
 
-import { ProtocolClient, Content, ContentSerdes, ProtocolHelpers } from "@node-wot/core";
+import { ProtocolClient, Content, ContentSerdes, ProtocolHelpers, createDebugLogger } from "@node-wot/core";
 import { SecurityScheme } from "@node-wot/td-tools";
 import { modbusFunctionToEntity } from "./utils";
 import { ModbusConnection, PropertyOperation } from "./modbus-connection";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
+
+const debug = createDebugLogger("binding-modbus", "modbus-client");
 
 const DEFAULT_PORT = 805;
 const DEFAULT_TIMEOUT = 1000;
@@ -163,14 +165,14 @@ export default class ModbusClient implements ProtocolClient {
         let connection = this._connections.get(hostAndPort);
 
         if (!connection) {
-            console.debug("[binding-modbus]", "Creating new ModbusConnection for ", hostAndPort);
+            debug(`Creating new ModbusConnection for ${hostAndPort}`);
             this._connections.set(
                 hostAndPort,
                 new ModbusConnection(host, port, { connectionTimeout: form["modbus:timeout"] || DEFAULT_TIMEOUT })
             );
             connection = this._connections.get(hostAndPort);
         } else {
-            console.debug("[binding-modbus]", "Reusing ModbusConnection for ", hostAndPort);
+            debug(`Reusing ModbusConnection for ${hostAndPort}`);
         }
         // create operation
         const operation = new PropertyOperation(form, endianness, body);

--- a/packages/binding-modbus/test/test-modbus-server.ts
+++ b/packages/binding-modbus/test/test-modbus-server.ts
@@ -13,7 +13,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+import { createLoggers } from "@node-wot/core";
 import { ServerTCP } from "modbus-serial";
+
+const { error, debug } = createLoggers("binding-modbus", "test-modbus-server");
 
 export default class ModbusServer {
     serverTCP: ServerTCP;
@@ -77,10 +80,10 @@ export default class ModbusServer {
         return new Promise((resolve) => {
             this.serverTCP.on("SocketError", (err: Error) => {
                 // Handle socket error if needed, can be ignored
-                console.error(err);
+                error(err.toString());
             });
-            this.serverTCP.on("error", (e) => {
-                console.log(e);
+            this.serverTCP.on("error", (err) => {
+                debug(err.toString());
             });
 
             this.serverTCP.on("initialized", resolve);

--- a/packages/binding-mqtt/src/mqtt-client-factory.ts
+++ b/packages/binding-mqtt/src/mqtt-client-factory.ts
@@ -17,8 +17,10 @@
  * Protocol test suite to test protocol implementations
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createDebugLogger } from "@node-wot/core";
 import MqttClient from "./mqtt-client";
+
+const debug = createDebugLogger("binding-mqtt", "mqtt-client-factory");
 
 export default class MqttClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "mqtt";
@@ -35,7 +37,7 @@ export default class MqttClientFactory implements ProtocolClientFactory {
     }
 
     destroy(): boolean {
-        console.debug("[binding-mqtt]", `MqttClientFactory stopping all clients for '${this.scheme}'`);
+        debug(`MqttClientFactory stopping all clients for '${this.scheme}'`);
         this.clients.forEach((client) => client.stop());
         return true;
     }

--- a/packages/binding-mqtt/src/mqtts-client-factory.ts
+++ b/packages/binding-mqtt/src/mqtts-client-factory.ts
@@ -17,9 +17,11 @@
  * Protocol test suite to test protocol implementations
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createDebugLogger } from "@node-wot/core";
 import { MqttClientConfig } from "./mqtt";
 import MqttClient from "./mqtt-client";
+
+const debug = createDebugLogger("binding-mqtt", "mqtts-client-factory");
 
 export default class MqttsClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "mqtts";
@@ -38,7 +40,7 @@ export default class MqttsClientFactory implements ProtocolClientFactory {
     }
 
     destroy(): boolean {
-        console.debug("[binding-mqtt]", `MqttClientFactory stopping all clients for '${this.scheme}'`);
+        debug(`MqttClientFactory stopping all clients for '${this.scheme}'`);
         this.clients.forEach((client) => client.stop());
         return true;
     }

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -17,11 +17,13 @@
  * Protocol test suite to test protocol implementations
  */
 
-import { ProtocolHelpers, Servient } from "@node-wot/core";
+import { createInfoLogger, ProtocolHelpers, Servient } from "@node-wot/core";
 import { expect, should } from "chai";
 import MqttBrokerServer from "../src/mqtt-broker-server";
 import MqttClientFactory from "../src/mqtt-client-factory";
 import MqttsClientFactory from "../src/mqtts-client-factory";
+
+const info = createInfoLogger("binding-mqtt", "mqtt-client-subscribe-test.integration");
 
 // should must be called to augment all variables
 should();
@@ -65,7 +67,7 @@ describe("MQTT client implementation", () => {
                 events: events,
             }).then((thing) => {
                 thing.expose().then(() => {
-                    console.info("Exposed", thing.getThingDescription().title);
+                    info(`Exposed ${thing.getThingDescription().title}`);
 
                     WoT.consume(thing.getThingDescription()).then((client) => {
                         let check = 0;
@@ -130,7 +132,7 @@ describe("MQTT client implementation", () => {
                 events: events,
             }).then((thing) => {
                 thing.expose().then(() => {
-                    console.info("Exposed", thing.getThingDescription().title);
+                    info(`Exposed ${thing.getThingDescription().title}`);
 
                     WoT.consume(thing.getThingDescription()).then((client) => {
                         let check = 0;

--- a/packages/binding-netconf/src/async-node-netconf.ts
+++ b/packages/binding-netconf/src/async-node-netconf.ts
@@ -16,6 +16,9 @@ import * as nodeNetconf from "node-netconf";
 import * as xpath2json from "./xpath2json";
 import { promises as fsPromises } from "fs";
 import { NetConfCredentials, RpcMethod } from "./netconf";
+import { createDebugLogger } from "@node-wot/core";
+
+const debug = createDebugLogger("binding-netconf", "async-node-netconf");
 
 type RouterParams = {
     host: string;
@@ -94,8 +97,7 @@ export class Client {
                 if (err) {
                     reject(err);
                 } else {
-                    console.debug(
-                        "[binding-netconf]",
+                    debug(
                         `New NetConf router opened connection with host ${this.routerParams.host}, port ${this.routerParams.port}, username ${this.routerParams.username}`
                     );
                     this.connected = true;

--- a/packages/binding-netconf/src/codecs/netconf-codec.ts
+++ b/packages/binding-netconf/src/codecs/netconf-codec.ts
@@ -13,9 +13,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+import { createDebugLogger } from "@node-wot/core";
 import * as TD from "@node-wot/td-tools";
 import Url from "url-parse";
 import { DataSchemaValue } from "wot-typescript-definitions";
+
+const debug = createDebugLogger("binding-netconf", "netconf-codec");
 
 interface PayloadNamespaces {
     payload: unknown;
@@ -29,7 +32,7 @@ export default class NetconfCodec {
     }
 
     bytesToValue(bytes: Buffer, schema: TD.DataSchema, parameters: { [key: string]: string }): DataSchemaValue {
-        // console.debug(`NetconfCodec parsing '${bytes.toString()}'`);
+        debug(`NetconfCodec parsing '${bytes.toString()}'`);
 
         try {
             let parsed = JSON.parse(bytes.toString());
@@ -94,7 +97,7 @@ export default class NetconfCodec {
     }
 
     valueToBytes(value: unknown, schema: TD.DataSchema, parameters?: { [key: string]: string }): Buffer {
-        // console.debug("NetconfCodec serializing", value);
+        debug(`NetconfCodec serializing ${value}`);
         let body = "";
         if (value !== undefined) {
             const NSs = {};

--- a/packages/binding-netconf/src/netconf-client-factory.ts
+++ b/packages/binding-netconf/src/netconf-client-factory.ts
@@ -16,9 +16,11 @@
 /**
  * Netconf protocol binding
  */
-import { ProtocolClientFactory, ProtocolClient, ContentSerdes } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, ContentSerdes, createDebugLogger } from "@node-wot/core";
 import NetconfClient from "./netconf-client";
 import NetconfCodec from "./codecs/netconf-codec";
+
+const debug = createDebugLogger("binding-netconf", "netconf-client-factory");
 
 export default class NetconfClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "netconf";
@@ -26,7 +28,7 @@ export default class NetconfClientFactory implements ProtocolClientFactory {
 
     public getClient(): ProtocolClient {
         this.contentSerdes.addCodec(new NetconfCodec()); // add custom codec for NetConf
-        console.debug("[binding-netconf]", `NetconfClientFactory creating client for '${this.scheme}'`);
+        debug(`NetconfClientFactory creating client for '${this.scheme}'`);
         return new NetconfClient();
     }
 

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -16,13 +16,15 @@
 /**
  * Netconf protocol binding
  */
-import { ProtocolClient, Content, ProtocolHelpers } from "@node-wot/core";
+import { ProtocolClient, Content, ProtocolHelpers, createLoggers } from "@node-wot/core";
 import { NetconfForm, NetConfCredentials, RpcMethod, isRpcMethod } from "./netconf";
 import * as TD from "@node-wot/td-tools";
 import * as AsyncNodeNetcon from "./async-node-netconf";
 import Url from "url-parse";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
+
+const { debug, warn } = createLoggers("binding-netconf", "netconf-client");
 
 const DEFAULT_TARGET = "candidate";
 
@@ -130,7 +132,7 @@ export default class NetconfClient implements ProtocolClient {
             payload = payload.payload;
             result = JSON.stringify(await this.client.rpc(xpathQuery, method, NSs, target, payload));
         } catch (err) {
-            console.debug("[binding-netconf]", err);
+            debug(err.toString());
             throw err;
         }
 
@@ -167,7 +169,7 @@ export default class NetconfClient implements ProtocolClient {
 
     public setSecurity(metadata: Array<TD.SecurityScheme>, credentials?: NetConfCredentials): boolean {
         if (metadata === undefined || !Array.isArray(metadata) || metadata.length === 0) {
-            console.warn("[binding-netconf]", `NetconfClient without security`);
+            warn(`NetconfClient without security`);
             return false;
         }
         if (!credentials || (!credentials.password && !credentials.privateKey)) {

--- a/packages/binding-opcua/src/codec.ts
+++ b/packages/binding-opcua/src/codec.ts
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ContentCodec } from "@node-wot/core";
+import { ContentCodec, createLoggers } from "@node-wot/core";
 import { DataSchema } from "@node-wot/td-tools";
 import { DataValue } from "node-opcua-data-value";
 import { DataType, Variant } from "node-opcua-variant";
@@ -30,6 +30,8 @@ import {
 } from "node-opcua-json";
 import { BinaryStream } from "node-opcua-binary-stream";
 import { DataSchemaValue } from "wot-typescript-definitions";
+
+const { debug } = createLoggers("binding-opcua", "codec");
 
 // Strict mode has a lot of other checks and it prevents runtime unexpected problems
 // TODO: in the future we should use the strict mode
@@ -166,8 +168,8 @@ export class OpcuaJSONCodec implements ContentCodec {
             case "DataValue": {
                 const isValid = schemaDataValueJSONValidate(parsed);
                 if (!isValid) {
-                    console.log("[OpcuaJSONCodec|bytesToValue] parsed =", parsed);
-                    console.log("[OpcuaJSONCodec|bytesToValue]", schemaDataValueJSONValidate.errors);
+                    debug(`bytesToValue: parsed = ${parsed}`);
+                    debug(`bytesToValue: ${schemaDataValueJSONValidate.errors}`);
                     throw new Error("Invalid JSON dataValue : " + JSON.stringify(parsed, null, " "));
                 }
                 if (wantDataValue) {
@@ -182,7 +184,7 @@ export class OpcuaJSONCodec implements ContentCodec {
                     return dataValue;
                 }
                 const v = opcuaJsonEncodeVariant(opcuaJsonDecodeVariant(parsed), true);
-                console.log(v);
+                debug(`${v}`);
                 return v;
             }
             case "Value": {

--- a/packages/binding-opcua/src/factory.ts
+++ b/packages/binding-opcua/src/factory.ts
@@ -13,9 +13,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ProtocolClientFactory, ProtocolClient, ContentSerdes } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, ContentSerdes, createLoggers } from "@node-wot/core";
 import { OpcuaJSONCodec, OpcuaBinaryCodec } from "./codec";
 import { OPCUAProtocolClient } from "./opcua-protocol-client";
+
+const { debug } = createLoggers("binding-opcua", "factory");
 
 export class OPCUAClientFactory implements ProtocolClientFactory {
     readonly scheme: string = "opc.tcp";
@@ -30,7 +32,7 @@ export class OPCUAClientFactory implements ProtocolClientFactory {
     }
 
     getClient(): ProtocolClient {
-        console.debug("[binding-opcua]", `OpcuaClientFactory creating client for '${this.scheme}'`);
+        debug(`OpcuaClientFactory creating client for '${this.scheme}'`);
         if (this._clients[0]) {
             return this._clients[0];
         }
@@ -39,12 +41,12 @@ export class OPCUAClientFactory implements ProtocolClientFactory {
     }
 
     init(): boolean {
-        console.debug("[binding-opcua]", "init");
+        debug("init");
         return true;
     }
 
     destroy(): boolean {
-        console.debug("[binding-opcua]", "destroy");
+        debug("destroy");
 
         const clients = this._clients;
         this._clients = [];

--- a/packages/binding-opcua/test/client-test.ts
+++ b/packages/binding-opcua/test/client-test.ts
@@ -15,13 +15,15 @@
 import Ajv from "ajv/dist/core";
 import { expect } from "chai";
 
-import { ContentSerdes, ProtocolHelpers } from "@node-wot/core";
+import { ContentSerdes, ProtocolHelpers, createLoggers } from "@node-wot/core";
 
 import { VariableIds, OPCUAServer } from "node-opcua";
 
 import { OPCUAProtocolClient, OPCUAForm, OPCUAFormInvoke } from "../src/opcua-protocol-client";
 import { OpcuaJSONCodec, schemaDataValue } from "../src/codec";
 import { startServer } from "./fixture/basic-opcua-server";
+
+const { debug } = createLoggers("binding-opcua", "opcua-protocol-client");
 
 describe("OPCUA Client", function () {
     this.timeout(60000);
@@ -31,7 +33,7 @@ describe("OPCUA Client", function () {
     before(async () => {
         opcuaServer = await startServer();
         endpoint = opcuaServer.getEndpointUrl();
-        console.log("endpoint = ", endpoint);
+        debug(`endpoint = ${endpoint}`);
     });
     before(() => {
         // ensure codec is loaded
@@ -99,7 +101,7 @@ describe("OPCUA Client", function () {
             const content = await client.readResource(readForm);
             const content2 = { ...content, body: await ProtocolHelpers.readStreamFully(content.body) };
 
-            console.log("readResource returned: ", content2.body.toString("ascii"));
+            debug(`readResource returned: ${content2.body.toString("ascii")}`);
 
             const codecSerDes = ContentSerdes.get();
             const dataValue = codecSerDes.contentToValue(content2, schemaDataValue) as Record<string, unknown>;
@@ -109,7 +111,7 @@ describe("OPCUA Client", function () {
                 expect(dataValue.SourceTimestamp).to.be.instanceOf(Date);
                 dataValue.SourceTimestamp = "*";
             }
-            console.log(dataValue);
+            debug(`${dataValue}`);
             expect(dataValue).to.eql(expected);
         });
     });
@@ -180,7 +182,7 @@ describe("OPCUA Client", function () {
         const contentResult2 = { ...contentResult, body: await ProtocolHelpers.readStreamFully(contentResult.body) };
         const codecSerDes = ContentSerdes.get();
         const outputArguments = codecSerDes.contentToValue(contentResult2, schemaDataValue);
-        console.log("Y4: outputArguments:", outputArguments);
+        debug(`Y4: outputArguments: ${outputArguments}`);
 
         outputArguments.should.eql({ PreviousSetPoint: 27 });
     });

--- a/packages/binding-opcua/test/fixture/basic-opcua-server.ts
+++ b/packages/binding-opcua/test/fixture/basic-opcua-server.ts
@@ -35,6 +35,9 @@ import {
     CallMethodResultOptions,
 } from "node-opcua";
 import { KeyValuePair } from "node-opcua-types";
+import { createLoggers } from "@node-wot/core";
+
+const { info } = createLoggers("binding-opcua", "basic-opcua-server");
 
 interface UAVariable2 extends UAVariable {
     setValueFromSource(value: VariantLike, statusCode?: StatusCode, sourceTimestamp?: Date): void;
@@ -193,7 +196,7 @@ export async function startServer(): Promise<OPCUAServer> {
     );
 
     await server.start();
-    console.log("Server started", server.getEndpointUrl());
+    info(`Server started: ${server.getEndpointUrl()}`);
     return server;
 }
 

--- a/packages/binding-opcua/test/opcua-codec-test.ts
+++ b/packages/binding-opcua/test/opcua-codec-test.ts
@@ -16,7 +16,7 @@
 import { exist } from "should";
 import { expect } from "chai";
 
-import { ContentSerdes, ProtocolHelpers } from "@node-wot/core";
+import { ContentSerdes, ProtocolHelpers, createLoggers } from "@node-wot/core";
 import { ObjectSchema } from "@node-wot/td-tools";
 
 import { DataValue } from "node-opcua-data-value";
@@ -26,6 +26,8 @@ import { opcuaJsonEncodeDataValue } from "node-opcua-json";
 import { StatusCodes } from "node-opcua-status-code";
 
 import { jsonify, OpcuaBinaryCodec, OpcuaJSONCodec, theOpcuaBinaryCodec, theOpcuaJSONCodec } from "../src/codec";
+
+const { debug } = createLoggers("binding-opcua", "opcua-codec-test");
 
 const dataValue1 = new DataValue({});
 const dataValue2 = new DataValue({
@@ -94,7 +96,7 @@ describe("OPCUA JSON Serdes ", () => {
                 exist(ContentSerdes.getMediaType(contentType));
                 const payload = serdes.valueToContent(dataValue, schema, contentType);
                 const body = await ProtocolHelpers.readStreamFully(payload.body);
-                console.log(body.toString("ascii"));
+                debug(body.toString("ascii"));
                 JSON.parse(body.toString()).should.eql(expected1[index]);
             }
         );
@@ -113,7 +115,7 @@ describe("OPCUA JSON Serdes ", () => {
             exist(ContentSerdes.getMediaType(contentType));
             const payload = serdes.valueToContent(dataValue, schema, contentType);
             const body = await ProtocolHelpers.readStreamFully(payload.body);
-            console.log(body.toString("ascii"));
+            debug(body.toString("ascii"));
             body.toString().should.eql(expected2[index]);
         });
     });

--- a/packages/binding-opcua/test/schema-validation-test.ts
+++ b/packages/binding-opcua/test/schema-validation-test.ts
@@ -13,12 +13,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+import { createLoggers } from "@node-wot/core";
 import { expect } from "chai";
 
 import { DataType, DataValue, StatusCodes, VariantArrayType } from "node-opcua-client";
 import { opcuaJsonEncodeDataValue } from "node-opcua-json";
 
 import { schemaDataValueValidate, schemaDataValueJSONValidate } from "../src/codec";
+
+const { debug } = createLoggers("binding-opcua", "schema-validation-test");
 
 const data = {
     uint32: new DataValue({
@@ -71,11 +74,10 @@ describe("schemas", () => {
                 const obj1 = new DataValue({}).toJSON();
                 const isValid = validate(obj1);
                 if (!isValid) {
-                    console.log(isValid);
-                    console.log(validate.errors);
-                    console.log(obj1);
+                    debug(`Valid: ${isValid}`);
+                    debug(`Errors: ${validate.errors}`);
                 }
-                // console.log(obj1);
+                debug(`${obj1}`);
                 expect(isValid).equal(true);
             });
         });
@@ -89,9 +91,9 @@ describe("schemas", () => {
 
                 const isValid = validate(dataValueJSON);
                 if (!isValid) {
-                    console.log(isValid);
-                    console.log(validate.errors);
-                    console.log(dataValueJSON);
+                    debug(`Valid: ${isValid}`);
+                    debug(`Errors: ${validate.errors}`);
+                    debug(`dataValueJSON: ${dataValueJSON}`);
                 }
 
                 expect(isValid).eql(true);

--- a/packages/binding-websockets/src/ws-client-factory.ts
+++ b/packages/binding-websockets/src/ws-client-factory.ts
@@ -17,8 +17,10 @@
  * HTTP client Factory
  */
 
-import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createLoggers } from "@node-wot/core";
 import WebSocketClient from "./ws-client";
+
+const { debug } = createLoggers("binding-websockets", "ws-client-factory");
 
 export default class WebSocketClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "ws";
@@ -29,18 +31,18 @@ export default class WebSocketClientFactory implements ProtocolClientFactory {
     }
 
     public getClient(): ProtocolClient {
-        console.debug("[binding-websockets]", `HttpClientFactory creating client for '${this.scheme}'`);
+        debug(`HttpClientFactory creating client for '${this.scheme}'`);
         return new WebSocketClient();
     }
 
     public init(): boolean {
-        // console.info(`HttpClientFactory for '${HttpClientFactory.scheme}' initializing`);
+        // info(`HttpClientFactory for '${HttpClientFactory.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`HttpClientFactory for '${HttpClientFactory.scheme}' destroyed`);
+        // info(`HttpClientFactory for '${HttpClientFactory.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -17,9 +17,11 @@
  * WebSockets client
  */
 
-import { ProtocolClient, Content } from "@node-wot/core";
+import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Form, SecurityScheme } from "@node-wot/td-tools";
 import { Subscription } from "rxjs/Subscription";
+
+const { debug, warn } = createLoggers("binding-websockets", "ws-client");
 
 export default class WebSocketClient implements ProtocolClient {
     // eslint-disable-next-line no-useless-constructor
@@ -74,13 +76,13 @@ export default class WebSocketClient implements ProtocolClient {
 
     public setSecurity(metadata: Array<SecurityScheme>, credentials?: unknown): boolean {
         if (metadata === undefined || !Array.isArray(metadata) || metadata.length === 0) {
-            console.warn("[binding-websockets]", `WebSocketClient received empty security metadata`);
+            warn("WebSocketClient received empty security metadata");
             return false;
         }
         // TODO support for multiple security schemes (see http-client.ts)
         const security: SecurityScheme = metadata[0];
 
-        console.debug("[binding-websockets]", `WebSocketClient using security scheme '${security.scheme}'`);
+        debug(`WebSocketClient using security scheme '${security.scheme}'`);
         return true;
     }
 }

--- a/packages/binding-websockets/src/wss-client-factory.ts
+++ b/packages/binding-websockets/src/wss-client-factory.ts
@@ -32,13 +32,13 @@ export default class WssClientFactory implements ProtocolClientFactory {
     }
 
     public init(): boolean {
-        // console.info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' initializing`);
+        // info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' initializing`);
         // TODO uncomment info if something is executed here
         return true;
     }
 
     public destroy(): boolean {
-        // console.info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' destroyed`);
+        // info(`HttpsClientFactory for '${HttpsClientFactory.scheme}' destroyed`);
         // TODO uncomment info if something is executed here
         return true;
     }

--- a/packages/binding-websockets/test/ws-tests.ts
+++ b/packages/binding-websockets/test/ws-tests.ts
@@ -17,9 +17,12 @@
  * Protocol test suite to test protocol implementations
  */
 
+import { createLoggers } from "@node-wot/core";
 import { suite, test } from "@testdeck/mocha";
 import { expect, should } from "chai";
 import WebSocketServer from "../src/ws-server";
+
+const { info } = createLoggers("binding-websockets", "ws-tests");
 
 // should must be called to augment all variables
 should();
@@ -33,7 +36,7 @@ class WebSocketsTest {
         await wsServer.start(null);
         expect(wsServer.getPort()).to.eq(port); // from test
 
-        console.log("Test stopping WebSocket server");
+        info("Test stopping WebSocket server");
 
         await wsServer.stop();
         expect(wsServer.getPort()).to.eq(-1); // from getPort() when not listening

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -40,3 +40,6 @@ export { default as ExposedThing } from "./exposed-thing";
 // Helper Implementations
 export { default as Helpers } from "./helpers";
 export { default as ProtocolHelpers } from "./protocol-helpers";
+
+// Logger Functions
+export { createLoggers, createDebugLogger, createErrorLogger, createInfoLogger, createWarnLogger } from "./logger";

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -41,7 +41,7 @@ import { Resolver } from "@node-wot/td-tools/src/resolver-interface";
 import { DataSchema } from "wot-thing-description-types";
 import { createLoggers } from "./logger";
 
-const { debug, error } = createLoggers("core", "helpers");
+const { debug, error, warn } = createLoggers("core", "helpers");
 
 const tdSchema = TDSchema;
 // RegExps take from https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts
@@ -161,10 +161,7 @@ export default class Helpers implements Resolver {
                 .readResource(new TD.Form(uri, ContentSerdes.TD))
                 .then(async (content) => {
                     if (content.type !== ContentSerdes.TD && content.type !== ContentSerdes.JSON_LD) {
-                        console.warn(
-                            "[core/helpers]",
-                            `WoTImpl received TD with media type '${content.type}' from ${uri}`
-                        );
+                        warn(`WoTImpl received TD with media type '${content.type}' from ${uri}`);
                     }
 
                     const td = (await ProtocolHelpers.readStreamFully(content.body)).toString("utf-8");

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -68,7 +68,7 @@ export default class Helpers implements Resolver {
 
     public static extractScheme(uri: string): string {
         const parsed = new URL(uri);
-        // console.log(parsed)
+        debug(parsed);
         // remove trailing ':'
         if (parsed.protocol === null) {
             throw new Error(`Protocol in url "${uri}" must be valid`);

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -32,9 +32,11 @@ import { ProtocolClient, ProtocolClientFactory, Content } from "../src/protocol-
 import { ContentSerdes } from "../src/content-serdes";
 import Helpers from "../src/helpers";
 import { Readable } from "stream";
-import { ProtocolHelpers } from "../src/core";
+import { createLoggers, ProtocolHelpers } from "../src/core";
 import { ThingDescription } from "wot-typescript-definitions";
 import chaiAsPromised from "chai-as-promised";
+
+const { debug } = createLoggers("core", "ClientTest");
 
 chaiUse(chaiAsPromised);
 
@@ -323,12 +325,12 @@ class WoTClientTest {
         this.servient.start().then((myWoT) => {
             this.WoT = myWoT;
         });
-        console.log("started test suite");
+        debug("started test suite");
     }
 
     static async after(): Promise<void> {
         await this.servient.shutdown();
-        console.log("finished test suite");
+        debug("finished test suite");
     }
 
     @test async "read a Property"() {

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -30,6 +30,9 @@ import { Readable } from "stream";
 import { InteractionInput, InteractionOptions, InteractionOutput } from "wot-typescript-definitions";
 import chaiAsPromised from "chai-as-promised";
 import ProtocolHelpers from "../src/protocol-helpers";
+import { createLoggers } from "../src/core";
+
+const { debug } = createLoggers("core", "ServerTest");
 
 chaiUse(chaiAsPromised);
 // should must be called to augment all variables
@@ -82,12 +85,12 @@ class WoTServerTest {
         this.servient.start().then((WoTruntime) => {
             this.WoT = WoTruntime;
         });
-        console.log("started test suite");
+        debug("started test suite");
     }
 
     static async after(): Promise<void> {
         await this.servient.shutdown();
-        console.log("finished test suite");
+        debug("finished test suite");
     }
 
     @test async "should be able to add a Thing based on WoT.ThingFragment"() {
@@ -527,7 +530,7 @@ class WoTServerTest {
                     if (!this.counter) {
                         // init counter the first time
                         this.counter = 0;
-                        console.log("local counter state initialized with 0");
+                        debug("local counter state initialized with 0");
                     } else {
                         expect(typeof this.counter).equals("number");
                         expect(this.counter).greaterThan(0);

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -41,6 +41,7 @@
     },
     "dependencies": {
         "ajv": "^7.0.4",
+        "debug": "^4.3.4",
         "is-absolute-url": "3.0.3",
         "json-placeholder-replacer": "^1.0.35",
         "url-toolkit": "2.1.6",

--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -21,9 +21,15 @@ import isAbsoluteUrl = require("is-absolute-url");
 import URLToolkit = require("url-toolkit");
 import { ThingContext } from "wot-thing-description-types";
 
+// TODO: Refactor and reuse debug solution from core package
+import debug from "debug";
+const namespace = "node-wot:td-tools:td-parser";
+const logDebug = debug(`${namespace}:debug`);
+const logWarn = debug(`${namespace}:warn`);
+
 /** Parses a TD into a Thing object */
 export function parseTD(td: string, normalize?: boolean): Thing {
-    console.debug("[td-tools/td-parser]", `parseTD() parsing\n\`\`\`\n${td}\n\`\`\``);
+    logDebug(`parseTD() parsing\n\`\`\`\n${td}\n\`\`\``);
 
     // remove a potential Byte Order Mark (BOM)
     // see https://github.com/eclipse/thingweb.node-wot/issues/109
@@ -131,7 +137,7 @@ export function parseTD(td: string, normalize?: boolean): Thing {
     }
 
     if (thing.security === undefined) {
-        console.warn("[td-tools/td-parser]", `parseTD() found no security metadata`);
+        logWarn("parseTD() found no security metadata");
     }
     // wrap in array for later simplification
     if (typeof thing.security === "string") {
@@ -197,14 +203,11 @@ export function parseTD(td: string, normalize?: boolean): Thing {
 
     if (Object.prototype.hasOwnProperty.call(thing, "base")) {
         if (normalize === undefined || normalize === true) {
-            console.debug("[td-tools/td-parser]", `parseTD() normalizing 'base' into 'forms'`);
+            logDebug("parseTD() normalizing 'base' into 'forms'");
 
             for (const form of allForms) {
                 if (!form.href.match(/^([a-z0-9+-.]+:).+/i)) {
-                    console.debug(
-                        "[td-tools/td-parser]",
-                        `parseTDString() applying base '${thing.base}' to '${form.href}'`
-                    );
+                    logDebug(`parseTDString() applying base '${thing.base}' to '${form.href}'`);
                     form.href = URLToolkit.buildAbsoluteURL(thing.base, form.href);
                 }
             }

--- a/packages/td-tools/src/thing-model-helpers.ts
+++ b/packages/td-tools/src/thing-model-helpers.ts
@@ -24,6 +24,12 @@ import { ThingModel } from "wot-thing-model-types";
 import TMSchema from "wot-thing-model-types/schema/tm-json-schema-validation.json";
 import { Resolver } from "./resolver-interface";
 
+// TODO: Refactor and reuse debug solution from core package
+import debug from "debug";
+const namespace = "node-wot:td-tools:thing-model-helpers";
+const logDebug = debug(`${namespace}:debug`);
+const logError = debug(`${namespace}:error`);
+
 const tmSchema = TMSchema;
 // RegExps take from https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts
 const ajv = new Ajv({ strict: false })
@@ -236,10 +242,10 @@ export class ThingModelHelpers {
                         res.on("end", () => {
                             try {
                                 const parsedData = JSON.parse(rawData);
-                                console.debug("[td-tools]", "http fetched:", parsedData);
+                                logDebug(`https fetched: ${parsedData}`);
                                 resolve(parsedData);
-                            } catch (e) {
-                                console.error("[td-tools]", e instanceof Error ? e.message : e);
+                            } catch (error) {
+                                logError(error);
                             }
                         });
                     }).on("error", (e) => {
@@ -259,10 +265,10 @@ export class ThingModelHelpers {
                             res.on("end", () => {
                                 try {
                                     const parsedData = JSON.parse(rawData);
-                                    console.debug("[td-tools]", "https fetched:", parsedData);
+                                    logDebug(`https fetched: ${parsedData}`);
                                     resolve(parsedData);
-                                } catch (e) {
-                                    console.error("[td-tools]", (e as Error).message);
+                                } catch (error) {
+                                    logError(error);
                                 }
                             });
                         })

--- a/packages/td-tools/test/TDParseTest.ts
+++ b/packages/td-tools/test/TDParseTest.ts
@@ -28,6 +28,12 @@ import Thing, {
 } from "../src/thing-description";
 import * as TDParser from "../src/td-parser";
 import * as TDHelpers from "../src/td-helpers";
+
+// TODO: Refactor and reuse debug solution from core package
+import debug from "debug";
+const namespace = "node-wot:td-tools:TDParseTest";
+const logDebug = debug(`${namespace}:debug`);
+
 // should must be called to augment all variables
 should();
 
@@ -360,7 +366,7 @@ class TDParserTest {
         const testTD = `{ "title": "NoContext" }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(3);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -379,7 +385,7 @@ class TDParserTest {
     }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(3);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -399,7 +405,7 @@ class TDParserTest {
         const thing: Thing = TDParser.parseTD(testTD);
         TDHelpers.setContextLanguage(thing, "en", true);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(3);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -412,7 +418,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": "http://iot.schema.org/", "@type": "iot:Sensor" }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(4);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -429,7 +435,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": ["http://iot.schema.org/"], "@type": ["iot:Sensor"] }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(4);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -446,7 +452,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": ["http://iot.schema.org/", "https://www.w3.org/2019/wot/td/v1"], "@type": ["iot:Sensor"] }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(3);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -458,7 +464,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": ["http://iot.schema.org/", "https://www.w3.org/2022/wot/td/v1.1"], "@type": ["iot:Sensor"] }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(3);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V11);
@@ -470,7 +476,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": ["http://iot.schema.org/", "https://www.w3.org/2022/wot/td/v1.1", "https://www.w3.org/2019/wot/td/v1"], "@type": ["iot:Sensor"] }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(4);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -483,7 +489,7 @@ class TDParserTest {
         const testTD = `{ "title": "OtherContext", "@context": { "iot": "http://iot.schema.org/" } }`;
         const thing: Thing = TDParser.parseTD(testTD);
 
-        console.dir(thing);
+        logDebug(`${thing}`);
 
         expect(thing).to.have.property("@context").that.has.length(4);
         expect(thing["@context"][0]).to.equal(DEFAULT_CONTEXT_V1);
@@ -671,7 +677,7 @@ class TDParserTest {
         expect(thing).to.have.property("actions");
         expect(thing).to.have.property("events");
 
-        // console.debug(td["@context"]);
+        logDebug(`${thing["@context"]}`);
         expect(thing.properties).to.have.property("status");
         expect(thing.properties.status.readOnly).equals(true);
         expect(thing.properties.status.observable).equals(false);
@@ -690,7 +696,7 @@ class TDParserTest {
         expect(thing).to.have.property("actions");
         expect(thing).to.have.property("events");
 
-        // console.debug(td["@context"]);
+        logDebug(`${thing["@context"]}`);
         expect(thing.properties).to.have.property("status");
         expect(thing.properties.status.readOnly).equals(true);
         expect(thing.properties.status.observable).equals(false);


### PR DESCRIPTION
This PR applies the new logging approach to the binding packages. I was a bit unsure about the examples, which is why I left them out for now. Moreover, the logging in the `td-tools` package is a bit provisional for now, as I could not import the logging functions from the `core` package, as this would cause a circular dependency.

In the other packages, however, logging should be much improved and cleaner already. The fact that it needs to turned on explicitly also makes the CI logs much more readable.