### PR TITLE
Fixed package.json dependency versions of exposed-thing example

### DIFF
--- a/examples/templates/exposed-thing/package.json
+++ b/examples/templates/exposed-thing/package.json
@@ -16,10 +16,10 @@
         "tslint": "5.12.1"
     },
     "dependencies": {
-        "@node-wot/binding-http": "0.8.3",
-        "@node-wot/core": "0.8.3",
+        "@node-wot/binding-http": "^0.8.2",
+        "@node-wot/core": "^0.8.2",
         "request": "2.88.0",
-        "ajv": "^7.0.4"
+        "ajv": "^6.12.6"
     },
     "optionalDependencies": {},
     "scripts": {

--- a/examples/templates/exposed-thing/package.json
+++ b/examples/templates/exposed-thing/package.json
@@ -16,8 +16,8 @@
         "tslint": "5.12.1"
     },
     "dependencies": {
-        "@node-wot/binding-http": "^0.8.2",
-        "@node-wot/core": "^0.8.2",
+        "@node-wot/binding-http": "0.8.x",
+        "@node-wot/core": "0.8.x",
         "request": "2.88.0",
         "ajv": "^6.12.6"
     },


### PR DESCRIPTION
Hi!

I am new to node-wot and wanted to quickly setup a demo with two things. I found the exposed-thing template in the examples folder.

While one can use the example when executing `npm install` and `npm build` from the root directory, copying the example folder and executing the same command within the exposed-thing folder fails for two reasons:

1. `"@node-wot/binding-http": "0.8.3"` and `"@node-wot/core": "0.8.3"` are not published on the npm registry yet. Without installing modules and building from the root of the project, npm fails to load these modules from the registry.
2. `"ajv": "^7.0.4"` breaks the code in `index.js` (importing and using ajv) since the way of importing the library changed from version `^6.12.4` (which is locked in the `package-lock.json` in the root).

I suggest chaging the dependency versions as commited in this PR because:

- It does not break installing and building from the root folder
- but also allows copying the exposed-thing demo folder as standalone project and installing + building the project from there.

For me, such a basic structure of a WoT project is very helpfull, because I clearly see the required dependencies, which are not so obvious while having a mono repo with many npm workspaces.

Happy to get some feedback on this! :) 
