### PR TITLE
Expose internal WoT implementation

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -50,3 +50,7 @@ export { default as ProtocolHelpers } from "./protocol-helpers";
 
 // Logger Functions
 export { createLoggers, createDebugLogger, createErrorLogger, createInfoLogger, createWarnLogger } from "./logger";
+
+// WoT Runtime
+export type { default as WoT } from "./wot-impl";
+export type { ThingDiscoveryProcess } from "./wot-impl";

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -27,7 +27,7 @@ import { inspect } from "util";
 
 const { debug } = createLoggers("core", "wot-impl");
 
-class ThingDiscoveryProcess implements WoT.ThingDiscoveryProcess {
+export class ThingDiscoveryProcess implements WoT.ThingDiscoveryProcess {
     constructor(
         private directory: WoT.ConsumedThing,
         public filter?: WoT.ThingFilter


### PR DESCRIPTION
This PR adds type exports for `WoT` and `ThingDiscoveryProcess` to `core.ts`. These are type-only exports (`export type`), preventing actual instantiation (maybe in future revisions we can relax the constraint, and we can export the real values -> it is a backward compatible change that we can do as we like). Additionally, `ThingDiscoveryProcess` was made directly exportable in `wot-impl.ts`.

This resolves the missing runtime exports while maintaining type safety. 

Fixes #1282.