### PR TITLE
chore: have CI for tests across all Os's (manual) while default CI ru…

### DIFF
--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -1,13 +1,13 @@
-name: Default CI Pipeline
+name: Full CI Pipeline
 
-on: [push, pull_request]
+on: workflow_dispatch
 jobs:
     setup-and-test:
         runs-on: ${{ matrix.os }}
 
         strategy:
             matrix:
-                os: [ubuntu-latest]
+                os: [macos-latest, ubuntu-latest, windows-latest]
                 node-version: [14.x, 16.x, 18.x]
 
         steps:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "workspaces": [
         "./packages/td-tools",
         "./packages/core",
-        "./packages/binding-!(firestore-browser-bundle)",
+        "./packages/binding-!(firestore-browser-bundle|firestore)",
         "./packages/cli",
         "./packages/examples",
         "./packages/browser-bundle"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     "references": [
         { "path": "./packages/binding-coap" },
         { "path": "./packages/binding-file" },
-        { "path": "./packages/binding-firestore" },
+        /*{ "path": "./packages/binding-firestore" }, Disabled see https://github.com/eclipse/thingweb.node-wot/issues/827*/
         { "path": "./packages/binding-http" },
         { "path": "./packages/binding-mbus" },
         { "path": "./packages/binding-modbus" },


### PR DESCRIPTION
…ns on linux only

alternative for https://github.com/eclipse/thingweb.node-wot/pull/865