### PR TITLE
Use singleton pattern in the Modbus client factory

### DIFF
--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -19,12 +19,26 @@ const debug = createDebugLogger("binding-modbus", "modbus-client-factory");
 
 export default class ModbusClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "modbus+tcp";
+    private singleton: ModbusClient;
 
     public getClient(): ProtocolClient {
-        debug(`Creating client for '${this.scheme}'`);
-        return new ModbusClient();
+        debug(`Get client for '${this.scheme}'`);
+        if (!this.singleton) {
+            this.init();
+        }
+        return this.singleton;
     }
 
-    public init = (): boolean => true;
-    public destroy = (): boolean => true;
+    public init(): boolean {
+        debug(`Initializing client for '${this.scheme}'`);
+        this.singleton = new ModbusClient();
+        return true;
+    }
+
+    public destroy(): boolean {
+        debug(`Destroying client for '${this.scheme}'`);
+        this.singleton.stop();
+        this.singleton = undefined;
+        return true;
+    }
 }

--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -12,10 +12,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { ProtocolClientFactory, ProtocolClient, createDebugLogger } from "@node-wot/core";
+import { ProtocolClientFactory, ProtocolClient, createDebugLogger, createWarnLogger } from "@node-wot/core";
 import ModbusClient from "./modbus-client";
 
 const debug = createDebugLogger("binding-modbus", "modbus-client-factory");
+const warn = createWarnLogger("binding-modbus", "modbus-client-factory");
 
 export default class ModbusClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "modbus+tcp";
@@ -23,20 +24,24 @@ export default class ModbusClientFactory implements ProtocolClientFactory {
 
     public getClient(): ProtocolClient {
         debug(`Get client for '${this.scheme}'`);
-        if (!this.singleton) {
-            this.init();
-        }
+        this.init();
         return this.singleton;
     }
 
     public init(): boolean {
-        debug(`Initializing client for '${this.scheme}'`);
-        this.singleton = new ModbusClient();
+        if (!this.singleton) {
+            debug(`Initializing client for '${this.scheme}'`);
+            this.singleton = new ModbusClient();
+        }
         return true;
     }
 
     public destroy(): boolean {
         debug(`Destroying client for '${this.scheme}'`);
+        if (!this.singleton) {
+            warn(`Destroying a not initialized client factory for '${this.scheme}'`);
+            return true; // do not cause an error
+        }
         this.singleton.stop();
         this.singleton = undefined;
         return true;


### PR DESCRIPTION
As discussed in #904, with the Modbus client caching should happen per `Servient` as multiple connections to the same ModbusTCP network will cause collisions. For this reason in the issue, I discussed the possibility to cache clients in a global manner, but when I was starting to implement I figured out that this feature is already there! we have a factory. Therefore, for Modbus, I simply implement a singleton and should work for most of the use cases. With this change, one Servient will have only one instance of the `ModbusClient`, that will manage the dispatch of requests to multiple hosts. It also manages connections and, consequently, can serialize multiple requests to one single host. 