### PR TITLE
chore: add Node.js 20 and remove Node.js 14 workflow

### DIFF
--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                node-version: [14.x, 16.x, 18.x, 20.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                node-version: [14.x, 16.x, 18.x]
+                node-version: [14.x, 16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [14.x, 16.x, 18.x, 20.x]
+                node-version: 16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [14.x, 16.x, 18.x]
+                node-version: [14.x, 16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Note: we can also start "thinking" about removing Node.js 14