### PR TITLE
fix(binding-coap): fix content negotiation test

### DIFF
--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -25,7 +25,7 @@ import * as TD from "@node-wot/td-tools";
 import CoapServer from "../src/coap-server";
 import { CoapClient } from "../src/coap";
 import { Readable } from "stream";
-import { IncomingMessage, request } from "coap";
+import { IncomingMessage, registerFormat, request } from "coap";
 
 // should must be called to augment all variables
 should();
@@ -295,6 +295,8 @@ class CoapServerTest {
 
         const uri = `coap://localhost:${coapServer.getPort()}/test`;
         let responseCounter = 0;
+
+        registerFormat("application/foobar", 65000);
 
         const defaultContentFormat = "application/td+json";
         const unsupportedContentFormat = "application/foobar";


### PR DESCRIPTION
This PR fixes an issue with the current CoAP tests raised by @danielpeintner in https://github.com/eclipse/thingweb.node-wot/pull/878#issuecomment-1326023114. The content negotiation test currently fails due to the fact that `application/foobar` (which was added as an example for an unsupported content type) is not registered in node-coap and therefore throws an error.

In order to resolve this problem, this PR adds a call to the `registerFormat` function and registers `application/foobar` with the reserved numeric value 65000 within the test in question.