### PR TITLE
Fix the build by locking versions during the container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ node_modules/
 coverage/
 .*/
 tmp/
-*-lock*.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-alpine3.11 as BUILD
+FROM docker.io/library/node:12.16.1-alpine3.11 as BUILD
 RUN apk add --no-cache \
 	gcc \
     g++ \
@@ -12,6 +12,7 @@ RUN npm install -g npm@7
 ARG BUILD_ENV=production
 WORKDIR /app
 COPY ./package.json ./
+COPY ./package-lock.json ./
 COPY ./tsconfig.json ./
 COPY ./packages packages/
 
@@ -21,7 +22,7 @@ RUN npm install && npm run build
 # this wil reduce the size of the image built in next steps significantly
 RUN if [ "${BUILD_ENV}" = "production" ]; then npm prune --production; fi
 
-FROM node:12.16.1-alpine3.11
+FROM docker.io/library/node:12.16.1-alpine3.11
 
 COPY --from=BUILD  /app /app
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "publish": "npm publish --workspaces",
         "check:versions": "node utils/check_package_version_consistency.js",
         "build:docker": "docker build -t wot-servient .",
+        "build:podman": "podman build -t wot-servient .",
         "clean:dist": "npm exec  --workspaces -- npx rimraf tsconfig.tsbuildinfo dist",
         "update:wot-typescript-definitions": "npx npm-check-updates  -u -f \"wot-typescript-definitions\" --deep",
         "link": "npm link -ws"


### PR DESCRIPTION
This adds the lock file to the build container, to use the expected versions and not let the build process select newer ones.

I believe this is ok, as the container build already selects a fixed build and runtime container tag. So the content of the container should be much more predictable.

This also adds full container names instead of shortnames.

Closes: #870