### PR TITLE
chore : Added TypeScript types as dependencies instead of devDependencies

### DIFF
--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -24,7 +24,6 @@
         "@types/basic-auth": "1.1.3",
         "@types/eventsource": "^1.1.15",
         "@types/express": "^4.17.3",
-        "@types/node-fetch": "^2.6.12",
         "body-parser": "^1.20.3",
         "express": "^4.20.0",
         "ssestream": "^1.1.0",
@@ -32,6 +31,7 @@
     },
     "dependencies": {
         "@node-wot/core": "1.0.0",
+        "@types/node-fetch": "^2.6.12",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",
         "client-oauth2": "^4.2.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,13 +16,13 @@
     "types": "dist/core.d.ts",
     "devDependencies": {
         "@types/content-type": "^1.1.8",
-        "@types/debug": "^4.1.7",
         "@types/uritemplate": "^0.3.4",
         "@types/uuid": "^8.3.1"
     },
     "dependencies": {
         "@petamoriken/float16": "^3.1.1",
         "@thingweb/thing-model": "^1.0.4",
+        "@types/debug": "^4.1.7",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "cbor": "^8.1.0",


### PR DESCRIPTION
Closes #1476

### Summary

Moves `@types/debug` and `@types/node-fetch` from `devDependencies` to `dependencies` in `packages/core` and `packages/binding-http`.

### Problem

The packages `@node-wot/core` and `@node-wot/binding-http` export types from `debug` and `node-fetch` in their public API (declaration files). However, these type definitions were listed in `devDependencies`, causing TypeScript compilation errors for consumers who do not have these types installed manually.

### Solution

Moved the following packages to `dependencies`:
- `@types/debug` in `@node-wot/core`
- `@types/node-fetch` in `@node-wot/binding-http`