### PR TITLE
refactor: add missing HTTP options (address, baseUri, and urlRewrite)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -63,6 +63,9 @@ wot-servient.conf.json syntax:
     },
     "http": {
         "port": HPORT,
+        "address": HADDRESS,
+        "baseUri": HBASEURI,
+        "urlRewrite": HURLREWRITE,
         "proxy": PROXY,
         "allowSelfSigned": ALLOW
     },
@@ -89,6 +92,9 @@ wot-servient.conf.json fields:
   STATIC          : string with hostname or IP literal for static address config
   RUNSCRIPT       : boolean to activate the 'runScript' Action (default=false)
   HPORT           : integer defining the HTTP listening port
+  HADDRESS        : string defining HTTP address
+  HBASEURI        : string defining HTTP base URI
+  HURLREWRITE     : map (from URL -> to URL) defining HTTP URL rewrites
   PROXY           : object with "href" field for the proxy URI,
                                 "scheme" field for either "basic" or "bearer", and
                                 corresponding credential fields as defined below

--- a/packages/cli/src/wot-servient-schema.conf.json
+++ b/packages/cli/src/wot-servient-schema.conf.json
@@ -35,6 +35,16 @@
                 "port": {
                     "type": "integer"
                 },
+                "address": {
+                    "type": "string"
+                },
+                "baseUri": {
+                    "type": "string"
+                },
+                "urlRewrite": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
                 "proxy": {
                     "type": "object",
                     "required": ["href"],


### PR DESCRIPTION
Note: left out serverKey, serverCert, and security

fixes https://github.com/eclipse/thingweb.node-wot/issues/815