### PR TITLE
feat(binding-coap)!: use blockSize instead of blockSZX

### DIFF
--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -218,13 +218,13 @@ export default class CoapClient implements ProtocolClient {
         return options;
     }
 
-    private setBlockOption(req: OutgoingMessage, optionName: "Block1" | "Block2", blockSZX?: BlockSize): void {
-        if (blockSZX == null) {
+    private setBlockOption(req: OutgoingMessage, optionName: "Block1" | "Block2", blockSize?: BlockSize): void {
+        if (blockSize == null) {
             return;
         }
 
         try {
-            const block2OptionValue = blockSizeToOptionValue(blockSZX);
+            const block2OptionValue = blockSizeToOptionValue(blockSize);
             req.setOption(optionName, block2OptionValue);
         } catch (e) {
             warn(e.toString());
@@ -257,8 +257,8 @@ export default class CoapClient implements ProtocolClient {
     private applyFormDataToRequest(form: CoapForm, req: OutgoingMessage) {
         const blockwise = form["cov:blockwise"];
         if (blockwise != null) {
-            this.setBlockOption(req, "Block2", blockwise["cov:block2SZX"]);
-            this.setBlockOption(req, "Block1", blockwise["cov:block1SZX"]);
+            this.setBlockOption(req, "Block2", blockwise["cov:block2Size"]);
+            this.setBlockOption(req, "Block1", blockwise["cov:block1Size"]);
         }
     }
 

--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -34,8 +34,8 @@ export type BlockSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024;
 export type BlockSizeOptionValue = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface BlockWiseTransferParameters {
-    "cov:block2SZX"?: BlockSize;
-    "cov:block1SZX"?: BlockSize;
+    "cov:block2Size"?: BlockSize;
+    "cov:block1Size"?: BlockSize;
 }
 
 export class CoapForm extends Form {


### PR DESCRIPTION
This PR incorporates the changes made in https://github.com/w3c/wot-binding-templates/pull/259 into the CoAP binding implementation.