### PR TITLE
docs: revise README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can find more (non-)installation options in the specific [package README](./
 
 ### As a CLI tool
 
-You can alternatively use node-wot via its command line interface (CLI). Please visit the [CLI tool README](./packages/cli/README.md) to find out more.
+You can alternatively use node-wot via its command line interface (CLI). Please visit the [CLI tool README](https://github.com/eclipse-thingweb/node-wot/tree/master/packages/cli) to find out more.
 
 #### As global tool
 


### PR DESCRIPTION
Trying to streamline the information given in the README for "new" users (including people who have not used it in a long time).

I noticed that it is complicated with some of the duplication, e.g., https://thingweb.io/docs/node-wot/api/ or https://github.com/eclipse-thingweb/node-wot/blob/master/packages/binding-coap/README.md

We also already saw that some of the references online Things are not reachable, e.g., coap://plugfest.thingweb.io/testthing (neither HTTP nor CoAP).