### PR TITLE
feat(binding-http): Make Access-Control-Allow-Origin header configurable

### DIFF
--- a/packages/binding-http/README.md
+++ b/packages/binding-http/README.md
@@ -180,6 +180,7 @@ The protocol binding can be configured using his constructor or trough servient 
     baseUri?: string                         // A Base URI to be used in the TD in cases where the client will access a different URL than the actual machine serving the thing.  [See Using BaseUri below]
     urlRewrite?: Record<string, string>      // A record to allow for other URLs pointing to existing endpoints, e.g., { "/myroot/myUrl": "/test/properties/test" }
     middleware?: MiddlewareRequestHandler;   // the MiddlewareRequestHandler function. See [Adding a middleware] section below.
+    allowedOrigins?: string;                 // Configures the Access-Control-Allow-Origin header. Defaults to "*" (any origin). See [Configuring CORS] section below.
 }
 ```
 
@@ -304,6 +305,21 @@ The exposed thing on the internal server will product form URLs such as:
 > `baseUri` tells the producer to prefix URLs which may include hostnames, network interfaces, and URI prefixes which are not local to the machine exposing the Thing.
 
 > `address` tells the HttpServer a specific local network interface to bind its TCP listener.
+
+### Configuring CORS
+
+By default, the HTTP binding sets the `Access-Control-Allow-Origin` header to `"*"`, allowing any origin to access exposed Things. You can restrict this to a specific origin using the `allowedOrigins` configuration option:
+
+```js
+servient.addServer(
+    new HttpServer({
+        port: 8080,
+        allowedOrigins: "https://my-app.example.com",
+    })
+);
+```
+
+When a security scheme (e.g. `basic`, `bearer`) is configured, the server echoes the request's `Origin` header and sets `Access-Control-Allow-Credentials: true`, regardless of the `allowedOrigins` value. This is required for browsers to send credentials in cross-origin requests.
 
 ### Adding a middleware
 

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -65,6 +65,7 @@ export default class HttpServer implements ProtocolServer {
     private readonly baseUri?: string;
     private readonly urlRewrite?: Record<string, string>;
     private readonly devFriendlyUri: boolean;
+    private readonly allowedOrigins: string;
     private readonly supportedSecuritySchemes: string[] = ["nosec"];
     private readonly validOAuthClients: RegExp = /.*/g;
     private readonly server: http.Server | https.Server;
@@ -85,6 +86,7 @@ export default class HttpServer implements ProtocolServer {
         this.urlRewrite = config.urlRewrite;
         this.middleware = config.middleware;
         this.devFriendlyUri = config.devFriendlyUri ?? true;
+        this.allowedOrigins = config.allowedOrigins ?? "*";
 
         const router = Router({
             ignoreTrailingSlash: true,
@@ -249,6 +251,10 @@ export default class HttpServer implements ProtocolServer {
 
     public getThings(): Map<string, ExposedThing> {
         return this.things;
+    }
+
+    public getAllowedOrigins(): string {
+        return this.allowedOrigins;
     }
 
     /** returns server port number and indicates that server is running when larger than -1  */

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -47,6 +47,11 @@ export interface HttpConfig {
     security?: SecurityScheme[];
     devFriendlyUri?: boolean;
     middleware?: MiddlewareRequestHandler;
+    /**
+     * Configures the Access-Control-Allow-Origin header.
+     * Default is "*" (any origin allowed).
+     */
+    allowedOrigins?: string;
 }
 
 export interface OAuth2ServerConfig extends SecurityScheme {

--- a/packages/binding-http/src/routes/action.ts
+++ b/packages/binding-http/src/routes/action.ts
@@ -67,7 +67,7 @@ export default async function actionRoute(
         return;
     }
     // TODO: refactor this part to move into a common place
-    setCorsForThing(req, res, thing);
+    setCorsForThing(req, res, thing, this.getAllowedOrigins());
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -110,6 +110,6 @@ export default async function actionRoute(
     } else {
         // may have been OPTIONS that failed the credentials check
         // as a result, we pass corsPreflightWithCredentials
-        respondUnallowedMethod(req, res, "POST", corsPreflightWithCredentials);
+        respondUnallowedMethod(req, res, "POST", corsPreflightWithCredentials, this.getAllowedOrigins());
     }
 }

--- a/packages/binding-http/src/routes/common.ts
+++ b/packages/binding-http/src/routes/common.ts
@@ -21,7 +21,8 @@ export function respondUnallowedMethod(
     req: IncomingMessage,
     res: ServerResponse,
     allowed: string,
-    corsPreflightWithCredentials = false
+    corsPreflightWithCredentials = false,
+    allowedOrigins = "*"
 ): void {
     // Always allow OPTIONS to handle CORS pre-flight requests
     if (!allowed.includes("OPTIONS")) {
@@ -40,7 +41,7 @@ export function respondUnallowedMethod(
             res.setHeader("Access-Control-Allow-Origin", origin);
             res.setHeader("Access-Control-Allow-Credentials", "true");
         } else {
-            res.setHeader("Access-Control-Allow-Origin", "*");
+            res.setHeader("Access-Control-Allow-Origin", allowedOrigins);
         }
         res.setHeader("Access-Control-Allow-Methods", allowed);
         res.setHeader("Access-Control-Allow-Headers", "content-type, authorization, *");
@@ -91,7 +92,12 @@ export function securitySchemeToHttpHeader(scheme: string): string {
     return first.toUpperCase() + rest.join("").toLowerCase();
 }
 
-export function setCorsForThing(req: IncomingMessage, res: ServerResponse, thing: ExposedThing): void {
+export function setCorsForThing(
+    req: IncomingMessage,
+    res: ServerResponse,
+    thing: ExposedThing,
+    allowedOrigins = "*"
+): void {
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
     // Set CORS headers
 
@@ -100,6 +106,6 @@ export function setCorsForThing(req: IncomingMessage, res: ServerResponse, thing
         res.setHeader("Access-Control-Allow-Origin", origin);
         res.setHeader("Access-Control-Allow-Credentials", "true");
     } else {
-        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Access-Control-Allow-Origin", allowedOrigins);
     }
 }

--- a/packages/binding-http/src/routes/event.ts
+++ b/packages/binding-http/src/routes/event.ts
@@ -47,7 +47,7 @@ export default async function eventRoute(
         return;
     }
     // TODO: refactor this part to move into a common place
-    setCorsForThing(req, res, thing);
+    setCorsForThing(req, res, thing, this.getAllowedOrigins());
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -109,7 +109,7 @@ export default async function eventRoute(
     } else {
         // may have been OPTIONS that failed the credentials check
         // as a result, we pass corsPreflightWithCredentials
-        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials);
+        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials, this.getAllowedOrigins());
     }
     // resource found and response sent
 }

--- a/packages/binding-http/src/routes/properties.ts
+++ b/packages/binding-http/src/routes/properties.ts
@@ -39,7 +39,7 @@ export default async function propertiesRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCorsForThing(req, res, thing);
+    setCorsForThing(req, res, thing, this.getAllowedOrigins());
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -86,6 +86,6 @@ export default async function propertiesRoute(
     } else {
         // may have been OPTIONS that failed the credentials check
         // as a result, we pass corsPreflightWithCredentials
-        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials);
+        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials, this.getAllowedOrigins());
     }
 }

--- a/packages/binding-http/src/routes/property-observe.ts
+++ b/packages/binding-http/src/routes/property-observe.ts
@@ -57,7 +57,7 @@ export default async function propertyObserveRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCorsForThing(req, res, thing);
+    setCorsForThing(req, res, thing, this.getAllowedOrigins());
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -113,6 +113,6 @@ export default async function propertyObserveRoute(
         res.writeHead(202);
         res.end();
     } else {
-        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials);
+        respondUnallowedMethod(req, res, "GET", corsPreflightWithCredentials, this.getAllowedOrigins());
     }
 }

--- a/packages/binding-http/src/routes/property.ts
+++ b/packages/binding-http/src/routes/property.ts
@@ -77,7 +77,7 @@ export default async function propertyRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCorsForThing(req, res, thing);
+    setCorsForThing(req, res, thing, this.getAllowedOrigins());
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -108,7 +108,7 @@ export default async function propertyRoute(
     } else if (req.method === "PUT") {
         const readOnly: boolean = property.readOnly ?? false;
         if (readOnly) {
-            respondUnallowedMethod(req, res, "GET, PUT");
+            respondUnallowedMethod(req, res, "GET, PUT", false, this.getAllowedOrigins());
             return;
         }
 
@@ -128,6 +128,6 @@ export default async function propertyRoute(
     } else {
         // may have been OPTIONS that failed the credentials check
         // as a result, we pass corsPreflightWithCredentials
-        respondUnallowedMethod(req, res, "GET, PUT", corsPreflightWithCredentials);
+        respondUnallowedMethod(req, res, "GET, PUT", corsPreflightWithCredentials, this.getAllowedOrigins());
     } // Property exists?
 }

--- a/packages/binding-http/src/routes/thing-description.ts
+++ b/packages/binding-http/src/routes/thing-description.ts
@@ -169,7 +169,7 @@ export default async function thingDescriptionRoute(
         const payload = await content.toBuffer();
 
         negotiateLanguage(td, thing, req);
-        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Access-Control-Allow-Origin", this.getAllowedOrigins());
         res.setHeader("Content-Type", contentType);
         res.writeHead(200);
         debug(`Sending HTTP response for TD with Content-Type ${contentType}.`);

--- a/packages/binding-http/src/routes/things.ts
+++ b/packages/binding-http/src/routes/things.ts
@@ -22,7 +22,7 @@ export default function thingsRoute(
     res: ServerResponse,
     _params: unknown
 ): void {
-    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Origin", this.getAllowedOrigins());
     res.setHeader("Content-Type", ContentSerdes.DEFAULT);
     res.writeHead(200);
     const list = [];


### PR DESCRIPTION

Added allowedOrigins option to HttpConfig interface to let users configure the Access-Control-Allow-Origin header value. Defaults to '*' for backward compatibility.

Since allowedOrigins is an optional field, this is fully backward compatible .

Fixes #941