### PR TITLE
feat: respect tm:optional

### DIFF
--- a/packages/td-tools/test/thing-model/tmodels/TmOptional.tm.jsonld
+++ b/packages/td-tools/test/thing-model/tmodels/TmOptional.tm.jsonld
@@ -1,0 +1,29 @@
+{
+    "@context": ["https://www.w3.org/2022/wot/td/v1.1"],
+    "@type": "tm:ThingModel",
+    "title": "Lamp Thing Model",
+    "id": "urn:example:{{RANDOM_ID_PATTERN}}",
+    "description": "Lamp Thing Model Description",
+    "version" : {"model" : "1.0.0" },
+    "tm:optional": [
+        "/events/overheating"
+    ],
+    "properties": {
+        "status": {
+            "description": "current status of the lamp (on|off)",
+            "type": "string",
+            "readOnly": true
+        }
+    },
+    "actions": {
+        "toggle": {
+            "description": "Turn the lamp on or off"
+        }
+    },
+    "events": {
+        "overheating": {
+            "description": "Lamp reaches a critical temperature (overheating)",
+            "data": {"type": "string"}
+        }
+    }
+}


### PR DESCRIPTION
This PR modifies `getPartialTDs` method, so that it respects `tm:optional` and returns an array where the first element has all affordances, and the rest are constructed by removing one by one the optional ones.

Signed-off-by: fatadel <fatadel@gmail.com>