### PR TITLE
chore: use proper name for netconf client test

### DIFF
--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -31,7 +31,7 @@ should();
 
 chai.use(spies);
 
-describe("outer describe", function () {
+describe("Netconf client implementation", function () {
     this.timeout(10000);
     let client: NetconfClient;
 


### PR DESCRIPTION
Note: I stumbled over "outer describe" when looking at the test log output 