### PR TITLE
fix(binding-http): node-fetch content-length and streams fix

### DIFF
--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -175,7 +175,8 @@ export default class HttpClient implements ProtocolClient {
     }
 
     public async invokeResource(form: HttpForm, content?: Content): Promise<Content> {
-        const headers = content ? [["content-type", content.type]] : [];
+        const headers = content ? [["content-type", content.type],
+                                   ["content-length", content.length.toString()]] : [];
 
         const request = await this.generateFetchRequest(form, "POST", {
             headers: headers,

--- a/packages/core/src/content-serdes.ts
+++ b/packages/core/src/content-serdes.ts
@@ -182,7 +182,7 @@ export class ContentSerdes {
         }
         // http server does not like Readable.from(bytes)
         // it works only with Arrays or strings
-        return new Content(contentType, Readable.from([bytes]));
+        return new Content(contentType, Readable.from([bytes]), bytes.length);
     }
 }
 

--- a/packages/core/src/content.ts
+++ b/packages/core/src/content.ts
@@ -19,10 +19,12 @@ import ProtocolHelpers from "./protocol-helpers";
 export class Content {
     type: string;
     body: NodeJS.ReadableStream;
+    length: number;
 
-    constructor(type: string, body: NodeJS.ReadableStream) {
+    constructor(type: string, body: NodeJS.ReadableStream, length: number = -1) {
         this.type = type;
         this.body = body;
+        this.length = length;
     }
 
     toBuffer(): Promise<Buffer> {


### PR DESCRIPTION
In node-fetch, if body is of request is a Stream, [Content-Length is not set automatically](https://github.com/node-fetch/node-fetch/blob/55a4870ae5f805d8ff9a890ea2c652c9977e048e/README.md?plain=1#L549) and results in weird output.

Submitted related issue #886 

Signed-off-by: moiz <mrasheed@purdue.edu>