### PR TITLE
fix(binding-coap): use correct delimiter for CoRE resources

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -229,7 +229,7 @@ export default class CoapServer implements ProtocolServer {
 
                 return [formattedPath, ...parameterValues].join(";");
             })
-            .join("");
+            .join(",");
     }
 
     private handleWellKnownCore(req: IncomingMessage, res: OutgoingMessage) {

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -260,18 +260,22 @@ class CoapServerTest {
 
         await coapServer.start(null);
 
-        const testThing = new ExposedThing(null, {
-            title: "Test",
-        });
+        const testTitles = ["Test1", "Test2"];
 
-        await coapServer.expose(testThing);
+        for (const title of testTitles) {
+            const thing = new ExposedThing(null, {
+                title,
+            });
+
+            await coapServer.expose(thing);
+        }
 
         const uri = `coap://localhost:${coapServer.getPort()}/.well-known/core`;
 
         const coapClient = new CoapClient(coapServer);
         const resp = await coapClient.readResource(new TD.Form(uri));
         expect((await ProtocolHelpers.readStreamFully(resp.body)).toString()).to.equal(
-            '</test>;rt="wot.thing";ct="50 432"'
+            '</test1>;rt="wot.thing";ct="50 432",</test2>;rt="wot.thing";ct="50 432"'
         );
 
         return coapServer.stop();


### PR DESCRIPTION
Dealing with another CoRE Link-Format implementation, I noticed that I forget the `,` as a delimiter between resources in our current implementation (see, for example, [section 5 of RFC 6690](https://www.rfc-editor.org/rfc/rfc6690#section-5)). This PR provides a simple fix and adjusts the existing test accordingly.