### PR TITLE
fix(binding-modbus): use debug log level when closing connection

### DIFF
--- a/packages/binding-modbus/src/modbus-connection.ts
+++ b/packages/binding-modbus/src/modbus-connection.ts
@@ -414,7 +414,7 @@ export class ModbusConnection {
         debug("Closing unused connection");
         this.client.close((err: string) => {
             if (!err) {
-                error("Session closed");
+                debug("Session closed");
                 this.connecting = false;
             } else {
                 error(`Cannot close session. ${err}`);


### PR DESCRIPTION
Easy fix for a minor issue. I found it when I was debugging error messages but I found this one that should be rather simply a generic debug message.