### PR TITLE
Web Thing Protocol Websocket Client Implementation

### DIFF
--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -96,7 +96,10 @@ export default class WebSocketClient implements ProtocolClient {
             response = await this.sendRequest(ws, request);
 
             // Extract value from W3C response
-            const value = (response as Record<string, unknown>).value !== undefined ? (response as Record<string, unknown>).value : response;
+            const value =
+                (response as Record<string, unknown>).value !== undefined
+                    ? (response as Record<string, unknown>).value
+                    : response;
             return new Content(
                 form.contentType ?? "application/json",
                 this.bufferToStream(Buffer.from(JSON.stringify(value)))
@@ -169,7 +172,10 @@ export default class WebSocketClient implements ProtocolClient {
             response = await this.sendRequest(ws, request);
 
             // Extract output from W3C response
-            const output = (response as Record<string, unknown>).output !== undefined ? (response as Record<string, unknown>).output : response;
+            const output =
+                (response as Record<string, unknown>).output !== undefined
+                    ? (response as Record<string, unknown>).output
+                    : response;
             return new Content(
                 form.response?.contentType ?? form.contentType ?? "application/json",
                 this.bufferToStream(Buffer.from(JSON.stringify(output)))
@@ -549,7 +555,9 @@ export default class WebSocketClient implements ProtocolClient {
             const subprotocol = this.extractSubprotocol(form);
             const protocols = subprotocol ? [subprotocol] : undefined;
 
-            debug(`Creating WebSocket connection to ${form.href}${protocols ? ` with subprotocol ${subprotocol}` : ""}`);
+            debug(
+                `Creating WebSocket connection to ${form.href}${protocols ? ` with subprotocol ${subprotocol}` : ""}`
+            );
 
             // Connect to the full href, not just baseUrl
             const ws = new WebSocket(form.href, protocols, wsOptions);

--- a/packages/binding-websockets/test/ws-tests.ts
+++ b/packages/binding-websockets/test/ws-tests.ts
@@ -17,7 +17,7 @@
  * Protocol test suite to test protocol implementations
  */
 
-import Servient, { createLoggers, ExposedThing } from "@node-wot/core";
+import Servient, { createLoggers } from "@node-wot/core";
 import { suite, test } from "@testdeck/mocha";
 import { expect, should } from "chai";
 import WebSocketServer from "../src/ws-server";
@@ -54,7 +54,7 @@ class WebSocketsTest {
         const receivedConnections: string[] = [];
 
         mockServer.on("connection", (ws, req) => {
-            receivedConnections.push(req.url || "/");
+            receivedConnections.push(req.url ?? "/");
             ws.on("message", (msg) => {
                 const data = JSON.parse(msg.toString());
                 // Echo back with id
@@ -77,8 +77,8 @@ class WebSocketsTest {
             };
 
             // Both should succeed and connect to different paths
-            const result1 = await client.readResource(form1);
-            const result2 = await client.readResource(form2);
+            await client.readResource(form1);
+            await client.readResource(form2);
 
             expect(receivedConnections).to.include("/endpoint1");
             expect(receivedConnections).to.include("/endpoint2");
@@ -181,12 +181,7 @@ class WebSocketsTest {
                 op: "subscribeproperty",
             };
 
-            const subscription = await client.subscribeResource(
-                form,
-                () => {},
-                undefined,
-                undefined
-            );
+            await client.subscribeResource(form, () => {}, undefined, undefined);
 
             // Unsubscribe should trigger the correct operation
             await client.unlinkResource(form);
@@ -247,12 +242,7 @@ class WebSocketsTest {
                 op: "subscribeevent",
             };
 
-            const subscription = await client.subscribeResource(
-                form,
-                () => {},
-                undefined,
-                undefined
-            );
+            await client.subscribeResource(form, () => {}, undefined, undefined);
 
             // Unsubscribe should trigger the correct operation
             await client.unlinkResource(form);


### PR DESCRIPTION
During the Plugfest we had to implement the Node-WoT web thing protocol websockets to talk to another device. This is the is the work done there. This was a quick draft with testing done against a single device so there could be some edge-cases. 