### PR TITLE
fix http client and server property "subscription"

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -756,6 +756,9 @@ export default class HttpServer implements ProtocolServer {
                                     res.writeHead(500);
                                     res.end(err.message);
                                 }
+                            } else if (req.method === "HEAD") {
+                                res.writeHead(202);
+                                res.end();
                             } else {
                                 respondUnallowedMethod(res, "GET");
                             }
@@ -854,6 +857,11 @@ export default class HttpServer implements ProtocolServer {
                                         respondUnallowedMethod(res, "GET, PUT");
                                     }
                                     // resource found and response sent
+                                    return;
+                                } else if (req.method === "HEAD") {
+                                    // HEAD support for long polling subscription
+                                    res.writeHead(202);
+                                    res.end();
                                     return;
                                 } else {
                                     respondUnallowedMethod(res, "GET, PUT");

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -485,17 +485,15 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
             if (options.formIndex >= 0 && options.formIndex < forms.length) {
                 form = forms[options.formIndex];
                 const scheme = Helpers.extractScheme(form.href);
-                const localClient = this.getClients().get(scheme);
-                if (localClient !== undefined) {
-                    // reuse client
-                    client = localClient;
-                } else if (this.getServient().hasClientFor(scheme)) {
-                    // new client
+                if (this.getServient().hasClientFor(scheme)) {
                     debug(`ConsumedThing '${this.title}' got client for '${scheme}'`);
                     client = this.getServient().getClientFor(scheme);
 
-                    this.ensureClientSecurity(client, form);
-                    this.getClients().set(scheme, client);
+                    if (!this.getClients().get(scheme)) {
+                        // new client
+                        this.ensureClientSecurity(client, form);
+                        this.getClients().set(scheme, client);
+                    }
                 } else {
                     throw new Error(`ConsumedThing '${this.title}' missing ClientFactory for '${scheme}'`);
                 }

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -485,16 +485,17 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
             if (options.formIndex >= 0 && options.formIndex < forms.length) {
                 form = forms[options.formIndex];
                 const scheme = Helpers.extractScheme(form.href);
-
-                if (this.getServient().hasClientFor(scheme)) {
+                const localClient = this.getClients().get(scheme);
+                if (localClient !== undefined) {
+                    // reuse client
+                    client = localClient;
+                } else if (this.getServient().hasClientFor(scheme)) {
+                    // new client
                     debug(`ConsumedThing '${this.title}' got client for '${scheme}'`);
                     client = this.getServient().getClientFor(scheme);
 
-                    if (!this.getClients().get(scheme)) {
-                        // new client
-                        this.ensureClientSecurity(client, form);
-                        this.getClients().set(scheme, client);
-                    }
+                    this.ensureClientSecurity(client, form);
+                    this.getClients().set(scheme, client);
                 } else {
                     throw new Error(`ConsumedThing '${this.title}' missing ClientFactory for '${scheme}'`);
                 }


### PR DESCRIPTION
Hi, currently the `thing.observeProperty` was not working on the browser and server for the http binding.

- the HEAD header was not supported so I add it
- calling `.stop()` on the returned Subscription was not working. It came from the fact that the Client was not recycled and was generated each time by the Servient. => I'm not totally sure of this fix as it touches pretty abstract code.

Reviews are welcome