### PR TITLE
refactor(binding-coap): refactor server's destroy method

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -194,25 +194,21 @@ export default class CoapServer implements ProtocolServer {
         });
     }
 
-    public destroy(thingId: string): Promise<boolean> {
+    public async destroy(thingId: string): Promise<boolean> {
         debug(`CoapServer on port ${this.getPort()} destroying thingId '${thingId}'`);
-        return new Promise<boolean>((resolve, reject) => {
-            let removedThing: ExposedThing;
-            for (const name of Array.from(this.things.keys())) {
-                const expThing = this.things.get(name);
-                if (expThing?.id === thingId) {
-                    this.things.delete(name);
-                    this.coreResources.delete(name);
-                    removedThing = expThing;
-                }
+        for (const name of this.things.keys()) {
+            const exposedThing = this.things.get(name);
+            if (exposedThing?.id === thingId) {
+                this.things.delete(name);
+                this.coreResources.delete(name);
+
+                info(`CoapServer succesfully destroyed '${exposedThing.title}'`);
+                return true;
             }
-            if (removedThing) {
-                info(`CoapServer succesfully destroyed '${removedThing.title}'`);
-            } else {
-                info(`CoapServer failed to destroy thing with thingId '${thingId}'`);
-            }
-            resolve(removedThing !== undefined);
-        });
+        }
+
+        info(`CoapServer failed to destroy thing with thingId '${thingId}'`);
+        return false;
     }
 
     private formatCoreLinkFormatResources() {


### PR DESCRIPTION
In the context of #963. I noticed that the `CoapServer`'s `destroy` method could use some cleanup. This PR refactors the method a bit, using `async/await` instead of a `Promise`, making the code a bit more readable.

There are other places like these elsewhere in the code, I will try to do some further cleanup when I'll continue working on #963 and issues like #982.