### PR TITLE
Allign URL template for modbus client

### DIFF
--- a/packages/binding-modbus/README.md
+++ b/packages/binding-modbus/README.md
@@ -84,7 +84,7 @@ Timeout in milliseconds of the modbus request. Default to 1000 milliseconds
 The URL is used to transport all addressing information necessary to describe the MODBUS connection and register addresses. It has the following structure:
 
 ```
-modbus+tcp:// <host> [ : <port> ] [/ <unitid> [ ?address=<address> [&quantity=<quantity> ] ] ]
+modbus+tcp:// <host> [ : <port> ] [/ <unitid> [ / <address> ] [&quantity=<quantity> ] ]
 ```
 
 with the following meaning:

--- a/packages/binding-modbus/src/modbus.ts
+++ b/packages/binding-modbus/src/modbus.ts
@@ -60,7 +60,7 @@ export class ModbusForm extends Form {
     /**
      * Physical address of the unit connected to the bus.
      */
-    public "modbus:unitID": number;
+    public "modbus:unitID"?: number;
     /**
      * Defines the starting address of registers or coils that are
      * meant to be written.

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -121,9 +121,34 @@ describe("Modbus client test", () => {
         client["validateAndFillDefaultForm"](form)["modbus:function"].should.be.equal(1, "Wrong substitution");
     });
 
-    it("should override form values with URL", () => {
+    it("should accept just URL parameters", () => {
         const form: ModbusForm = {
-            href: "modbus://127.0.0.1:8502/2?address=2&quantity=5",
+            href: "modbus://127.0.0.1:8502/2/2?quantity=5",
+            "modbus:function": "readCoil",
+        };
+
+        // eslint-disable-next-line dot-notation
+        client["validateAndFillDefaultForm"](form);
+        form["modbus:unitID"].should.be.equal(2, "unitID  value not set");
+        form["modbus:address"].should.be.equal(2, "address value not set");
+        form["modbus:quantity"].should.be.equal(5, "quantity value not set");
+    });
+
+    it("should accept just URL parameters without quantity", () => {
+        const form: ModbusForm = {
+            href: "modbus://127.0.0.1:8502/2/2",
+            "modbus:function": "readCoil",
+        };
+
+        // eslint-disable-next-line dot-notation
+        client["validateAndFillDefaultForm"](form);
+        form["modbus:unitID"].should.be.equal(2, "unitID  value not set");
+        form["modbus:address"].should.be.equal(2, "address value not set");
+    });
+
+    it("should override correctly form values with URL", () => {
+        const form: ModbusForm = {
+            href: "modbus://127.0.0.1:8502/2/2?quantity=5",
             "modbus:function": "readCoil",
             "modbus:address": 0,
             "modbus:quantity": 1,
@@ -132,9 +157,9 @@ describe("Modbus client test", () => {
 
         // eslint-disable-next-line dot-notation
         client["overrideFormFromURLPath"](form);
-        form["modbus:unitID"].should.be.equal(2, "Form value not overridden");
-        form["modbus:address"].should.be.equal(2, "Form value not overridden");
-        form["modbus:quantity"].should.be.equal(5, "Form value not overridden");
+        form["modbus:unitID"].should.be.equal(2, "unitID value not overridden");
+        form["modbus:address"].should.be.equal(2, "address value not overridden");
+        form["modbus:quantity"].should.be.equal(5, "quantity value not overridden");
     });
 
     describe("misc", () => {


### PR DESCRIPTION
As the title states this simple PR changes the URL template declared in the Modbus binding to be aligned with https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/index.html#url. Tests were updated and improved. 