### PR TITLE
Support ID-based CoAP paths for exposed Things

### DIFF
--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -28,8 +28,27 @@ export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
 export interface CoapServerConfig {
+    /**
+     * Port on which the CoAP server listens.
+     * Defaults to 5683.
+     */
     port?: number;
+
+    /**
+     * Network address to bind to.
+     * If undefined, binds to all interfaces.
+     */
     address?: string;
+
+    /**
+     * Controls how Thing resource paths are generated.
+     *
+     * If `true` (default), a slugified title-based path is created.
+     * If the Thing has an ID, an additional ID-based path is created.
+     *
+     * If `false` and the Thing has an ID, only the ID-based path is created.
+     * If no ID is provided, a title-based path is still created.
+     */
     devFriendlyUri?: boolean;
 }
 


### PR DESCRIPTION
This PR implements ID-based path support for the CoAP binding, similar to the HTTP implementation introduced in #1464.

Changes:
- Added `devFriendlyUri` configuration option (default: true)
- Implemented dual-path registration (slugified title + id-based path)
- Ensured proper cleanup of all aliases in `destroy()`
- Added tests verifying reachability via both title and id paths

This maintains backward compatibility while enabling stable, production-safe URIs for CoAP-exposed Things.
Fixes -  #1458 