### PR TITLE
feat: add support for AID's interfaceMetadata datatype conversion to TD's type

### DIFF
--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -366,7 +366,7 @@ export class AssetInterfaceDescriptionUtil {
 
                 for (const vi of value) {
                     // The first block of if condition is expected to be temporary. will be adjusted or removed when a decision on how the datapoint's datatype would be modelled is made for AID.
-                    if (vi.interaction.constraint && vi.interaction.constraints instanceof Array) {
+                    if (vi.interaction.constraints && vi.interaction.constraints instanceof Array) {
                         for (const constraint of vi.interaction.constraints)
                             if (constraint.type === "valueType") {
                                 if (constraint.value === "float") {

--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -365,6 +365,18 @@ export class AssetInterfaceDescriptionUtil {
                 thing.properties[key].forms = [];
 
                 for (const vi of value) {
+                    // The first block of if condition is expected to be temporary. will be adjusted or removed when a decision on how the datapoint's datatype would be modelled is made for AID.
+                    if (vi.interaction.constraint && vi.interaction.constraints instanceof Array) {
+                        for (const constraint of vi.interaction.constraints)
+                            if (constraint.type === "valueType") {
+                                if (constraint.value === "float") {
+                                    thing.properties[key].type = "number";
+                                } else {
+                                    thing.properties[key].type = constraint.value;
+                                }
+                            }
+                    }
+
                     if (vi.endpointMetadata) {
                         vi.secNamesForEndpoint = secNamesForEndpointMetadata.get(vi.endpointMetadata);
                     }

--- a/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
+++ b/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
@@ -184,6 +184,12 @@ class AssetInterfaceDescriptionUtilTest {
         expect(tdObj.securityDefinitions[tdObj.security[0]]).to.have.property("scheme").that.equals("nosec");
 
         expect(tdObj).to.have.property("properties").to.have.property("count");
+        // to check if count properties has type element that is equals the value defined in AID->integer
+        expect(tdObj)
+            .to.have.property("properties")
+            .to.have.property("count")
+            .to.have.property("type")
+            .that.equals("integer");
 
         // form entries
         expect(tdObj)


### PR DESCRIPTION
This pull request is made to support asset-interface-description.ts functionality by adding a feature that reflects data types of AID datapoints in the converted TD.  