### PR TITLE
Draft: CoAP server to include IPv6 when no address specified

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -83,7 +83,7 @@ export default class CoapServer implements ProtocolServer {
 
     constructor(config?: CoapServerConfig) {
         this.port = config?.port ?? 5683;
-        this.address = config?.address;
+        this.address = config?.address ?? "::";
 
         // WoT-specific content formats
         registerFormat(ContentSerdes.JSON_LD, 2100);


### PR DESCRIPTION
When starting a servient with a `new CoapServer()`, it only binds to IPv4 addresses. At least my expectation is that the CoAP server should bind to all addresses of a host when no specific address is given. Hence, I consider this a bug.

This is just a strawman hotfix to start the work on fixing IPv6 support for the CoAP server.

When no address is given to NodeJS `dgram`, it only binds to the IPv4 wildcard address (`0.0.0.0`), but not IPv6 even when the host has it enabled. There might be an implicit default for the type being set to `udp4`.

When passing the IPv6 wildcard address `::` to sockets, the expectation is that it binds to both IPv6 and IPv4 addresses (i.e., dual-stack). This can be reconfigured at least under Linux with the `net.ipv6.bindv6only` sysctl parameter, but then the hosts expectation is that the default wildcard means only `::` without `0.0.0.0`. It might still confuse node-wot users who are not aware of `net.ipv6.bindv6only`.

Please investigate and test this further, as I did not test this on IPv4-only machines. It might directly fail there and might need more code to detect IPv6 support on the host before defaulting to `::`.

Overall, the issue is with `dgram`, whose dual-stack capabilities are quite broken by requiring a decision on `udp4` vs `upd6` upfront.