### PR TITLE
feat(binding-coap): add support for Size2 estimate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2645,7 +2645,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "dev": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -4797,19 +4796,19 @@
             }
         },
         "node_modules/coap": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.11.tgz",
-            "integrity": "sha512-38BP98kiOzpv45aX1YmjR1OskPnHRQ3V/w43Ogp05sUGShhxVPBwmfjDRPHrpP8WnJbhwAdrj9WghaQ4ZxpHOQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.2.1.tgz",
+            "integrity": "sha512-2SHlQZUJ/fMgWezw+84idBXmvOFa9CRda/pFoWIj6vRQ5TjTWv833Xqj6b8XueCLA3lQnbA0f0n+ugvzgzmY0Q==",
             "dependencies": {
                 "@types/bl": "^5.0.2",
                 "@types/lru-cache": "^5.1.1",
                 "bl": "^5.0.0",
                 "capitalize": "^2.0.4",
-                "coap-packet": "^1.1.0",
-                "debug": "^4.3.3",
+                "coap-packet": "^1.1.1",
+                "debug": "^4.3.4",
                 "fastseries": "^2.0.0",
                 "lru-cache": "^6.0.0",
-                "readable-stream": "^3.6.0"
+                "readable-stream": "^4.2.0"
             },
             "engines": {
                 "node": ">=10"
@@ -4854,6 +4853,20 @@
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/coap/node_modules/readable-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+            "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/code-point-at": {
@@ -7087,7 +7100,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7096,7 +7108,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -14401,7 +14412,6 @@
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -18853,7 +18863,7 @@
                 "@node-wot/core": "0.8.3",
                 "@node-wot/td-tools": "0.8.3",
                 "@types/node": "16.4.13",
-                "coap": "^1.0.11",
+                "coap": "^1.2.1",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -20594,7 +20604,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
                 "chai": "^4.3.4",
-                "coap": "^1.0.11",
+                "coap": "^1.2.1",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-config-standard": "^16.0.3",
@@ -22219,7 +22229,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "dev": true,
             "requires": {
                 "event-target-shim": "^5.0.0"
             }
@@ -23985,19 +23994,19 @@
             "dev": true
         },
         "coap": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.11.tgz",
-            "integrity": "sha512-38BP98kiOzpv45aX1YmjR1OskPnHRQ3V/w43Ogp05sUGShhxVPBwmfjDRPHrpP8WnJbhwAdrj9WghaQ4ZxpHOQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/coap/-/coap-1.2.1.tgz",
+            "integrity": "sha512-2SHlQZUJ/fMgWezw+84idBXmvOFa9CRda/pFoWIj6vRQ5TjTWv833Xqj6b8XueCLA3lQnbA0f0n+ugvzgzmY0Q==",
             "requires": {
                 "@types/bl": "^5.0.2",
                 "@types/lru-cache": "^5.1.1",
                 "bl": "^5.0.0",
                 "capitalize": "^2.0.4",
-                "coap-packet": "^1.1.0",
-                "debug": "^4.3.3",
+                "coap-packet": "^1.1.1",
+                "debug": "^4.3.4",
                 "fastseries": "^2.0.0",
                 "lru-cache": "^6.0.0",
-                "readable-stream": "^3.6.0"
+                "readable-stream": "^4.2.0"
             },
             "dependencies": {
                 "bl": {
@@ -24017,6 +24026,17 @@
                     "requires": {
                         "base64-js": "^1.3.1",
                         "ieee754": "^1.2.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+                    "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+                    "requires": {
+                        "abort-controller": "^3.0.0",
+                        "buffer": "^6.0.3",
+                        "events": "^3.3.0",
+                        "process": "^0.11.10"
                     }
                 }
             }
@@ -25830,14 +25850,12 @@
         "event-target-shim": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "dev": true
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
         "events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
         "events-listener": {
             "version": "1.1.0",
@@ -31906,8 +31924,7 @@
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "dev": true
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
         },
         "process-nextick-args": {
             "version": "2.0.1",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -37,7 +37,7 @@
         "@node-wot/core": "0.8.3",
         "@node-wot/td-tools": "0.8.3",
         "@types/node": "16.4.13",
-        "coap": "^1.0.11",
+        "coap": "^1.2.1",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -319,4 +319,30 @@ class CoapServerTest {
             req.end();
         }
     }
+
+    @test async "should supply Size2 option when fetching a TD"() {
+        const portNumber = 9002;
+        const coapServer = new CoapServer(portNumber);
+
+        await coapServer.start(null);
+
+        const testThing = new ExposedThing(null, {
+            title: "Test",
+            description: "This is a test!".repeat(100),
+        });
+
+        await coapServer.expose(testThing);
+
+        const req = request({
+            host: "localhost",
+            pathname: "test",
+            port: coapServer.getPort(),
+        });
+        req.setOption("Size2", 0);
+        req.on("response", (res) => {
+            expect(res.headers.Size2).to.equal(JSON.stringify(testThing.getThingDescription()).length);
+            coapServer.stop();
+        });
+        req.end();
+    }
 }


### PR DESCRIPTION
In order to also support the assertion [`exploration-server-coap-size2`](https://w3c.github.io/wot-discovery#exploration-server-coap-size2), this PR adjusts the CoAP binding to be able to include the option in responses. However, there are a couple of bugs which prevent this PR from being complete at the moment, therefore I opened it only as a draft for now.