### PR TITLE
Improve test timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12709,6 +12709,7 @@
                 "wot-thing-description-types": "^1.1.0-13-October-2022"
             },
             "devDependencies": {
+                "@sinonjs/fake-timers": "^10.0.2",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/accept-language-parser": "^1.5.2",
                 "@types/basic-auth": "1.1.3",
@@ -12741,6 +12742,24 @@
                 "typescript": "4.4.3",
                 "typescript-standard": "^0.3.36",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
+            }
+        },
+        "packages/binding-http/node_modules/@sinonjs/commons": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "packages/binding-http/node_modules/@sinonjs/fake-timers": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+            "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^2.0.0"
             }
         },
         "packages/binding-mbus": {
@@ -13582,6 +13601,7 @@
             "requires": {
                 "@node-wot/core": "0.8.5",
                 "@node-wot/td-tools": "0.8.5",
+                "@sinonjs/fake-timers": "*",
                 "@testdeck/mocha": "^0.1.2",
                 "@types/accept-language-parser": "^1.5.2",
                 "@types/basic-auth": "1.1.3",
@@ -13624,6 +13644,26 @@
                 "typescript-standard": "^0.3.36",
                 "wot-thing-description-types": "^1.1.0-13-October-2022",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.23"
+            },
+            "dependencies": {
+                "@sinonjs/commons": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+                    "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+                    "dev": true,
+                    "requires": {
+                        "type-detect": "4.0.8"
+                    }
+                },
+                "@sinonjs/fake-timers": {
+                    "version": "10.0.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+                    "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^2.0.0"
+                    }
+                }
             }
         },
         "@node-wot/binding-mbus": {

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -18,6 +18,7 @@
         "./dist/http-client.js": "./dist/http-client-browser.js"
     },
     "devDependencies": {
+        "@sinonjs/fake-timers": "^10.0.2",
         "@testdeck/mocha": "^0.1.2",
         "@types/accept-language-parser": "^1.5.2",
         "@types/basic-auth": "1.1.3",

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -124,7 +124,6 @@ class HttpClientOAuthTest {
         const model = HttpClientOAuthTest.model;
         await model.expireAllTokens();
         this.client.setSecurity([scheme], { clientId: "thom", clientSecret: "nightworld" });
-        await sleep(1000);
         const resource = await this.client.readResource({
             href: "https://127.0.0.1:3000/resource",
         });
@@ -148,7 +147,6 @@ class HttpClientOAuthTest {
             username: "thomseddon",
             password: "nightworld",
         });
-        await sleep(1000);
         const resource = await this.client.readResource({
             href: "https://127.0.0.1:3000/resource",
         });

--- a/packages/binding-http/test/http-client-oauth-tests.ts
+++ b/packages/binding-http/test/http-client-oauth-tests.ts
@@ -26,10 +26,6 @@ import { readFileSync } from "fs";
 import OAuthServer from "express-oauth-server";
 import bodyParser from "body-parser";
 
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 @suite("HTTP oauth client implementation")
 class HttpClientOAuthTest {
     private client: HttpClient;

--- a/packages/binding-http/test/memory-model.ts
+++ b/packages/binding-http/test/memory-model.ts
@@ -170,7 +170,7 @@ export default class InMemoryModel implements ClientCredentialsModel, PasswordMo
 
     expireAllTokens(): void {
         for (const token of this.tokens) {
-            token.accessTokenExpiresAt = new Date();
+            token.accessTokenExpiresAt = new Date(new Date().setHours(-1));
         }
     }
 }

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -188,10 +188,10 @@ describe("Modbus client test", () => {
                 "modbus:address": 4444,
                 "modbus:quantity": 1,
                 "modbus:unitID": 1,
-                "modbus:timeout": 1000,
+                "modbus:timeout": 100,
             };
 
-            await client.readResource(form).should.eventually.be.rejected;
+            await client.readResource(form).should.eventually.be.rejectedWith("Timed out");
         }).timeout(5000);
     });
     describe("read resource", () => {

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -91,7 +91,7 @@ describe("Modbus connection", () => {
                 "modbus:unitID": 1,
             };
             const connection = new ModbusConnection("127.0.0.1", 8502, {
-                connectionTimeout: 1000,
+                connectionTimeout: 100,
                 connectionRetryTime: 10,
                 maxRetries: 1,
             });

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -88,13 +88,9 @@ describe("MQTT client implementation", () => {
                                 }
                             })
                             .then(() => {
-                                const job = setInterval(() => {
-                                    ++counter;
-                                    thing.emitEvent(eventName, counter);
-                                    if (counter === 3) {
-                                        clearInterval(job);
-                                    }
-                                }, 1000);
+                                for (let i = 0; i < 4; i++) {
+                                    thing.emitEvent(eventName, i);
+                                }
                             })
                             .catch((e) => {
                                 expect(true).to.equal(false);
@@ -153,13 +149,9 @@ describe("MQTT client implementation", () => {
                                 }
                             })
                             .then(() => {
-                                const job = setInterval(() => {
-                                    ++counter;
-                                    thing.emitEvent(eventName, counter);
-                                    if (counter === 3) {
-                                        clearInterval(job);
-                                    }
-                                }, 1000);
+                                for (let i = 0; i < 4; i++) {
+                                    thing.emitEvent(eventName, i);
+                                }
                             })
                             .catch((e) => {
                                 expect(true).to.equal(false);

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -51,8 +51,6 @@ describe("MQTT client implementation", () => {
 
         servient.addClientFactory(new MqttClientFactory());
 
-        let counter = 0;
-
         servient.start().then((WoT) => {
             expect(brokerServer.getPort()).to.equal(brokerPort);
             expect(brokerServer.getAddress()).to.equal(brokerAddress);
@@ -76,7 +74,6 @@ describe("MQTT client implementation", () => {
                         client
                             .subscribeEvent(eventName, (x) => {
                                 if (!eventReceived) {
-                                    counter = 0;
                                     eventReceived = true;
                                 } else {
                                     ProtocolHelpers.readStreamFully(ProtocolHelpers.toNodeStream(x.data)).then(
@@ -112,8 +109,6 @@ describe("MQTT client implementation", () => {
         servient.addClientFactory(new MqttClientFactory());
         servient.addClientFactory(new MqttsClientFactory({ rejectUnauthorized: false }));
 
-        let counter = 0;
-
         servient.start().then((WoT) => {
             expect(brokerServer.getPort()).to.equal(brokerPort);
             expect(brokerServer.getAddress()).to.equal(brokerAddress);
@@ -137,7 +132,6 @@ describe("MQTT client implementation", () => {
                         client
                             .subscribeEvent(eventName, (x) => {
                                 if (!eventReceived) {
-                                    counter = 0;
                                     eventReceived = true;
                                 } else {
                                     ProtocolHelpers.readStreamFully(ProtocolHelpers.toNodeStream(x.data)).then(


### PR DESCRIPTION
I did some improvements in our test suites hoping to reduce wasted time while developing with node-wot. With the reference to #831, the situation is improved but it is not perfect. Some caveats:
- fake timers do not work with sockets ( I went deep down inside node.js internals and I figured out that they are not using the usual `setTimeout` or equivalent method but rather an internal version. Mocking the `Socket.setTimeout` method does not work either -> I gave up). This still causes some slowness in the Modbus protocol binding.
- mbus still times out at 2sec even if you set another timeout
- OPC-UA is still quite slow. 

In general I think we should save about 5 seconds or more each run. 