### PR TITLE
Move endianness from binding-modbus to core

### DIFF
--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -15,9 +15,9 @@
 /**
  * Modbus master based on modbus-serial
  */
-import { ModbusForm, ModbusFunction, ModbusEndianness } from "./modbus";
+import { ModbusForm, ModbusFunction } from "./modbus";
 
-import { ProtocolClient, Content, DefaultContent, createDebugLogger } from "@node-wot/core";
+import { ProtocolClient, Content, DefaultContent, createDebugLogger, Endianness } from "@node-wot/core";
 import { SecurityScheme } from "@node-wot/td-tools";
 import { modbusFunctionToEntity } from "./utils";
 import { ModbusConnection, PropertyOperation } from "./modbus-connection";
@@ -184,14 +184,14 @@ export default class ModbusClient implements ProtocolClient {
         return operation.execute();
     }
 
-    private validateEndianness(form: ModbusForm): ModbusEndianness {
-        let endianness = ModbusEndianness.BIG_ENDIAN;
+    private validateEndianness(form: ModbusForm): Endianness {
+        let endianness = Endianness.BIG_ENDIAN;
         if (form.contentType) {
             const contentValues: string[] = form.contentType.split(";") ?? [];
             // Check endian-ness
             const byteSeq = contentValues.find((value) => /^byteSeq=/.test(value));
             if (byteSeq) {
-                const guessEndianness = ModbusEndianness[byteSeq.split("=")[1] as keyof typeof ModbusEndianness];
+                const guessEndianness = Endianness[byteSeq.split("=")[1] as keyof typeof Endianness];
                 if (guessEndianness) {
                     endianness = guessEndianness;
                 } else {

--- a/packages/binding-modbus/src/modbus.ts
+++ b/packages/binding-modbus/src/modbus.ts
@@ -84,10 +84,3 @@ export class ModbusForm extends Form {
      */
     public "modbus:pollingTime"?: number;
 }
-
-export enum ModbusEndianness {
-    BIG_ENDIAN = "BIG_ENDIAN",
-    LITTLE_ENDIAN = "LITTLE_ENDIAN",
-    BIG_ENDIAN_BYTE_SWAP = "BIG_ENDIAN_BYTE_SWAP",
-    LITTLE_ENDIAN_BYTE_SWAP = "LITTLE_ENDIAN_BYTE_SWAP",
-}

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -239,6 +239,7 @@ describe("Modbus client test", () => {
 
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
+                contentType: "application/octet-stream",
                 "modbus:function": 3,
                 "modbus:address": 0,
                 "modbus:quantity": 1,
@@ -248,6 +249,7 @@ describe("Modbus client test", () => {
             const result = await client.readResource(form);
             const body = await result.toBuffer();
             body.should.deep.equal(Buffer.from([0, 3]), "Wrong data");
+            result.type.should.be.equal("application/octet-stream", "Wrong content type");
         });
 
         it("should read a resource using read multiple holding registers function", async () => {
@@ -255,6 +257,7 @@ describe("Modbus client test", () => {
 
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
+                contentType: "application/octet-stream; length=6",
                 "modbus:function": 3,
                 "modbus:address": 0,
                 "modbus:quantity": 3,
@@ -264,6 +267,7 @@ describe("Modbus client test", () => {
             const result = await client.readResource(form);
             const body = await result.toBuffer();
             body.should.deep.equal(Buffer.from([0, 3, 0, 2, 0, 1]), "Wrong data");
+            result.type.should.be.equal("application/octet-stream; length=6", "Wrong content type");
         });
 
         it("should read a resource using read input registers function", async () => {

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -298,40 +298,6 @@ describe("Modbus client test", () => {
             body.should.deep.equal(Buffer.from([0, 3, 0, 2, 0, 1]), "Wrong data");
         });
 
-        it("should read a resource using read multiple input registers function with little endian conversion", async () => {
-            testServer.setRegisters([3, 2, 1, 0]);
-
-            const form: ModbusForm = {
-                href: "modbus://127.0.0.1:8502",
-                contentType: "application/octet-stream;byteSeq=LITTLE_ENDIAN",
-                "modbus:function": 4,
-                "modbus:address": 0,
-                "modbus:quantity": 4,
-                "modbus:unitID": 1,
-            };
-
-            const result = await client.readResource(form);
-            const body = await result.toBuffer();
-            body.should.deep.equal(Buffer.from([0, 0, 1, 0, 2, 0, 3, 0]), "Wrong data");
-        });
-
-        it("should read a resource using read multiple input registers function with little endian byte swap conversion", async () => {
-            testServer.setRegisters([3, 2, 1, 0]);
-
-            const form: ModbusForm = {
-                href: "modbus://127.0.0.1:8502",
-                contentType: "application/octet-stream;byteSeq=LITTLE_ENDIAN_BYTE_SWAP",
-                "modbus:function": 4,
-                "modbus:address": 0,
-                "modbus:quantity": 4,
-                "modbus:unitID": 1,
-            };
-
-            const result = await client.readResource(form);
-            const body = await result.toBuffer();
-            body.should.deep.equal(Buffer.from([0, 0, 0, 1, 0, 2, 0, 3]), "Wrong data");
-        });
-
         it("should throw exception for unknown function", () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
@@ -423,40 +389,14 @@ describe("Modbus client test", () => {
         it("should write a resource with little endian ordering", async () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
-                contentType: "application/octet-stream;length=2;byteSeq=LITTLE_ENDIAN",
-                "modbus:function": 16,
+                contentType: "application/octet-stream;byteSeq=LITTLE_ENDIAN",
+                "modbus:function": 6,
                 "modbus:address": 0,
                 "modbus:unitID": 1,
             };
 
-            await client.writeResource(form, new Content("", Readable.from([0x60, 0x59, 0x49, 0x25])));
-            testServer.registers.should.be.deep.equal([9545, 22880], "wrong coil value");
-        });
-
-        it("should write a resource with byte swap big endian ordering", async () => {
-            const form: ModbusForm = {
-                href: "modbus://127.0.0.1:8502",
-                contentType: "application/octet-stream;length=2;byteSeq=BIG_ENDIAN_BYTE_SWAP",
-                "modbus:function": 16,
-                "modbus:address": 0,
-                "modbus:unitID": 1,
-            };
-
-            await client.writeResource(form, new Content("", Readable.from([0x49, 0x25, 0x60, 0x59])));
-            testServer.registers.should.be.deep.equal([9545, 22880], "wrong coil value");
-        });
-
-        it("should write a resource with byte swap little endian ordering", async () => {
-            const form: ModbusForm = {
-                href: "modbus://127.0.0.1:8502",
-                contentType: "application/octet-stream;length=2;byteSeq=LITTLE_ENDIAN_BYTE_SWAP",
-                "modbus:function": 16,
-                "modbus:address": 0,
-                "modbus:unitID": 1,
-            };
-
-            await client.writeResource(form, new Content("", Readable.from([0x59, 0x60, 0x25, 0x49])));
-            testServer.registers.should.be.deep.equal([9545, 22880], "wrong coil value");
+            await client.writeResource(form, new Content("", Readable.from([0x01, 0x01]))); // 257 little-endian
+            testServer.registers.should.be.deep.equal([257], "wrong coil value");
         });
     });
 

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -12,13 +12,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { ModbusEndianness } from "./../src/modbus";
 import { should } from "chai";
 import * as chai from "chai";
 import { ModbusForm } from "../src/modbus";
 import ModbusServer from "./test-modbus-server";
 import chaiAsPromised from "chai-as-promised";
 import { ModbusConnection, PropertyOperation } from "../src/modbus-connection";
+import { Endianness } from "@node-wot/core";
 
 // should must be called to augment all variables
 should();
@@ -75,7 +75,7 @@ describe("Modbus connection", () => {
                 connectionRetryTime: 10,
                 maxRetries: 1,
             });
-            const op = new PropertyOperation(form, ModbusEndianness.BIG_ENDIAN);
+            const op = new PropertyOperation(form, Endianness.BIG_ENDIAN);
             connection.enqueue(op);
 
             await op.execute().should.eventually.be.rejected;
@@ -95,7 +95,7 @@ describe("Modbus connection", () => {
                 connectionRetryTime: 10,
                 maxRetries: 1,
             });
-            const op = new PropertyOperation(form, ModbusEndianness.BIG_ENDIAN);
+            const op = new PropertyOperation(form, Endianness.BIG_ENDIAN);
             connection.enqueue(op);
 
             await op.execute().should.eventually.be.rejected;

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -92,86 +92,92 @@ export default class OctetstreamCodec implements ContentCodec {
             case "boolean":
                 // true if any byte is non-zero
                 return !bytes.every((val) => val === 0);
-
             case "byte":
             case "short":
             case "int":
             case "integer":
-                switch (dataLength) {
-                    case 1:
-                        return signed ? bytes.readInt8(0) : bytes.readUInt8(0);
-
-                    case 2:
-                        return bigendian
-                            ? signed
-                                ? bytes.readInt16BE(0)
-                                : bytes.readUInt16BE(0)
-                            : signed
-                            ? bytes.readInt16LE(0)
-                            : bytes.readUInt16LE(0);
-
-                    case 4:
-                        return bigendian
-                            ? signed
-                                ? bytes.readInt32BE(0)
-                                : bytes.readUInt32BE(0)
-                            : signed
-                            ? bytes.readInt32LE(0)
-                            : bytes.readUInt32LE(0);
-
-                    default: {
-                        let result = 0;
-                        let negative;
-
-                        if (bigendian) {
-                            result = bytes.reduce((prev, curr) => prev << (8 + curr));
-                            negative = bytes.readInt8(0) < 0;
-                        } else {
-                            result = bytes.reduceRight((prev, curr) => prev << (8 + curr));
-                            negative = bytes.readInt8(dataLength - 1) < 0;
-                        }
-
-                        if (signed && negative) {
-                            result -= 1 << (8 * dataLength);
-                        }
-
-                        // warn about numbers being too big to be represented as safe integers
-                        if (!Number.isSafeInteger(result)) {
-                            warn("Result is not a safe integer");
-                        }
-
-                        return result;
-                    }
-                }
-
+                return this.integerToValue(bytes, { dataLength, bigendian, signed });
             case "float":
             case "double":
             case "number":
-                debug("qui", bigendian);
-                switch (dataLength) {
-                    case 2:
-                        return getFloat16(new DataView(bytes.buffer), bytes.byteOffset, !bigendian);
-                    case 4:
-                        return bigendian ? bytes.readFloatBE(0) : bytes.readFloatLE(0);
-
-                    case 8:
-                        return bigendian ? bytes.readDoubleBE(0) : bytes.readDoubleLE(0);
-
-                    default:
-                        throw new Error("Wrong buffer length for type 'number', must be 2, 4, 8, or is " + dataLength);
-                }
-
+                return this.numberToValue(bytes, { dataLength, bigendian });
             case "string":
                 return bytes.toString(parameters.charset as BufferEncoding);
-
             case "array":
             case "object":
                 throw new Error("Unable to handle dataType " + dataType);
-
             case "null":
                 return null;
             default:
                 throw new Error("Unable to handle dataType " + dataType);
+        }
+    }
+
+    private integerToValue(
+        bytes: Buffer,
+        options: { dataLength: number; bigendian: boolean; signed: boolean }
+    ): number {
+        const { dataLength, bigendian, signed } = options;
+        switch (dataLength) {
+            case 1:
+                return signed ? bytes.readInt8(0) : bytes.readUInt8(0);
+            case 2:
+                return bigendian
+                    ? signed
+                        ? bytes.readInt16BE(0)
+                        : bytes.readUInt16BE(0)
+                    : signed
+                    ? bytes.readInt16LE(0)
+                    : bytes.readUInt16LE(0);
+
+            case 4:
+                return bigendian
+                    ? signed
+                        ? bytes.readInt32BE(0)
+                        : bytes.readUInt32BE(0)
+                    : signed
+                    ? bytes.readInt32LE(0)
+                    : bytes.readUInt32LE(0);
+
+            default: {
+                let result = 0;
+                let negative;
+
+                if (bigendian) {
+                    result = bytes.reduce((prev, curr) => prev << (8 + curr));
+                    negative = bytes.readInt8(0) < 0;
+                } else {
+                    result = bytes.reduceRight((prev, curr) => prev << (8 + curr));
+                    negative = bytes.readInt8(dataLength - 1) < 0;
+                }
+
+                if (signed && negative) {
+                    result -= 1 << (8 * dataLength);
+                }
+
+                // warn about numbers being too big to be represented as safe integers
+                if (!Number.isSafeInteger(result)) {
+                    warn("Result is not a safe integer");
+                }
+
+                return result;
+            }
+        }
+    }
+
+    private numberToValue(bytes: Buffer, options: { dataLength: number; bigendian: boolean }): number {
+        const { dataLength, bigendian } = options;
+        switch (dataLength) {
+            case 2:
+                return getFloat16(new DataView(bytes.buffer), bytes.byteOffset, !bigendian);
+            case 4:
+                return bigendian ? bytes.readFloatBE(0) : bytes.readFloatLE(0);
+
+            case 8:
+                return bigendian ? bytes.readDoubleBE(0) : bytes.readDoubleLE(0);
+
+            default:
+                throw new Error("Wrong buffer length for type 'number', must be 2, 4, 8, or is " + dataLength);
         }
     }
 
@@ -185,7 +191,6 @@ export default class OctetstreamCodec implements ContentCodec {
         const bigendian = !parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN); // default to bigendian
         let signed = parameters.signed !== "false"; // if signed is undefined -> true (default)
         let length = parameters.length ? parseInt(parameters.length) : undefined;
-        let buf: Buffer;
 
         if (value === undefined) {
             throw new Error("Undefined value");
@@ -211,122 +216,137 @@ export default class OctetstreamCodec implements ContentCodec {
             case "byte":
             case "short":
             case "int":
-            case "integer": {
-                length = length ?? 4;
-                if (typeof value !== "number") {
-                    throw new Error("Value is not a number");
-                }
-
-                // warn about numbers being too big to be represented as safe integers
-                if (!Number.isSafeInteger(value)) {
-                    warn("Value is not a safe integer");
-                }
-                const limit = Math.pow(2, 8 * length) - 1;
-                // throw error on overflow
-                if (signed) {
-                    if (value < -limit || value >= limit) {
-                        throw new Error(
-                            "Integer overflow when representing signed " + value + " in " + length + " byte(s)"
-                        );
-                    }
-                } else {
-                    if (value < 0 || value >= limit) {
-                        throw new Error(
-                            "Integer overflow when representing unsigned " + value + " in " + length + " byte(s)"
-                        );
-                    }
-                }
-
-                buf = Buffer.alloc(length);
-                // Handle byte swapping
-                if (parameters.byteSeq?.includes("BYTE_SwAP") && length > 1) {
-                    buf.swap16();
-                }
-                switch (length) {
-                    case 1:
-                        signed ? buf.writeInt8(value, 0) : buf.writeUInt8(value, 0);
-                        break;
-
-                    case 2:
-                        bigendian
-                            ? signed
-                                ? buf.writeInt16BE(value, 0)
-                                : buf.writeUInt16BE(value, 0)
-                            : signed
-                            ? buf.writeInt16LE(value, 0)
-                            : buf.writeUInt16LE(value, 0);
-                        break;
-
-                    case 4:
-                        bigendian
-                            ? signed
-                                ? buf.writeInt32BE(value, 0)
-                                : buf.writeUInt32BE(value, 0)
-                            : signed
-                            ? buf.writeInt32LE(value, 0)
-                            : buf.writeUInt32LE(value, 0);
-                        break;
-
-                    default:
-                        if (signed && value < 0) {
-                            // convert to unsigned byte sequence
-                            value += 1 << (8 * length);
-                        }
-
-                        // use arithmetic instead of shift to cover more than 32 bits
-                        for (let i = 0; i < length; ++i) {
-                            const byte = value % 0x100;
-                            value /= 0x100;
-                            buf.writeInt8(byte, bigendian ? length - i - 1 : i);
-                        }
-                }
-
-                return buf;
-            }
+            case "integer":
+                return this.valueToInteger(value, {
+                    dataLength: length,
+                    bigendian,
+                    signed,
+                    byteSeq: parameters.byteSeq ?? "",
+                });
             case "float":
             case "number":
-                if (typeof value !== "number") {
-                    throw new Error("Value is not a number");
-                }
-
-                length = length ?? 8;
-                buf = Buffer.alloc(length);
-                // Handle byte swapping
-                if (parameters.byteSeq?.includes("BYTE_SwAP") && length > 1) {
-                    buf.swap16();
-                }
-                switch (length) {
-                    case 2:
-                        setFloat16(new DataView(buf.buffer), 0, value, !bigendian);
-                        break;
-                    case 4:
-                        bigendian ? buf.writeFloatBE(value, 0) : buf.writeFloatLE(value, 0);
-                        break;
-
-                    case 8:
-                        bigendian ? buf.writeDoubleBE(value, 0) : buf.writeDoubleLE(value, 0);
-                        break;
-
-                    default:
-                        throw new Error("Wrong buffer length for type 'number', must be 4 or 8, is " + length);
-                }
-
-                return buf;
-
+                return this.valueToNumber(value, { dataLength: length, bigendian, byteSeq: parameters.byteSeq ?? "" });
             case "string": {
                 const str = String(value);
                 return Buffer.from(str /*, params.charset */);
             }
-
             case "array":
             case "object":
             case "undefined":
                 throw new Error("Unable to handle dataType " + dataType);
-
             case "null":
                 return Buffer.alloc(0);
             default:
                 throw new Error("Unable to handle dataType " + dataType);
         }
+    }
+
+    private valueToInteger(
+        value: unknown,
+        options: { dataLength: number | undefined; bigendian: boolean; signed: boolean; byteSeq: string }
+    ): Buffer {
+        const length = options.dataLength ?? 4;
+        const { bigendian, signed, byteSeq } = options;
+
+        if (typeof value !== "number") {
+            throw new Error("Value is not a number");
+        }
+
+        // warn about numbers being too big to be represented as safe integers
+        if (!Number.isSafeInteger(value)) {
+            warn("Value is not a safe integer");
+        }
+        const limit = Math.pow(2, 8 * length) - 1;
+        // throw error on overflow
+        if (signed) {
+            if (value < -limit || value >= limit) {
+                throw new Error("Integer overflow when representing signed " + value + " in " + length + " byte(s)");
+            }
+        } else {
+            if (value < 0 || value >= limit) {
+                throw new Error("Integer overflow when representing unsigned " + value + " in " + length + " byte(s)");
+            }
+        }
+
+        const buf = Buffer.alloc(length);
+        // Handle byte swapping
+        if (byteSeq?.includes("BYTE_SwAP") && length > 1) {
+            buf.swap16();
+        }
+        switch (length) {
+            case 1:
+                signed ? buf.writeInt8(value, 0) : buf.writeUInt8(value, 0);
+                break;
+
+            case 2:
+                bigendian
+                    ? signed
+                        ? buf.writeInt16BE(value, 0)
+                        : buf.writeUInt16BE(value, 0)
+                    : signed
+                    ? buf.writeInt16LE(value, 0)
+                    : buf.writeUInt16LE(value, 0);
+                break;
+
+            case 4:
+                bigendian
+                    ? signed
+                        ? buf.writeInt32BE(value, 0)
+                        : buf.writeUInt32BE(value, 0)
+                    : signed
+                    ? buf.writeInt32LE(value, 0)
+                    : buf.writeUInt32LE(value, 0);
+                break;
+
+            default:
+                if (signed && value < 0) {
+                    // convert to unsigned byte sequence
+                    value += 1 << (8 * length);
+                }
+
+                // use arithmetic instead of shift to cover more than 32 bits
+                for (let i = 0; i < length; ++i) {
+                    const byte = value % 0x100;
+                    value /= 0x100;
+                    buf.writeInt8(byte, bigendian ? length - i - 1 : i);
+                }
+        }
+
+        return buf;
+    }
+
+    private valueToNumber(
+        value: unknown,
+        options: { dataLength: number | undefined; bigendian: boolean; byteSeq: string }
+    ): Buffer {
+        if (typeof value !== "number") {
+            throw new Error("Value is not a number");
+        }
+
+        const length = options.dataLength ?? 8;
+        const { bigendian, byteSeq } = options;
+        const buf = Buffer.alloc(length);
+
+        // Handle byte swapping
+        if (byteSeq && length > 1) {
+            buf.swap16();
+        }
+        switch (length) {
+            case 2:
+                setFloat16(new DataView(buf.buffer), 0, value, !bigendian);
+                break;
+            case 4:
+                bigendian ? buf.writeFloatBE(value, 0) : buf.writeFloatLE(value, 0);
+                break;
+
+            case 8:
+                bigendian ? buf.writeDoubleBE(value, 0) : buf.writeDoubleLE(value, 0);
+                break;
+
+            default:
+                throw new Error("Wrong buffer length for type 'number', must be 4 or 8, is " + length);
+        }
+
+        return buf;
     }
 }

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -254,7 +254,7 @@ export default class OctetstreamCodec implements ContentCodec {
 
         // warn about numbers being too big to be represented as safe integers
         if (!Number.isSafeInteger(value)) {
-            warn("Value is not a safe integer");
+            warn("Value is not a safe integer", value);
         }
         const limit = Math.pow(2, 8 * length) - 1;
         // throw error on overflow

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -56,7 +56,8 @@ export default class OctetstreamCodec implements ContentCodec {
         schema?: DataSchema,
         parameters: { [key: string]: string | undefined } = {}
     ): DataSchemaValue {
-        debug(`OctetstreamCodec parsing '${bytes.toString()}'`);
+        debug("OctetstreamCodec parsing", bytes);
+        debug("Parameters", parameters);
 
         const bigendian = !parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN); // default to big endian
         let signed = parameters.signed !== "false"; // default to signed
@@ -146,6 +147,7 @@ export default class OctetstreamCodec implements ContentCodec {
             case "float":
             case "double":
             case "number":
+                debug("qui", bigendian);
                 switch (dataLength) {
                     case 2:
                         return getFloat16(new DataView(bytes.buffer), bytes.byteOffset, !bigendian);

--- a/packages/core/src/protocol-interfaces.ts
+++ b/packages/core/src/protocol-interfaces.ts
@@ -96,3 +96,10 @@ export interface ProtocolServer {
     stop(): Promise<void>;
     getPort(): number;
 }
+
+export enum Endianness {
+    BIG_ENDIAN = "BIG_ENDIAN",
+    LITTLE_ENDIAN = "LITTLE_ENDIAN",
+    BIG_ENDIAN_BYTE_SWAP = "BIG_ENDIAN_BYTE_SWAP",
+    LITTLE_ENDIAN_BYTE_SWAP = "LITTLE_ENDIAN_BYTE_SWAP",
+}


### PR DESCRIPTION
This PR mainly fixes #903, but it adds a bunch of other changes aimed to improve raw encoding and decoding. Since there are some refactor commits I suggest to start reviewing from start to end using this agenda:
- ecd0107defbc2e2fc8337cbaf78b3f645ad4abb5: is the main change. Here I remove the logic of handling endianess in the modbus client and moved it to the core codecs. 
- 5f67eb4304c4a66b06b8f1df8244f666a8137231: while debugging I found out that Buffer.toString() does not print the nice output you can see from `console.log(buff) // prints <Buf 0x2e 0xc5>`. Now the buffer is printed correctly plus some other information about the parameters used while decoding the value. 
- fc72c1ed2b3b0cec79a2d921e18c2af2a0bfd27e while I was at it I refactored the two main parsing functions of the codec
- eb4275d5b561d26cd60420b78c5377b3e73b1f9a: I found out that some of the problems were caused by the fact the Modbus client was not reporting back the right contentType, I fixed it here. 