### PR TITLE
feat(binding-coap): implement DNS-SD via mDNS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12724,6 +12724,7 @@
                 "@node-wot/td-tools": "0.8.7",
                 "@types/node": "16.4.13",
                 "coap": "^1.3.0",
+                "multicast-dns": "^7.2.5",
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
@@ -12732,6 +12733,7 @@
             "devDependencies": {
                 "@testdeck/mocha": "^0.1.2",
                 "@types/chai": "^4.2.18",
+                "@types/multicast-dns": "^7.2.1",
                 "@types/node": "16.4.13",
                 "@typescript-eslint/eslint-plugin": "^4.30.0",
                 "@typescript-eslint/parser": "^4.30.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -16,6 +16,7 @@
     "devDependencies": {
         "@testdeck/mocha": "^0.1.2",
         "@types/chai": "^4.2.18",
+        "@types/multicast-dns": "^7.2.1",
         "@types/node": "16.4.13",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
@@ -38,6 +39,7 @@
         "@node-wot/td-tools": "0.8.7",
         "@types/node": "16.4.13",
         "coap": "^1.3.0",
+        "multicast-dns": "^7.2.5",
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -31,6 +31,7 @@ import { Socket } from "dgram";
 import { Server, createServer, registerFormat, IncomingMessage, OutgoingMessage } from "coap";
 import slugify from "slugify";
 import { Readable } from "stream";
+import { MdnsIntroducer } from "./mdns-introducer";
 
 const { debug, warn, info, error } = createLoggers("binding-coap", "coap-server");
 
@@ -57,6 +58,9 @@ export default class CoapServer implements ProtocolServer {
 
     private readonly port: number = 5683;
     private readonly address?: string = undefined;
+
+    private mdnsIntroducer: MdnsIntroducer;
+
     private readonly server: Server = createServer(
         { reuseAddr: false },
         (req: IncomingMessage, res: OutgoingMessage) => {
@@ -92,6 +96,7 @@ export default class CoapServer implements ProtocolServer {
                 this.server.on("error", (err: Error) => {
                     error(`CoapServer for port ${this.port} failed: ${err.message}`);
                 });
+                this.mdnsIntroducer = new MdnsIntroducer(this.address);
                 resolve();
             });
         });
@@ -104,6 +109,7 @@ export default class CoapServer implements ProtocolServer {
             this.server.once("error", (err: Error) => {
                 reject(err);
             });
+            this.mdnsIntroducer?.close();
             this.server.close(() => {
                 resolve();
             });
@@ -136,7 +142,8 @@ export default class CoapServer implements ProtocolServer {
 
         debug(`CoapServer on port ${this.getPort()} exposes '${thing.title}' as unique '/${urlPath}'`);
 
-        if (this.getPort() !== -1) {
+        const port = this.getPort();
+        if (port !== -1) {
             this.things.set(urlPath, thing);
 
             // fill in binding data
@@ -187,6 +194,14 @@ export default class CoapServer implements ProtocolServer {
                     }
                 } // media types
             } // addresses
+
+            const parameters = {
+                urlPath,
+                port,
+                serviceName: "_wot._udp.local",
+            };
+
+            this.mdnsIntroducer?.registerExposedThing(thing, parameters);
         } // running
 
         return new Promise<void>((resolve, reject) => {
@@ -201,6 +216,7 @@ export default class CoapServer implements ProtocolServer {
             if (exposedThing?.id === thingId) {
                 this.things.delete(name);
                 this.coreResources.delete(name);
+                this.mdnsIntroducer?.delete(name);
 
                 info(`CoapServer succesfully destroyed '${exposedThing.title}'`);
                 return true;

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -102,18 +102,22 @@ export default class CoapServer implements ProtocolServer {
         });
     }
 
-    public stop(): Promise<void> {
-        info(`CoapServer stopping on port ${this.getPort()}`);
+    private closeServer(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             // stop promise handles all errors from now on
             this.server.once("error", (err: Error) => {
                 reject(err);
             });
-            this.mdnsIntroducer?.close();
             this.server.close(() => {
                 resolve();
             });
         });
+    }
+
+    public async stop(): Promise<void> {
+        info(`CoapServer stopping on port ${this.getPort()}`);
+       await this.closeServer();
+       await this.mdnsIntroducer?.close();
     }
 
     /** returns socket to be re-used by CoapClients */

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -116,8 +116,8 @@ export default class CoapServer implements ProtocolServer {
 
     public async stop(): Promise<void> {
         info(`CoapServer stopping on port ${this.getPort()}`);
-       await this.closeServer();
-       await this.mdnsIntroducer?.close();
+        await this.closeServer();
+        await this.mdnsIntroducer?.close();
     }
 
     /** returns socket to be re-used by CoapClients */

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -139,6 +139,6 @@ export class MdnsIntroducer {
     public async close(): Promise<void> {
         return new Promise((resolve) => {
             this.mdns.destroy(resolve);
-        })
+        });
     }
 }

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -136,7 +136,9 @@ export class MdnsIntroducer {
         this.mdnsEntries.delete(urlPath);
     }
 
-    public close(): void {
-        this.mdns.destroy();
+    public async close(): Promise<void> {
+        return new Promise((resolve) => {
+            this.mdns.destroy(resolve);
+        })
     }
 }

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -137,8 +137,13 @@ export class MdnsIntroducer {
     }
 
     public async close(): Promise<void> {
-        return new Promise((resolve) => {
-            this.mdns.destroy(resolve);
+        return new Promise((resolve, reject) => {
+            this.mdns.destroy((error?: Error) => {
+                if (error != null) {
+                    reject(error);
+                }
+                resolve();
+            });
         });
     }
 }

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import makeMdns = require("multicast-dns");
+import { networkInterfaces } from "os";
+import { MulticastDNS } from "multicast-dns";
+import { Answer } from "dns-packet";
+import { ExposedThing } from "@node-wot/core";
+
+interface MdnsDiscoveryParameters {
+    urlPath: string;
+    port: number;
+    serviceName: string;
+    scheme?: string;
+    type?: "Thing" | "Directory";
+}
+
+type IpAddressFamily = "IPv4" | "IPv6";
+
+/**
+ * Implements DNS-based Service Discovery as a TD discovery mechanism
+ * using MDNS.
+ *
+ * @see https://www.w3.org/TR/wot-discovery/#introduction-dns-sd-sec
+ */
+export class MdnsIntroducer {
+    private readonly mdns: MulticastDNS;
+
+    private readonly mdnsEntries: Map<string, Answer[]>;
+
+    private readonly ipAddressFamily: IpAddressFamily;
+
+    constructor(address?: string, ipAddressFamily?: IpAddressFamily) {
+        this.ipAddressFamily = ipAddressFamily ?? "IPv4";
+
+        const type = ipAddressFamily === "IPv6" ? "udp6" : "udp4";
+
+        this.mdns = makeMdns({
+            ip: address,
+            type,
+        });
+        this.mdnsEntries = new Map();
+        this.mdns.on("query", (query) => {
+            this.sendMdnsResponses(query);
+        });
+    }
+
+    private sendMdnsResponses(query: makeMdns.QueryPacket): void {
+        this.mdnsEntries.forEach((value) => {
+            const entryName = value[0].name;
+            const matchingQuestions = query.questions.filter((question) => question.name === entryName);
+
+            if (matchingQuestions.length <= 0) {
+                return;
+            }
+
+            this.mdns.respond(value);
+        });
+    }
+
+    private determineTarget(): string {
+        const interfaces = networkInterfaces();
+
+        for (const iface in interfaces) {
+            for (const entry of interfaces[iface] ?? []) {
+                if (entry.internal === false) {
+                    if (entry.family === this.ipAddressFamily) {
+                        return entry.address;
+                    }
+                }
+            }
+        }
+
+        // TODO: Is it correct to throw an error here?
+        throw Error("Found no suitable IP address for performing MDNS introduction.");
+    }
+
+    private createTxtData(parameters: MdnsDiscoveryParameters): Array<string> {
+        const txtData = [`td=${parameters.urlPath}`];
+
+        const type = parameters.type;
+        if (type != null) {
+            txtData.push(`type=${type}`);
+        }
+
+        const scheme = parameters.scheme;
+        if (scheme != null) {
+            txtData.push(`scheme=${scheme}`);
+        }
+
+        return txtData;
+    }
+
+    public registerExposedThing(thing: ExposedThing, parameters: MdnsDiscoveryParameters): void {
+        const serviceName = parameters.serviceName;
+        const instanceName = `${thing.title}.${serviceName}`;
+
+        const target = this.determineTarget();
+        const txtData = this.createTxtData(parameters);
+
+        this.mdnsEntries.set(parameters.urlPath, [
+            {
+                name: serviceName,
+                type: "PTR",
+                data: instanceName,
+            },
+            {
+                name: instanceName,
+                type: "SRV",
+                data: {
+                    port: parameters.port,
+                    target,
+                },
+            },
+            {
+                name: instanceName,
+                type: "TXT",
+                data: txtData,
+            },
+        ]);
+    }
+
+    public delete(urlPath: string): void {
+        this.mdnsEntries.delete(urlPath);
+    }
+
+    public close(): void {
+        this.mdns.destroy();
+    }
+}


### PR DESCRIPTION
This PR adds DNS-SD functionality (via mDNS) to the `binding-coap` package in order to cover the respective [assertion](https://w3c.github.io/wot-discovery/#introduction-dns-sd-service-name-udp) from the Discovery specification.

I still need to do some interoperability testing, therefore I opened this PR only as a draft for now. However, hopefully the PR will be ready for review soon :)