### PR TITLE
Pull Request for asset-interface-description.ts file

### DIFF
--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -365,6 +365,17 @@ export class AssetInterfaceDescriptionUtil {
                 thing.properties[key].forms = [];
 
                 for (const vi of value) {
+                    //The first if condition is expected to be temporary. will be adjusted or removed when a decision on how the datapoint's datatype would be modelled is made for AID
+                    if(vi.interaction.constraints.length > 0 && vi.interaction.constraints.length > 0){
+                        if(vi.interaction.constraints[0].value === "float"){
+                            thing.properties[key].type = "number";
+                        }
+                        else{
+                            thing.properties[key].type = vi.interaction.constraints[0].value;
+                        }
+
+                    }
+
                     if (vi.endpointMetadata) {
                         vi.secNamesForEndpoint = secNamesForEndpointMetadata.get(vi.endpointMetadata);
                     }

--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -359,21 +359,23 @@ export class AssetInterfaceDescriptionUtil {
             for (const entry of smInformation.properties.entries()) {
                 const key = entry[0];
                 const value: AASInteraction[] = entry[1];
-                logInfo("Property" + key + " = " + value);
+                logInfo("vProperty" + key + " = " + value);
 
                 thing.properties[key] = {};
                 thing.properties[key].forms = [];
 
                 for (const vi of value) {
-                    //The first if condition is expected to be temporary. will be adjusted or removed when a decision on how the datapoint's datatype would be modelled is made for AID
-                    if(vi.interaction.constraints.length > 0 && vi.interaction.constraints.length > 0){
-                        if(vi.interaction.constraints[0].value === "float"){
-                            thing.properties[key].type = "number";
-                        }
-                        else{
-                            thing.properties[key].type = vi.interaction.constraints[0].value;
-                        }
+                    // The first if condition is expected to be temporary. will be adjusted or removed when a decision on how the datapoint's datatype would be modelled is made for AID
 
+                    if (vi.interaction.constraints instanceof Array && vi.interaction.constraints) {
+                        for (const constraint of vi.interaction.constraints)
+                            if (constraint.type === "valueType") {
+                                if (constraint.value === "float") {
+                                    thing.properties[key].type = "number";
+                                } else {
+                                    thing.properties[key].type = constraint.value;
+                                }
+                            }
                     }
 
                     if (vi.endpointMetadata) {

--- a/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
+++ b/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
@@ -184,6 +184,12 @@ class AssetInterfaceDescriptionUtilTest {
         expect(tdObj.securityDefinitions[tdObj.security[0]]).to.have.property("scheme").that.equals("nosec");
 
         expect(tdObj).to.have.property("properties").to.have.property("count");
+        // just inserter by Kaz
+        expect(tdObj)
+            .to.have.property("properties")
+            .to.have.property("count")
+            .to.have.property("type")
+            .that.equals("integer");
 
         // form entries
         expect(tdObj)


### PR DESCRIPTION
Hello, to start with, I am completely  new to JS and TS and this is my first time make a PR.  

When I was trying to test Modubs implementation of AID in node-wot, I bumped into a bug, the AID <-> TD code did not consider **qualifier** of each datapoints in AID. we actually include the valueType there which corresponds to the TD dataschema **type**.

So, I added a little line of codes in asset-interface-description.ts file to include the datatype modelled in AID for TD properties.  i did for only properties because the final for how to model the data type has not been made but it is important for modbus testing due to its payload type(octet-stream). 

Thank you and Regards.
