### PR TITLE
Fixing CI problems on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
         strategy:
             matrix:
-                os: [macos-latest, ubuntu-latest, windows-latest]
+                os: [macos-latest, ubuntu-latest, windows-latest] # windows-latest will be migrated
                 node-version: [22.x, 24.x]
 
         timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
         strategy:
             matrix:
-                os: [macos-latest, ubuntu-latest, windows-latest] # windows-latest will be migrated
+                os: [macos-latest, ubuntu-latest, windows-2022]
                 node-version: [22.x, 24.x]
 
         timeout-minutes: 30


### PR DESCRIPTION
Due to recent GitHub changes, "windows-latest" falls back to "windows-2025-vs2026" where we run into issues finding Visual Studio (see the [first commit of this PR](https://github.com/eclipse-thingweb/node-wot/pull/1529/commits/29d8ecfbf8c9233d2f864d679489e2a0a1b39f55) or all the other failing PRs right now).

Hence, I propose to remain on VS 2022 for now.

fixes https://github.com/eclipse-thingweb/node-wot/issues/1528