### PR TITLE
chore: increase dev version to 0.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -580,9 +580,9 @@
             "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
         },
         "node_modules/@serialport/bindings/node_modules/node-abi": {
-            "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-            "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
+            "integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -2914,9 +2914,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001434",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-            "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+            "version": "1.0.30001435",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+            "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
             "dev": true,
             "funding": [
                 {
@@ -12542,11 +12542,11 @@
         },
         "packages/binding-coap": {
             "name": "@node-wot/binding-coap",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/node": "16.4.13",
                 "coap": "^1.2.2",
                 "node-coap-client": "1.0.8",
@@ -12577,13 +12577,13 @@
         },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3"
+                "@node-wot/core": "0.8.4"
             },
             "devDependencies": {
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
@@ -12602,11 +12602,11 @@
         },
         "packages/binding-http": {
             "name": "@node-wot/binding-http",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/eventsource": "^1.1.2",
                 "accept-language-parser": "1.5.0",
                 "basic-auth": "2.0.1",
@@ -12655,11 +12655,11 @@
         },
         "packages/binding-mbus": {
             "name": "@node-wot/binding-mbus",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "node-mbus": "^1.2.2",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
             },
@@ -12689,11 +12689,11 @@
         },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
@@ -12724,11 +12724,11 @@
         },
         "packages/binding-mqtt": {
             "name": "@node-wot/binding-mqtt",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "aedes": "^0.46.2",
                 "mqtt": "^4.2.8",
                 "rxjs": "5.5.11",
@@ -12758,11 +12758,11 @@
         },
         "packages/binding-netconf": {
             "name": "@node-wot/binding-netconf",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/node-netconf": "npm:@types/netconf@^2.0.0",
                 "@types/url-parse": "^1.4.3",
                 "case-1.5.3": "npm:case@^1.5.3",
@@ -12794,11 +12794,11 @@
         },
         "packages/binding-opcua": {
             "name": "@node-wot/binding-opcua",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "ajv": "^7.0.4",
                 "ajv-formats": "^2.1.1",
                 "node-opcua": "2.77.0",
@@ -12861,12 +12861,12 @@
         },
         "packages/binding-websockets": {
             "name": "@node-wot/binding-websockets",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "slugify": "^1.4.5",
                 "ws": "^7.5.4"
             },
@@ -12895,7 +12895,7 @@
         },
         "packages/browser-bundle": {
             "name": "@node-wot/browser-bundle",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "events": "^2.1.0",
@@ -12903,9 +12903,9 @@
                 "resolve": "^1.1.7"
             },
             "devDependencies": {
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/binding-websockets": "0.8.3",
-                "@node-wot/core": "0.8.3",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/binding-websockets": "0.8.4",
+                "@node-wot/core": "0.8.4",
                 "browserify": "^17.0.0",
                 "readable-stream4": "npm:readable-stream@^4.0.0",
                 "tinyify": "2.5.2",
@@ -12923,21 +12923,21 @@
         },
         "packages/cli": {
             "name": "@node-wot/cli",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.3",
-                "@node-wot/binding-file": "0.8.3",
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/binding-mqtt": "0.8.3",
-                "@node-wot/binding-websockets": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-coap": "0.8.4",
+                "@node-wot/binding-file": "0.8.4",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/binding-mqtt": "0.8.4",
+                "@node-wot/binding-websockets": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "ajv": "^8.11.0",
                 "commander": "^9.1.0",
                 "dotenv": "^8.6.0",
                 "lodash": "^4.17.21",
-                "vm2": "^3.9.9"
+                "vm2": "3.9.11"
             },
             "bin": {
                 "wot-servient": "bin/index.js"
@@ -12988,10 +12988,10 @@
         },
         "packages/core": {
             "name": "@node-wot/core",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/td-tools": "0.8.4",
                 "@petamoriken/float16": "^3.1.1",
                 "ajv": "^7.0.4",
                 "debug": "^4.3.4",
@@ -13052,14 +13052,14 @@
         },
         "packages/examples": {
             "name": "@node-wot/examples",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.3",
-                "@node-wot/binding-file": "0.8.3",
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-coap": "0.8.4",
+                "@node-wot/binding-file": "0.8.4",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "rxjs": "5.5.11"
             },
             "devDependencies": {
@@ -13085,7 +13085,7 @@
         },
         "packages/td-tools": {
             "name": "@node-wot/td-tools",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^7.0.4",
@@ -13439,8 +13439,8 @@
         "@node-wot/binding-coap": {
             "version": "file:packages/binding-coap",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/node": "16.4.13",
@@ -13469,8 +13469,8 @@
         "@node-wot/binding-file": {
             "version": "file:packages/binding-file",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",
@@ -13490,8 +13490,8 @@
         "@node-wot/binding-http": {
             "version": "file:packages/binding-http",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/accept-language-parser": "^1.5.2",
                 "@types/basic-auth": "1.1.3",
@@ -13539,8 +13539,8 @@
         "@node-wot/binding-mbus": {
             "version": "file:packages/binding-mbus",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/chai": "^4.2.18",
                 "@types/chai-as-promised": "^7.1.4",
                 "@types/mocha": "^9.0.0",
@@ -13569,8 +13569,8 @@
         "@node-wot/binding-modbus": {
             "version": "file:packages/binding-modbus",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/chai": "^4.2.18",
                 "@types/chai-as-promised": "^7.1.4",
                 "@types/mocha": "^9.0.0",
@@ -13600,8 +13600,8 @@
         "@node-wot/binding-mqtt": {
             "version": "file:packages/binding-mqtt",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/node": "16.4.13",
@@ -13630,8 +13630,8 @@
         "@node-wot/binding-netconf": {
             "version": "file:packages/binding-netconf",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/chai": "^4.2.18",
                 "@types/mocha": "^9.0.0",
                 "@types/node": "16.4.13",
@@ -13662,8 +13662,8 @@
         "@node-wot/binding-opcua": {
             "version": "file:packages/binding-opcua",
             "requires": {
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/chai": "^4.2.18",
                 "@types/mocha": "^9.0.0",
                 "@types/node": "16.4.13",
@@ -13723,9 +13723,9 @@
         "@node-wot/binding-websockets": {
             "version": "file:packages/binding-websockets",
             "requires": {
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
                 "@types/node": "16.4.13",
@@ -13753,9 +13753,9 @@
         "@node-wot/browser-bundle": {
             "version": "file:packages/browser-bundle",
             "requires": {
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/binding-websockets": "0.8.3",
-                "@node-wot/core": "0.8.3",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/binding-websockets": "0.8.4",
+                "@node-wot/core": "0.8.4",
                 "browserify": "^17.0.0",
                 "events": "^2.1.0",
                 "inherits": "^2.0.3",
@@ -13776,13 +13776,13 @@
         "@node-wot/cli": {
             "version": "file:packages/cli",
             "requires": {
-                "@node-wot/binding-coap": "0.8.3",
-                "@node-wot/binding-file": "0.8.3",
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/binding-mqtt": "0.8.3",
-                "@node-wot/binding-websockets": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-coap": "0.8.4",
+                "@node-wot/binding-file": "0.8.4",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/binding-mqtt": "0.8.4",
+                "@node-wot/binding-websockets": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
@@ -13803,7 +13803,7 @@
                 "ts-node": "10.1.0",
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
-                "vm2": "^3.9.9",
+                "vm2": "3.9.11",
                 "wot-thing-description-types": "^1.1.0-13-October-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
             },
@@ -13829,7 +13829,7 @@
         "@node-wot/core": {
             "version": "file:packages/core",
             "requires": {
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/td-tools": "0.8.4",
                 "@petamoriken/float16": "^3.1.1",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
@@ -13887,11 +13887,11 @@
         "@node-wot/examples": {
             "version": "file:packages/examples",
             "requires": {
-                "@node-wot/binding-coap": "0.8.3",
-                "@node-wot/binding-file": "0.8.3",
-                "@node-wot/binding-http": "0.8.3",
-                "@node-wot/core": "0.8.3",
-                "@node-wot/td-tools": "0.8.3",
+                "@node-wot/binding-coap": "0.8.4",
+                "@node-wot/binding-file": "0.8.4",
+                "@node-wot/binding-http": "0.8.4",
+                "@node-wot/core": "0.8.4",
+                "@node-wot/td-tools": "0.8.4",
                 "@types/express-oauth-server": "^2.0.2",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
@@ -14052,9 +14052,9 @@
                     "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
                 },
                 "node-abi": {
-                    "version": "3.28.0",
-                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-                    "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+                    "version": "3.30.0",
+                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
+                    "integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
                     "requires": {
                         "semver": "^7.3.5"
                     }
@@ -15986,9 +15986,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001434",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-            "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+            "version": "1.0.30001435",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+            "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
             "dev": true
         },
         "capitalize": {

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-coap",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "CoAP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -34,8 +34,8 @@
         "typescript-standard": "^0.3.36"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "@types/node": "16.4.13",
         "coap": "^1.2.2",
         "node-coap-client": "1.0.8",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-file",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "File client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/file.js",
     "types": "dist/file.d.ts",
     "devDependencies": {
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/td-tools": "0.8.4",
         "@types/node": "16.4.13",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
@@ -31,7 +31,7 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3"
+        "@node-wot/core": "0.8.4"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-firestore-browser-bundle/package.json
+++ b/packages/binding-firestore-browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-firestore-browser-bundle",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "A binding-firestore bundle that can run in a web browser",
     "repository": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-firestore-browser-bundle",
     "publishConfig": {
@@ -17,7 +17,7 @@
         "tinyify": "2.5.2"
     },
     "dependencies": {
-        "@node-wot/binding-firestore": "0.8.3"
+        "@node-wot/binding-firestore": "0.8.4"
     },
     "scripts": {
         "build": "browserify -r vm:vm2 index.js --external coffee-script -o dist/binding-firestore-bundle.js"

--- a/packages/binding-firestore/package.json
+++ b/packages/binding-firestore/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-firestore",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "Firestore binding for node-wot",
     "repository": "https://github.com/eclipse/thingweb.node-wot/tree/master/packages/binding-firestore",
     "publishConfig": {
@@ -21,8 +21,8 @@
     "author": "hidetak",
     "license": "EPL-2.0",
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "buffer": "^5.5.0",
         "firebase": "9.7.0",
         "uuid": "^7.0.3"

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-http",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "HTTP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -52,8 +52,8 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "@types/eventsource": "^1.1.2",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mbus",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "M-Bus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -37,8 +37,8 @@
         "typescript-standard": "^0.3.36"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "node-mbus": "^1.2.2",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-modbus",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "Modbus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "contributors": [
@@ -40,8 +40,8 @@
         "typescript-standard": "^0.3.36"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "modbus-serial": "8.0.3",
         "rxjs": "5.5.11",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mqtt",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "MQTT binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -35,8 +35,8 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "aedes": "^0.46.2",
         "mqtt": "^4.2.8",
         "rxjs": "5.5.11",

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-netconf",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "NetConf client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -36,8 +36,8 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/td-tools": "0.8.3",
-        "@node-wot/core": "0.8.3",
+        "@node-wot/td-tools": "0.8.4",
+        "@node-wot/core": "0.8.4",
         "@types/node-netconf": "npm:@types/netconf@^2.0.0",
         "@types/url-parse": "^1.4.3",
         "case-1.5.3": "npm:case@^1.5.3",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-opcua",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "opcua client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -40,8 +40,8 @@
     "dependencies": {
         "ajv": "^7.0.4",
         "ajv-formats": "^2.1.1",
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "node-opcua": "2.77.0",
         "node-opcua-json": "0.19.1",
         "node-opcua-pubsub-client": "0.19.1",

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-websockets",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "WebSockets client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -37,9 +37,9 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/binding-http": "0.8.3",
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/binding-http": "0.8.4",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "slugify": "^1.4.5",
         "ws": "^7.5.4"
     },

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/browser-bundle",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "A node-wot bundle that can run in a web browser",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -13,9 +13,9 @@
     ],
     "main": "dist/wot-bundle.min.js",
     "devDependencies": {
-        "@node-wot/binding-http": "0.8.3",
-        "@node-wot/binding-websockets": "0.8.3",
-        "@node-wot/core": "0.8.3",
+        "@node-wot/binding-http": "0.8.4",
+        "@node-wot/binding-websockets": "0.8.4",
+        "@node-wot/core": "0.8.4",
         "browserify": "^17.0.0",
         "readable-stream4": "npm:readable-stream@^4.0.0",
         "tinyify": "2.5.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/cli",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "servient command line interface",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -40,18 +40,18 @@
         "ts-node": "10.1.0"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.3",
-        "@node-wot/binding-file": "0.8.3",
-        "@node-wot/binding-http": "0.8.3",
-        "@node-wot/binding-mqtt": "0.8.3",
-        "@node-wot/binding-websockets": "0.8.3",
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/binding-coap": "0.8.4",
+        "@node-wot/binding-file": "0.8.4",
+        "@node-wot/binding-http": "0.8.4",
+        "@node-wot/binding-mqtt": "0.8.4",
+        "@node-wot/binding-websockets": "0.8.4",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "ajv": "^8.11.0",
         "commander": "^9.1.0",
         "dotenv": "^8.6.0",
         "lodash": "^4.17.21",
-        "vm2": "^3.9.9"
+        "vm2": "3.9.11"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/core",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "W3C Web of Things (WoT) Servient framework",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -44,7 +44,7 @@
         "wot-typescript-definitions": "^0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/td-tools": "0.8.4",
         "@petamoriken/float16": "^3.1.1",
         "ajv": "^7.0.4",
         "debug": "^4.3.4",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/examples",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "private": true,
     "description": "Examples for node-wot (not published)",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
@@ -27,11 +27,11 @@
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.3",
-        "@node-wot/binding-file": "0.8.3",
-        "@node-wot/binding-http": "0.8.3",
-        "@node-wot/core": "0.8.3",
-        "@node-wot/td-tools": "0.8.3",
+        "@node-wot/binding-coap": "0.8.4",
+        "@node-wot/binding-file": "0.8.4",
+        "@node-wot/binding-http": "0.8.4",
+        "@node-wot/core": "0.8.4",
+        "@node-wot/td-tools": "0.8.4",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/td-tools",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "W3C Web of Things (WoT) Thing Description parser, serializer, and other tools",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",


### PR DESCRIPTION
Note: besides the actual version increase I also limited vm2 dependency to "3.9.11" for CLI since latest version "3.9.12" causes build issues

```
node_modules/vm2/index.d.ts:38:40 - error TS1176: Interface declaration cannot have 'implements' clause.

38 export interface VMFileSystemInterface implements VMFS, VMPath {
                                          ~~~~~~~~~~

node_modules/vm2/index.d.ts:46:14 - error TS2420: Class 'VMFileSystem' incorrectly implements interface 'VMFileSystemInterface'.
  Property 'isSeparator' is missing in type 'VMFileSystem' but required in type 'VMFileSystemInterface'.

46 export class VMFileSystem implements VMFileSystemInterface {
                ~~~~~~~~~~~~

  node_modules/vm2/index.d.ts:40:2
    40  isSeparator(char: string): boolean;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    'isSeparator' is declared here.
```