### PR TITLE
test(binding-http): add unit tests for CORS behavior

### DIFF
--- a/packages/binding-http/test/http-server-cors-test.ts
+++ b/packages/binding-http/test/http-server-cors-test.ts
@@ -194,4 +194,59 @@ class HttpServerCorsTest {
         expect(methods).to.contain("GET");
         expect(methods).to.contain("OPTIONS");
     }
+
+    @test async "should handle CORS for write property (PUT)"() {
+        this.thing = new ExposedThing(this.servient, {
+            title: "TestThingWrite",
+            properties: {
+                test: {
+                    type: "string",
+                    forms: [],
+                },
+            },
+        });
+
+        this.thing.setPropertyWriteHandler("test", () => Promise.resolve(undefined));
+
+        await this.httpServer.expose(this.thing);
+
+        const uri = `http://localhost:${this.httpServer.getPort()}/testthingwrite/properties/test`;
+        const response = await fetch(uri, {
+            method: "PUT",
+            body: JSON.stringify("new-value"),
+            headers: {
+                Origin: "http://example.com",
+                "Content-Type": "application/json",
+            },
+        });
+
+        expect(response.status).to.equal(204);
+        expect(response.headers.get("Access-Control-Allow-Origin")).to.equal("*");
+    }
+
+    @test async "should handle CORS for invoke action (POST)"() {
+        this.thing = new ExposedThing(this.servient, {
+            title: "TestThingAction",
+            actions: {
+                test: {
+                    forms: [],
+                },
+            },
+        });
+
+        this.thing.setActionHandler("test", () => Promise.resolve(undefined));
+
+        await this.httpServer.expose(this.thing);
+
+        const uri = `http://localhost:${this.httpServer.getPort()}/testthingaction/actions/test`;
+        const response = await fetch(uri, {
+            method: "POST",
+            headers: {
+                Origin: "http://example.com",
+            },
+        });
+
+        expect(response.status).to.equal(204); // Action without output returns 204
+        expect(response.headers.get("Access-Control-Allow-Origin")).to.equal("*");
+    }
 }


### PR DESCRIPTION
## Description
This PR adds unit tests to `binding-http` to verify CORS behavior, addressing the need for regression testing mentioned in issue #938. 

The new tests cover:
- CORS headers for `nosec` security scheme (wildcard origin).
- CORS headers for `basic` security scheme (reflected origin + credentials), covering both authorized (200) and unauthorized (401) responses.
- CORS headers for `OPTIONS` preflight requests.

## Motivation and Context
Currently, `http-server` implements CORS logic but lacks specific unit tests. These tests ensure that CORS headers are correctly set for different security configurations and request types, preventing future regressions.

## How Has This Been Tested?
- Ran `npm run test` in `packages/binding-http`.
- Verified that all 80 tests (including the 4 new CORS tests) passed.
- Ran `npm run lint` and `npm run format` to ensure code quality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test (adding missing tests or correcting existing tests)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.