### PR TITLE
chore: fix copyright year based on last update

### DIFF
--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -1,6 +1,6 @@
 import { ExposedThing, Content } from "@node-wot/core";
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/credential-test.ts
+++ b/packages/binding-http/test/credential-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-client-basic-test.ts
+++ b/packages/binding-http/test/http-client-basic-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/memory-model.ts
+++ b/packages/binding-http/test/memory-model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-http/test/oauth-token-validation-tests.ts
+++ b/packages/binding-http/test/oauth-token-validation-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-mbus/test/test-servient.ts
+++ b/packages/binding-mbus/test/test-servient.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/test/test-modbus-server.ts
+++ b/packages/binding-modbus/test/test-modbus-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-modbus/test/test-servient.ts
+++ b/packages/binding-modbus/test/test-servient.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-netconf/test/netconf-client-test.ts
+++ b/packages/binding-netconf/test/netconf-client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/client-test.ts
+++ b/packages/binding-opcua/test/client-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/fixture/basic-opcua-server.ts
+++ b/packages/binding-opcua/test/fixture/basic-opcua-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/full-opcua-thing-test.ts
+++ b/packages/binding-opcua/test/full-opcua-thing-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/opcua-codec-test.ts
+++ b/packages/binding-opcua/test/opcua-codec-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-opcua/test/schema-validation-test.ts
+++ b/packages/binding-opcua/test/schema-validation-test.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/binding-websockets/test/ws-tests.ts
+++ b/packages/binding-websockets/test/ws-tests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/cli/test/RuntimeTest.ts
+++ b/packages/cli/test/RuntimeTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/HelpersTest.ts
+++ b/packages/core/test/HelpersTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/InteractionOutputTest.ts
+++ b/packages/core/test/InteractionOutputTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ProtocolHelpersStreamTest.ts
+++ b/packages/core/test/ProtocolHelpersStreamTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/core/test/ProtocolHelpersTest.ts
+++ b/packages/core/test/ProtocolHelpersTest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
+++ b/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/utils/fix-copyright/CopyrightFix.java
+++ b/utils/fix-copyright/CopyrightFix.java
@@ -244,18 +244,19 @@ public class CopyrightFix {
                     }
                 } else {
                     if (isFileOfInterest(fileEntry)) {
-                        // limit to "src" files
-                        // Q1: what about test files
-                        // Q2: what about deeper nesting in src folder
+                        // limit to "src" and "test" folders
+                        List<String> lFolders = List.of("src", "test");
                         File fileOfInterest = null;
-                        // 1 level nesting
-                        if (fileEntry.getParentFile() != null && fileEntry.getParentFile().getName().equals("src")) {
+                        // 1. level nesting
+                        if (fileEntry.getParentFile() != null && lFolders.contains(fileEntry.getParentFile().getName())) {
                             fileOfInterest = fileEntry;
                         }
-                        // 2 level nesting
-                        if (fileEntry.getParentFile() != null && fileEntry.getParentFile().getParentFile() != null && fileEntry.getParentFile().getParentFile().getName().equals("src")) {
+                        // 2. level nesting
+                        if (fileEntry.getParentFile() != null && fileEntry.getParentFile().getParentFile() != null
+                                && lFolders.contains(fileEntry.getParentFile().getParentFile().getName())) {
                             fileOfInterest = fileEntry;
                         }
+                        // TODO what about deeper nesting in folders
                         if (fileOfInterest != null) {
                             try (BufferedReader br = new BufferedReader(new FileReader(fileOfInterest))) {
                                 // check first lines only


### PR DESCRIPTION
The copyright tool did not look into test folder.
I think we should update the year IF the copyright header is there. Having said that, I don't think test files need the header at all.

Since we missed to do that in the past future copyright runs will update the year to 2023 (since this commit will land in 2023)
:-(