### PR TITLE
Upgrade dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:12.16.1-alpine3.11 as BUILD
+FROM docker.io/library/node:18-alpine as BUILD
 RUN apk add --no-cache \
 	gcc \
     g++ \
@@ -6,7 +6,6 @@ RUN apk add --no-cache \
     linux-headers \
     udev \
     python3
-RUN npm install -g npm@7
 
 ## change it to maintain all the dev dependencies
 ARG BUILD_ENV=production
@@ -22,7 +21,7 @@ RUN npm install && npm run build
 # this wil reduce the size of the image built in next steps significantly
 RUN if [ "${BUILD_ENV}" = "production" ]; then npm prune --production; fi
 
-FROM docker.io/library/node:12.16.1-alpine3.11
+FROM docker.io/library/node:18-alpine
 
 COPY --from=BUILD  /app /app
 


### PR DESCRIPTION
As discussed in #869, Node 12 is in its EOL state. This PR upgrades the Dockerfile with the latest Node LTS version. As a consequence, I also removed `npm@7` install step because it is now bundled with Node. 


fix #869