### PR TITLE
fix(examples): remove auth server from oauth2 examples

### DIFF
--- a/examples/security/oauth/exposer.js
+++ b/examples/security/oauth/exposer.js
@@ -20,7 +20,6 @@ const td = {
         oauth2_sc: {
             scheme: "oauth2",
             flow: "client",
-            authorization: "https://example.com/authorization",
             token: "https://localhost:3000/token",
             scopes: ["user", "admin"],
         },

--- a/packages/examples/src/security/oauth/exposer.ts
+++ b/packages/examples/src/security/oauth/exposer.ts
@@ -23,7 +23,6 @@ const td: ExposedThingInit = {
         oauth2_sc: {
             scheme: "oauth2",
             flow: "client",
-            authorization: "https://example.com/authorization",
             token: "https://localhost:3000/token",
             scopes: ["user", "admin"],
         },


### PR DESCRIPTION
The assertions at https://w3c.github.io/wot-thing-description/#td-security-oauth2-client-flow were being violated